### PR TITLE
Optimise performance of max_page API route

### DIFF
--- a/server/controllers/api/show/script.py
+++ b/server/controllers/api/show/script.py
@@ -689,10 +689,12 @@ class ScriptMaxPageController(BaseAPIController):
                     self.finish({'message': 'Script does not have a current revision'})
                     return
 
-                max_page = 0
-                for line in revision.line_associations:
-                    if line.line.page > max_page:
-                        max_page = line.line.page
+                line_ids = session.query(ScriptLineRevisionAssociation).with_entities(
+                    ScriptLineRevisionAssociation.line_id).filter(
+                    ScriptLineRevisionAssociation.revision_id == revision.id)
+                max_page = session.query(ScriptLine).with_entities(
+                    func.max(ScriptLine.page)).where(
+                    ScriptLine.id.in_(line_ids)).first()[0]
 
                 self.set_status(200)
                 self.finish({


### PR DESCRIPTION
Before:

```
[I 230129 23:41:52 web:2271] 200 GET /api/v1/show/script/max_page (127.0.0.1) 728.69ms
```

After:

```
[I 230130 00:10:31 web:2271] 200 GET /api/v1/show/script/max_page (127.0.0.1) 19.61ms
```