### PR TITLE
Fix issue with act and scene heading not showing

### DIFF
--- a/client/src/vue_components/show/live/ScriptLineViewer.vue
+++ b/client/src/vue_components/show/live/ScriptLineViewer.vue
@@ -201,11 +201,16 @@ export default {
       return this.needsHeadings.every((x) => (x === true));
     },
     needsActSceneLabel() {
-      if (this.previousLine == null) {
+      let { previousLine, lineIndex } = this;
+      while (previousLine != null && (previousLine.stage_direction === true
+          || this.isWholeLineCut(previousLine))) {
+        [lineIndex, previousLine] = this.getPreviousLineForIndex(previousLine.page, lineIndex);
+      }
+      if (previousLine == null) {
         return true;
       }
-      return !(this.previousLine.act_id === this.line.act_id
-        && this.previousLine.scene_id === this.line.scene_id);
+      return !(previousLine.act_id === this.line.act_id
+        && previousLine.scene_id === this.line.scene_id);
     },
     actLabel() {
       return this.acts.find((act) => (act.id === this.line.act_id)).name;

--- a/client/src/vue_components/show/live/ScriptLineViewer.vue
+++ b/client/src/vue_components/show/live/ScriptLineViewer.vue
@@ -202,8 +202,7 @@ export default {
     },
     needsActSceneLabel() {
       let { previousLine, lineIndex } = this;
-      while (previousLine != null && (previousLine.stage_direction === true
-          || this.isWholeLineCut(previousLine))) {
+      while (previousLine != null && this.isWholeLineCut(previousLine)) {
         [lineIndex, previousLine] = this.getPreviousLineForIndex(previousLine.page, lineIndex);
       }
       if (previousLine == null) {


### PR DESCRIPTION
If the first line of a new scene/act is cut, then the act and scene heading would not be shown due to the way this was computed. Instead, update the logic to find the last non-cut line, and use this to determine whether we need to show the heading or not.