### PR TITLE
Add page up/down navigation to live view (#710)

### DIFF
--- a/client/src/views/show/ShowLiveView.vue
+++ b/client/src/views/show/ShowLiveView.vue
@@ -759,6 +759,8 @@ export default {
       // Process arrow keys
       if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
         this.handleKeyNavigation(event);
+      } else if (event.key === 'PageUp' || event.key === 'PageDown') {
+        this.handlePageNavigation(event);
       } else if (event.key === 'C') {
         this.handleCueEditToggle(event);
       }
@@ -786,6 +788,28 @@ export default {
       // Always move by 1 visible line in the appropriate direction
       const delta = event.key === 'ArrowDown' ? 1 : -1;
       this.navigateRelative(0, delta);
+    },
+    handlePageNavigation(event) {
+      // Only handle if we're the leader and not currently scrolling or starting an interval
+      if (!this.isScriptLeader || !this.initialLoad || this.isScrollingProgrammatically
+        || this.intervalTimerContext != null || this.CURRENT_SHOW_INTERVAL != null) return;
+
+      event.preventDefault();
+
+      // Navigate by page increments
+      const isPageDown = event.key === 'PageDown';
+      let targetPage = this.currentPage + (isPageDown ? 1 : -1);
+
+      // Ensure we stay within valid page bounds
+      if (targetPage < 1) {
+        targetPage = 1;
+      } else if (targetPage > this.currentLoadedPage) {
+        // Don't navigate beyond loaded pages
+        return;
+      }
+
+      // Navigate to the first line of the target page
+      this.navigateTo(targetPage, 0);
     },
     handleWheelNavigation(event) {
       // Only handle if we're the leader and not currently scrolling or starting an interval


### PR DESCRIPTION
## Summary
Implements issue #710 by adding keyboard handlers for PageUp and PageDown keys in the live script view, allowing users to jump between script pages quickly during live shows.

## Changes
- Added PageUp/PageDown key detection in `handleKeyPress()` method
- Implemented new `handlePageNavigation()` method with proper page-by-page navigation
- Maintains existing permission model (script leader only)
- Includes boundary checking to prevent navigation beyond loaded pages

## Features
- **PageUp**: Navigate to previous script page
- **PageDown**: Navigate to next script page
- **Leader-only**: Only works when user is the script leader
- **Interval-aware**: Disabled during interval overlays (consistent with existing navigation)
- **Boundary protection**: Won't navigate beyond page 1 or unloaded pages
- **Consistent positioning**: Always navigates to first line of target page

## Test plan
- [ ] Verify PageUp/PageDown keys work in live view for script leaders
- [ ] Confirm navigation is disabled for followers
- [ ] Test boundary conditions (first page, last loaded page)
- [ ] Verify navigation is disabled during intervals
- [ ] Check that navigation positioning is consistent

🤖 Generated with [Claude Code](https://claude.ai/code)