### PR TITLE
feat(test): Upgrade pytest to version 9.x

### DIFF
--- a/server/test_requirements.txt
+++ b/server/test_requirements.txt
@@ -1,5 +1,5 @@
-pytest<8.5
-pytest-asyncio
+pytest<9.1
+pytest-asyncio>=1.3.0
 pylint==3.3.9
 black==25.11.0
 isort==5.13.2


### PR DESCRIPTION
## Summary
- Upgraded pytest from <8.5 to <9.1 to adopt the latest testing framework features
- Updated pytest-asyncio to >=1.3.0 for pytest 9 compatibility
- All tests pass successfully with no breaking changes

## Motivation
pytest 9.0 was released on November 5, 2025, bringing improvements and bug fixes. This upgrade ensures we stay current with the testing framework and avoid future compatibility issues.

## Key Changes
| Dependency | Previous | New |
|------------|----------|-----|
| pytest | <8.5 | <9.1 |
| pytest-asyncio | (unpinned) | >=1.3.0 |

## Breaking Changes Analysis
After thorough analysis, none of the pytest 9.0 breaking changes affect our codebase:
- ✅ Python 3.9 dropped - We use Python >=3.13
- ✅ Test function yields - Our `@gen_test` decorated tests use Tornado's gen-based coroutines (valid)
- ✅ Duplicate path arguments - Not relevant to our usage
- ✅ CI mode detection - May need verification in CI/CD

## Testing Results
```
============================= test session starts ==============================
platform darwin -- Python 3.13.2, pytest-9.0.1, pluggy-1.6.0
collected 31 items

31 passed, 733 warnings in 7.18s
```

- ✅ All 31 tests pass
- ✅ No pytest-specific deprecation warnings
- ✅ Verified compatibility with:
  - Tornado AsyncHTTPTestCase tests
  - pytest-asyncio async tests  
  - pytest fixtures

**Note**: The 733 warnings are all from SQLAlchemy (unrelated to pytest upgrade)

## Test Plan
- [x] Run full test suite locally
- [x] Check for pytest deprecation warnings
- [x] Verify async test compatibility
- [ ] Verify CI/CD pipeline passes
- [ ] Monitor for any edge cases in production use

## References
- [pytest 9.0.0 Release Notes](https://github.com/pytest-dev/pytest/releases/tag/9.0.0)
- [pytest-asyncio 1.3.0 Release](https://pytest-asyncio.readthedocs.io/en/stable/reference/changelog.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)