### PR TITLE
fix(client): Apply strikethrough styling to cut stage directions in cue editor

### DIFF
--- a/client/src/vue_components/show/config/cues/ScriptLineCueEditor.vue
+++ b/client/src/vue_components/show/config/cues/ScriptLineCueEditor.vue
@@ -46,6 +46,7 @@
         >
           <i
             class="viewable-line"
+            :class="{'cut-line-part': linePartCuts.indexOf(line.line_parts[0].id) !== -1}"
             :style="stageDirectionStyling"
           >
             <template
@@ -159,6 +160,7 @@
                 >
                   <i
                     class="viewable-line"
+                    :class="{'cut-line-part': linePartCuts.indexOf(line.line_parts[0].id) !== -1}"
                     :style="stageDirectionStyling"
                   >
                     <template


### PR DESCRIPTION
## Fixes #691

## Problem
Cut stage directions were not displaying with strikethrough styling in the cue editor view, while regular cut line parts were correctly styled with strikethrough.

## Root Cause
The `cut-line-part` CSS class (which applies `text-decoration: line-through`) was only being applied to regular line parts, not to stage directions. The rendering logic had two separate code paths:

1. **Regular line parts** (lines 67-89): ✅ Applied `cut-line-part` class correctly
2. **Stage directions** (lines 42-65): ❌ Missing `cut-line-part` class

## Solution
Applied the existing `cut-line-part` CSS class to stage directions when they are cut, using the same logic already used for regular line parts:

```vue
:class="{'cut-line-part': linePartCuts.indexOf(line.line_parts[0].id) !== -1}"
```

Since stage directions have only one line part at index 0, we check if that line part's ID is in the `linePartCuts` array.

## Changes
**File**: `client/src/vue_components/show/config/cues/ScriptLineCueEditor.vue`

1. **Main cue editor view** (line 49): Added conditional class binding to stage direction element
2. **Modal dialog view** (line 163): Added same conditional class binding to modal's stage direction display

Both locations now consistently apply strikethrough styling to cut stage directions.

## Testing

### Manual Testing Required
Since this is a UI change, manual testing is needed:

1. Navigate to the cue editor page
2. Create or find a stage direction
3. Mark the stage direction as "cut"
4. **Expected**: Stage direction should display with strikethrough styling
5. **Before fix**: Stage direction displayed normally without strikethrough
6. **After fix**: Stage direction displays with strikethrough

### Visual Comparison

**Before:**
- Regular cut lines: ~~strikethrough~~ ✅
- Cut stage directions: *no strikethrough* ❌

**After:**
- Regular cut lines: ~~strikethrough~~ ✅  
- Cut stage directions: ~~*strikethrough*~~ ✅

## Code Quality
- ✅ No new dependencies
- ✅ Uses existing CSS class (`.cut-line-part`)
- ✅ Consistent with existing code patterns for regular line parts
- ✅ Applied in both main view and modal for consistency

## Impact
- **Low risk**: Only affects visual styling, no logic changes
- **Scope**: Only affects cue editor view for stage directions
- **Backwards compatible**: No API or data model changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)