### PR TITLE
Fix FK constraint errors in script line updates and revision deletion

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,6 +1,7 @@
 public/
 static/
 conf/
+conf.back/
 digiscript.sqlite
 digiscript.json
 


### PR DESCRIPTION
## Summary
Fixes two related FK constraint bugs in script revision handling:
1. **Line update migration**: CueAssociation and ScriptCuts not migrated when updating lines
2. **Revision deletion cascade**: Lazy loading triggers autoflush during cascade deletion

## Issue 1: Line Update Migration
When updating a line via `PATCH /api/v1/show/script`, DigiScript creates new `ScriptLine` and `ScriptLinePart` objects. Previously, revision-scoped associations (CueAssociation, ScriptCuts) were not migrated to the new objects.

**Problem:**
- FK constraint errors when cues attached (hard failure)
- Silent data loss when cuts attached (cascade deletion)

**Solution:**
- Migrate `CueAssociation`: `(revision, old_line_id)` → `(revision, new_line_id)`
- Migrate `ScriptCuts`: `(revision, old_line_part_id)` → `(revision, new_line_part_id)`
- Use `part_index` mapping to match old and new line parts

**Code changes:**
- `controllers/api/show/script/script.py` (lines 609-662): Added migration logic for both association types

## Issue 2: Revision Deletion Cascade
When deleting a revision, the `pre_delete` hook in `ScriptLineRevisionAssociation` accessed lazy-loaded relationships, triggering autoflush during cascade deletion.

**Problem:**
- Accessing `self.line` triggers lazy load
- Lazy load causes premature autoflush
- Autoflush tries to delete parent revision before children processed
- FK constraint error

**Solution:**
- Move deletion logic from `pre_delete` to `post_delete` hook (avoids cascade timing issues)
- Wrap logic in `session.no_autoflush` context (prevents lazy loading autoflush)
- Check ALL FK references before deleting orphaned lines:
  - `line_id` (via `revision_associations`)
  - `next_line_id` and `previous_line_id` (linked list pointers)
  - `cue_associations`

**Code changes:**
- `models/script.py` (lines 127-169): Refactored `post_delete` hook with comprehensive FK checking

## Tests Added
- ✅ 3 tests for line update association migration (`test_script.py`)
  - `test_update_line_with_cue_attached`
  - `test_update_line_with_cut_attached`
  - `test_update_line_with_both_cue_and_cut`
- ✅ 2 tests for revision deletion (`test_revisions.py`)
  - `test_delete_revision_with_multiple_lines`
  - `test_delete_non_current_revision`

All tests use production-valid scenarios created via API endpoints.

## Test Results
```
24 passed in 1.93s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)