### PR TITLE
Redirect from login if user is already authenticated

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -209,6 +209,13 @@ router.beforeEach(async (to, from, next) => {
     return showAllowed || scriptAllowed || cueTypesAllowed;
   };
 
+  // Check if we are navigating to the login page while already authenticated
+  // If so, redirect to where the user just was
+  if (to.path === '/login' && isAuthenticated) {
+    Vue.$toast.info('You are already logged in');
+    return next(from.fullPath);
+  }
+
   // Check authentication requirements
   if (requiresAuth && !isAuthenticated) {
     Vue.$toast.error('Please log in to access this page');


### PR DESCRIPTION
If a user is already authenticated and tries to go to the login page, redirect them back to where they came from, with a message telling them they are already logged in.

Closes #791 