### PR TITLE
feat: Allow multiple microphones per character (#796)

### DIFF
--- a/docs/pages/show_config/microphones.md
+++ b/docs/pages/show_config/microphones.md
@@ -37,8 +37,22 @@ To assign a microphone to a character, follow these steps:
 #### Allocation Constraints
 
 - You **cannot** allocate the same microphone to multiple characters in the same scene
-- You **cannot** allocate multiple microphones to a single character for a given scene
-- These constraints ensure practical microphone management during live shows
+  - This reflects the physical constraint that one microphone can only be worn by one person at a time
+
+#### Multiple Microphones Per Character
+
+DigiScript supports assigning multiple microphones to a single character in a scene. This is useful for:
+
+- **Primary + Backup Configuration**: Lead characters who aren't offstage long enough to swap out microphone packs can have both a primary and backup microphone assigned
+- **Redundancy**: Ensuring continuity in case of technical failures during performance
+- **Technical Flexibility**: Accommodating different microphone types or configurations for the same character
+
+To assign multiple microphones to a character:
+1. Select the first microphone from the dropdown and allocate it to the character
+2. Select the second microphone from the dropdown and allocate it to the same character
+3. The character will now show both microphones in the view mode (e.g., "Mic 1, Mic 2")
+
+In the Timeline view, characters with multiple microphones will display stacked bars showing all assigned microphones with consistent color-coding.
 
 #### Saving Allocations
 
@@ -50,14 +64,19 @@ The saved view provides a clear overview of microphone usage throughout the enti
 
 #### Conflict Detection
 
-DigiScript automatically detects potential microphone conflicts when the same microphone is allocated to different characters in adjacent scenes. Conflicts are highlighted in the allocations matrix to alert you to quick-changes that may require attention:
+DigiScript automatically detects potential microphone conflicts when the same microphone is allocated to different characters in adjacent scenes. Conflicts are tracked individually per microphone - a character with multiple microphones may have conflicts on some mics but not others. Conflicts are highlighted in the allocations matrix to alert you to quick-changes that may require attention:
 
 ![](../../images/config_show/mics_conflict_highlighting.png)
 
 - **Orange highlights** indicate conflicts within the same act (tight changeover required)
 - **Blue highlights** indicate conflicts across act boundaries (interval provides changeover time)
 
-Hovering over a highlighted allocation shows details about the conflict, including which scenes and characters are involved.
+Hovering over a highlighted allocation shows:
+- The full list of microphones assigned to that character in that scene
+- Details about which specific microphones have conflicts
+- Information about which scenes and characters are involved in each conflict
+
+When a character has multiple microphones, the tooltip will clearly indicate which microphone(s) have conflicts, allowing you to plan changeovers for specific microphones while others remain assigned.
 
 ### Microphone Timeline View
 


### PR DESCRIPTION
## Summary

Implements issue #796 to allow characters to have multiple microphones assigned to them in a scene. This feature enables primary/backup microphone configurations for lead characters who aren't offstage long enough to swap mic packs.

### Changes Made

- **MicAllocations.vue**: 
  - Removed validation preventing multiple mics per character (lines 300-307)
  - Updated `allocationByCharacter` computed property to display comma-separated mic names
  - Added enhanced conflict tooltip system showing per-mic conflict details
  
- **MicTimeline.vue**:
  - Updated `generateBarsForCharacter` to display stacked bars for characters with multiple mics
  - Updated `generateBarsForCast` with same stacking logic
  - Bars are color-coded by character/cast member (not by mic)
  
- **microphones.md**:
  - Added "Multiple Microphones Per Character" section with use cases
  - Updated conflict detection documentation
  - Added examples for primary/backup configurations

### Key Features

✅ Multiple mics can be assigned to the same character in the same scene  
✅ Constraint maintained: one mic can only be assigned to one character per scene  
✅ View mode displays comma-separated mic names (e.g., "Mic 1, Mic 2")  
✅ Conflict detection tracks conflicts individually per microphone  
✅ Enhanced tooltips show which specific mics have conflicts  
✅ Timeline visualization displays stacked bars for multi-mic characters  

### Database Compatibility

No database changes required! The existing composite primary key `(mic_id, scene_id, character_id)` already supports this feature. The constraint was only in the frontend validation.

## Test Plan

- [x] Create test show with 2 characters and 2 scenes
- [x] Create 3 microphones (Mic 1, Mic 2, Mic 3)
- [x] Assign Mic 1 to Lead Character in Scene 1
- [x] Assign Mic 2 to Lead Character in Scene 1 (same character, different mic)
- [x] Verify view mode displays "Mic 1, Mic 2"
- [x] Create conflict by assigning Mic 2 to Supporting Character in Scene 2
- [x] Verify conflict highlighting shows orange warning with exclamation triangle
- [x] Verify tooltip shows per-mic conflict details
- [x] Verify Timeline "By Character" mode shows stacked bars
- [x] Verify constraint: cannot assign same mic to two different characters in same scene
- [x] Screenshots captured for documentation

### Screenshots

Allocations view with multi-mic assignment and conflict:
![multi-mic-assignment-with-conflict](https://github.com/user-attachments/assets/...)

Timeline view with stacked bars:
![multi-mic-timeline-by-character](https://github.com/user-attachments/assets/...)

🤖 Generated with [Claude Code](https://claude.com/claude-code)