### PR TITLE
Extract shared stats table logic into statsTableMixin

### DIFF
--- a/client/src/mixins/statsTableMixin.js
+++ b/client/src/mixins/statsTableMixin.js
@@ -1,0 +1,102 @@
+import { mapActions, mapGetters } from 'vuex';
+
+/**
+ * Shared mixin for stats table components that display data organized by acts and scenes.
+ * Provides common logic for traversing and displaying act/scene hierarchies in table format.
+ *
+ * This mixin assumes the component has:
+ * - A Vuex store with ACT_BY_ID, SCENE_BY_ID, and CURRENT_SHOW getters
+ * - A Vuex store with GET_ACT_LIST and GET_SCENE_LIST actions
+ * - A `loaded` boolean in the component's data (for loading state)
+ * - A `getStats()` method that fetches component-specific statistics
+ *
+ * Components using this mixin should implement:
+ * - data() with `loaded: false` and component-specific stats object
+ * - methods.getStats() - async method to fetch stats from API
+ * - computed.tableData - component-specific data formatting
+ * - computed.tableFields - component-specific field names (can use this.sortedScenes)
+ */
+export default {
+  computed: {
+    /**
+     * Returns acts in order by following the linked list structure.
+     * Starts from first_act_id and follows next_act references.
+     */
+    sortedActs() {
+      if (this.CURRENT_SHOW.first_act_id == null) {
+        return [];
+      }
+      let currentAct = this.ACT_BY_ID(this.CURRENT_SHOW.first_act_id);
+      if (currentAct == null) {
+        return [];
+      }
+      const acts = [];
+      while (currentAct != null) {
+        acts.push(currentAct);
+        currentAct = this.ACT_BY_ID(currentAct.next_act);
+      }
+      return acts;
+    },
+
+    /**
+     * Returns scenes in order by following the linked list structure.
+     * Iterates through acts, then through scenes within each act.
+     */
+    sortedScenes() {
+      if (this.CURRENT_SHOW.first_act_id == null) {
+        return [];
+      }
+
+      let currentAct = this.ACT_BY_ID(this.CURRENT_SHOW.first_act_id);
+      if (currentAct == null || currentAct.first_scene == null) {
+        return [];
+      }
+
+      const scenes = [];
+      while (currentAct != null) {
+        let currentScene = this.SCENE_BY_ID(currentAct.first_scene);
+        while (currentScene != null) {
+          scenes.push(currentScene);
+          currentScene = this.SCENE_BY_ID(currentScene.next_scene);
+        }
+        currentAct = this.ACT_BY_ID(currentAct.next_act);
+      }
+      return scenes;
+    },
+    ...mapGetters(['ACT_BY_ID', 'SCENE_BY_ID', 'CURRENT_SHOW']),
+  },
+
+  async mounted() {
+    await this.GET_ACT_LIST();
+    await this.GET_SCENE_LIST();
+    await this.getStats();
+    this.loaded = true;
+  },
+
+  methods: {
+    /**
+     * Counts how many scenes belong to a given act.
+     * Used for table header colspan calculations.
+     */
+    numScenesPerAct(actId) {
+      return this.sortedScenes.filter((scene) => scene.act === actId).length;
+    },
+
+    /**
+     * Generates the slot name for a scene's table header.
+     * Used in template #[getHeaderName(scene.id)] syntax.
+     */
+    getHeaderName(sceneId) {
+      return `head(${sceneId})`;
+    },
+
+    /**
+     * Generates the slot name for a scene's table cell.
+     * Used in template #[getCellName(scene.id)] syntax.
+     */
+    getCellName(sceneId) {
+      return `cell(${sceneId})`;
+    },
+    ...mapActions(['GET_ACT_LIST', 'GET_SCENE_LIST']),
+  },
+};

--- a/client/src/vue_components/show/config/cast/CastLineStats.vue
+++ b/client/src/vue_components/show/config/cast/CastLineStats.vue
@@ -68,12 +68,14 @@
 </template>
 
 <script>
-import { mapActions, mapGetters } from 'vuex';
+import { mapGetters } from 'vuex';
 import { makeURL } from '@/js/utils';
 import log from 'loglevel';
+import statsTableMixin from '@/mixins/statsTableMixin';
 
 export default {
   name: 'CastLineStats',
+  mixins: [statsTableMixin],
   data() {
     return {
       loaded: false,
@@ -92,61 +94,10 @@ export default {
     tableFields() {
       return ['Cast', ...this.sortedScenes.map((scene) => (scene.id.toString()))];
     },
-    sortedActs() {
-      if (this.CURRENT_SHOW.first_act_id == null) {
-        return [];
-      }
-      let currentAct = this.ACT_BY_ID(this.CURRENT_SHOW.first_act_id);
-      if (currentAct == null) {
-        return [];
-      }
-      const acts = [];
-      while (currentAct != null) {
-        acts.push(currentAct);
-        currentAct = this.ACT_BY_ID(currentAct.next_act);
-      }
-      return acts;
-    },
-    sortedScenes() {
-      if (this.CURRENT_SHOW.first_act_id == null) {
-        return [];
-      }
-
-      let currentAct = this.ACT_BY_ID(this.CURRENT_SHOW.first_act_id);
-      if (currentAct == null || currentAct.first_scene == null) {
-        return [];
-      }
-
-      const scenes = [];
-      while (currentAct != null) {
-        let currentScene = this.SCENE_BY_ID(currentAct.first_scene);
-        while (currentScene != null) {
-          scenes.push(currentScene);
-          currentScene = this.SCENE_BY_ID(currentScene.next_scene);
-        }
-        currentAct = this.ACT_BY_ID(currentAct.next_act);
-      }
-      return scenes;
-    },
-    ...mapGetters(['ACT_BY_ID', 'SCENE_BY_ID', 'CURRENT_SHOW', 'CAST_BY_ID', 'CAST_LIST']),
-  },
-  async mounted() {
-    await this.GET_ACT_LIST();
-    await this.GET_SCENE_LIST();
-    await this.getCastStats();
-    this.loaded = true;
+    ...mapGetters(['CAST_BY_ID', 'CAST_LIST']),
   },
   methods: {
-    numScenesPerAct(actId) {
-      return this.sortedScenes.filter((scene) => scene.act === actId).length;
-    },
-    getHeaderName(sceneId) {
-      return `head(${sceneId})`;
-    },
-    getCellName(sceneId) {
-      return `cell(${sceneId})`;
-    },
-    async getCastStats() {
+    async getStats() {
       const response = await fetch(`${makeURL('/api/v1/show/cast/stats')}`);
       if (response.ok) {
         this.castStats = await response.json();
@@ -170,7 +121,6 @@ export default {
       }
       return 0;
     },
-    ...mapActions(['GET_ACT_LIST', 'GET_SCENE_LIST']),
   },
 };
 </script>

--- a/client/src/vue_components/show/config/characters/CharacterLineStats.vue
+++ b/client/src/vue_components/show/config/characters/CharacterLineStats.vue
@@ -68,12 +68,14 @@
 </template>
 
 <script>
-import { mapActions, mapGetters } from 'vuex';
+import { mapGetters } from 'vuex';
 import { makeURL } from '@/js/utils';
 import log from 'loglevel';
+import statsTableMixin from '@/mixins/statsTableMixin';
 
 export default {
   name: 'CharacterLineStats',
+  mixins: [statsTableMixin],
   data() {
     return {
       loaded: false,
@@ -92,61 +94,10 @@ export default {
     tableFields() {
       return ['Character', ...this.sortedScenes.map((scene) => (scene.id.toString()))];
     },
-    sortedActs() {
-      if (this.CURRENT_SHOW.first_act_id == null) {
-        return [];
-      }
-      let currentAct = this.ACT_BY_ID(this.CURRENT_SHOW.first_act_id);
-      if (currentAct == null) {
-        return [];
-      }
-      const acts = [];
-      while (currentAct != null) {
-        acts.push(currentAct);
-        currentAct = this.ACT_BY_ID(currentAct.next_act);
-      }
-      return acts;
-    },
-    sortedScenes() {
-      if (this.CURRENT_SHOW.first_act_id == null) {
-        return [];
-      }
-
-      let currentAct = this.ACT_BY_ID(this.CURRENT_SHOW.first_act_id);
-      if (currentAct == null || currentAct.first_scene == null) {
-        return [];
-      }
-
-      const scenes = [];
-      while (currentAct != null) {
-        let currentScene = this.SCENE_BY_ID(currentAct.first_scene);
-        while (currentScene != null) {
-          scenes.push(currentScene);
-          currentScene = this.SCENE_BY_ID(currentScene.next_scene);
-        }
-        currentAct = this.ACT_BY_ID(currentAct.next_act);
-      }
-      return scenes;
-    },
-    ...mapGetters(['ACT_BY_ID', 'SCENE_BY_ID', 'CURRENT_SHOW', 'CHARACTER_BY_ID', 'CHARACTER_LIST']),
-  },
-  async mounted() {
-    await this.GET_ACT_LIST();
-    await this.GET_SCENE_LIST();
-    await this.getCharacterStats();
-    this.loaded = true;
+    ...mapGetters(['CHARACTER_BY_ID', 'CHARACTER_LIST']),
   },
   methods: {
-    numScenesPerAct(actId) {
-      return this.sortedScenes.filter((scene) => scene.act === actId).length;
-    },
-    getHeaderName(sceneId) {
-      return `head(${sceneId})`;
-    },
-    getCellName(sceneId) {
-      return `cell(${sceneId})`;
-    },
-    async getCharacterStats() {
+    async getStats() {
       const response = await fetch(`${makeURL('/api/v1/show/character/stats')}`);
       if (response.ok) {
         this.characterStats = await response.json();
@@ -170,7 +121,6 @@ export default {
       }
       return 0;
     },
-    ...mapActions(['GET_ACT_LIST', 'GET_SCENE_LIST']),
   },
 };
 </script>

--- a/client/src/vue_components/show/config/cues/CueCountStats.vue
+++ b/client/src/vue_components/show/config/cues/CueCountStats.vue
@@ -68,12 +68,14 @@
 </template>
 
 <script>
-import { mapActions, mapGetters } from 'vuex';
+import { mapGetters } from 'vuex';
 import { makeURL } from '@/js/utils';
 import log from 'loglevel';
+import statsTableMixin from '@/mixins/statsTableMixin';
 
 export default {
   name: 'CueCountStats',
+  mixins: [statsTableMixin],
   data() {
     return {
       loaded: false,
@@ -92,61 +94,10 @@ export default {
     tableFields() {
       return ['Cues', ...this.sortedScenes.map((scene) => (scene.id.toString()))];
     },
-    sortedActs() {
-      if (this.CURRENT_SHOW.first_act_id == null) {
-        return [];
-      }
-      let currentAct = this.ACT_BY_ID(this.CURRENT_SHOW.first_act_id);
-      if (currentAct == null) {
-        return [];
-      }
-      const acts = [];
-      while (currentAct != null) {
-        acts.push(currentAct);
-        currentAct = this.ACT_BY_ID(currentAct.next_act);
-      }
-      return acts;
-    },
-    sortedScenes() {
-      if (this.CURRENT_SHOW.first_act_id == null) {
-        return [];
-      }
-
-      let currentAct = this.ACT_BY_ID(this.CURRENT_SHOW.first_act_id);
-      if (currentAct == null || currentAct.first_scene == null) {
-        return [];
-      }
-
-      const scenes = [];
-      while (currentAct != null) {
-        let currentScene = this.SCENE_BY_ID(currentAct.first_scene);
-        while (currentScene != null) {
-          scenes.push(currentScene);
-          currentScene = this.SCENE_BY_ID(currentScene.next_scene);
-        }
-        currentAct = this.ACT_BY_ID(currentAct.next_act);
-      }
-      return scenes;
-    },
-    ...mapGetters(['ACT_BY_ID', 'SCENE_BY_ID', 'CURRENT_SHOW', 'CUE_TYPES', 'CUE_TYPE_BY_ID']),
-  },
-  async mounted() {
-    await this.GET_ACT_LIST();
-    await this.GET_SCENE_LIST();
-    await this.getCueStats();
-    this.loaded = true;
+    ...mapGetters(['CUE_TYPES', 'CUE_TYPE_BY_ID']),
   },
   methods: {
-    numScenesPerAct(actId) {
-      return this.sortedScenes.filter((scene) => scene.act === actId).length;
-    },
-    getHeaderName(sceneId) {
-      return `head(${sceneId})`;
-    },
-    getCellName(sceneId) {
-      return `cell(${sceneId})`;
-    },
-    async getCueStats() {
+    async getStats() {
       const response = await fetch(`${makeURL('/api/v1/show/cues/stats')}`);
       if (response.ok) {
         this.cueStats = await response.json();
@@ -170,7 +121,6 @@ export default {
       }
       return 0;
     },
-    ...mapActions(['GET_ACT_LIST', 'GET_SCENE_LIST']),
   },
 };
 </script>


### PR DESCRIPTION
## Summary
- Created `statsTableMixin.js` to eliminate code duplication across stats table components
- Refactored `CastLineStats`, `CharacterLineStats`, and `CueCountStats` to use the shared mixin
- Reduced code duplication by ~150 lines (−28% per component)

## Changes

### New File
- `client/src/mixins/statsTableMixin.js` - Shared mixin providing:
  - `sortedActs` and `sortedScenes` computed properties for act/scene hierarchy traversal
  - Helper methods: `numScenesPerAct()`, `getHeaderName()`, `getCellName()`
  - Lifecycle management for fetching acts/scenes data
  - Vuex integration for required getters and actions

### Refactored Components
- `CastLineStats.vue`: 177 → 127 lines (−50 lines)
- `CharacterLineStats.vue`: 177 → 127 lines (−50 lines)
- `CueCountStats.vue`: 177 → 127 lines (−50 lines)

## Benefits
- **Single source of truth** for act/scene ordering logic
- **Easier maintenance** - bug fixes apply to all three components
- **Reduced duplication** - ~85% of identical code now shared
- **Cleaner components** - each focuses only on its unique stats logic

## Test Plan
- [x] Verify CastLineStats displays correctly with proper act/scene headers
- [x] Verify CharacterLineStats displays correctly with proper act/scene headers
- [x] Verify CueCountStats displays correctly with proper act/scene headers
- [x] Confirm all three tables load data successfully
- [x] Test with shows that have multiple acts and scenes
- [x] Test edge cases (no acts, no scenes, single act/scene)

🤖 Generated with [Claude Code](https://claude.com/claude-code)