### PR TITLE
Fix live show "Go to Page" navigation for pages 100+

### DIFF
--- a/client/src/views/show/ShowLiveView.vue
+++ b/client/src/views/show/ShowLiveView.vue
@@ -558,7 +558,8 @@ export default {
     },
     navigateTo(targetPage, targetLineOnPage, preventScroll = false) {
       // Check if the page is loaded
-      if (targetPage > this.currentLoadedPage) {
+      // Use Number() for defense-in-depth in case currentLoadedPage is ever a string
+      if (targetPage > Number(this.currentLoadedPage)) {
         return false;
       }
 
@@ -975,7 +976,7 @@ export default {
         let minLoadedPage = Number.POSITIVE_INFINITY;
         const respJson = await response.json();
         Object.entries(respJson).forEach((value) => {
-          const pageNumber = value[0];
+          const pageNumber = parseInt(value[0], 10);
           const pageContents = value[1];
 
           if (pageNumber > maxLoadedPage) {


### PR DESCRIPTION
## Summary
- Fixes string comparison bug in `loadCompiledScript()` that prevented "Go to Page" from working for pages 100+
- `Object.entries()` returns page numbers as strings, causing `"100" > "99"` to evaluate `false` (lexicographic comparison)
- Added `parseInt()` to convert page keys to integers before comparison
- Added `Number()` defense-in-depth in `navigateTo()` check

## Root Cause
When comparing page numbers to find `maxLoadedPage`, string comparison was used:
- `"100" > "99"` compares `"1"` vs `"9"` → `false`
- This caused `maxLoadedPage` to incorrectly cap at `"99"`
- Navigation to page 100+ would fail silently

## Test plan
- [x] Verified bug with diagnostic logging (maxLoadedPage was "99" with 117 pages loaded)
- [x] Manual test: Jump to page 100 now highlights line correctly
- [x] Manual test: Subsequent navigation maintains position
- [x] ESLint passes
- [x] Vitest passes (83 tests)

Fixes #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)