### PR TITLE
Add future annotations for TYPE_CHECKING compatibility

### DIFF
--- a/server/digi_server/settings.py
+++ b/server/digi_server/settings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import tomllib

--- a/server/utils/web/base_controller.py
+++ b/server/utils/web/base_controller.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Awaitable, Optional
 
 import bcrypt


### PR DESCRIPTION
## Summary
- Add `from __future__ import annotations` to `settings.py` and `base_controller.py`
- Required for proper deferred evaluation of type annotations when using `TYPE_CHECKING` imports
- Fixes runtime `NameError` when imported types are used in function signatures

This is a prerequisite for PR #880 (Server Side Version Checker).

🤖 Generated with [Claude Code](https://claude.ai/code)