### PR TITLE
Standardize on `from __future__ import annotations` and unquote type annotations

### DIFF
--- a/server/controllers/ws_controller.py
+++ b/server/controllers/ws_controller.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import json
 from typing import TYPE_CHECKING, Any, Awaitable, Dict, Optional, Union

--- a/server/models/cue.py
+++ b/server/models/cue.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 
 from sqlalchemy import ForeignKey, String, func, select
@@ -20,7 +22,7 @@ class CueType(db.Model, DeleteMixin):
     description: Mapped[str | None] = mapped_column(String(100))
     colour: Mapped[str | None] = mapped_column(String(16))
 
-    cues: Mapped[List["Cue"]] = relationship(
+    cues: Mapped[List[Cue]] = relationship(
         back_populates="cue_type", cascade="all, delete-orphan"
     )
 
@@ -38,10 +40,10 @@ class Cue(db.Model):
     cue_type_id: Mapped[int | None] = mapped_column(ForeignKey("cuetypes.id"))
     ident: Mapped[str | None] = mapped_column(String(50))
 
-    cue_type: Mapped["CueType"] = relationship(
+    cue_type: Mapped[CueType] = relationship(
         foreign_keys=[cue_type_id], back_populates="cues"
     )
-    revision_associations: Mapped[List["CueAssociation"]] = relationship(
+    revision_associations: Mapped[List[CueAssociation]] = relationship(
         cascade="all, delete-orphan", back_populates="cue"
     )
 
@@ -59,13 +61,13 @@ class CueAssociation(db.Model, DeleteMixin):
         ForeignKey("cue.id"), primary_key=True, index=True
     )
 
-    revision: Mapped["ScriptRevision"] = relationship(
+    revision: Mapped[ScriptRevision] = relationship(
         foreign_keys=[revision_id], back_populates="cue_associations"
     )
-    line: Mapped["ScriptLine"] = relationship(
+    line: Mapped[ScriptLine] = relationship(
         foreign_keys=[line_id], back_populates="cue_associations", viewonly=True
     )
-    cue: Mapped["Cue"] = relationship(
+    cue: Mapped[Cue] = relationship(
         foreign_keys=[cue_id], back_populates="revision_associations"
     )
 

--- a/server/models/mics.py
+++ b/server/models/mics.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, List
 
 from sqlalchemy import ForeignKey, String
@@ -19,7 +21,7 @@ class Microphone(db.Model):
     name: Mapped[str | None] = mapped_column(String(100))
     description: Mapped[str | None] = mapped_column(String(500))
 
-    allocations: Mapped[List["MicrophoneAllocation"]] = relationship(
+    allocations: Mapped[List[MicrophoneAllocation]] = relationship(
         cascade="all, delete-orphan", back_populates="microphone"
     )
 
@@ -33,6 +35,6 @@ class MicrophoneAllocation(db.Model):
         ForeignKey("character.id"), primary_key=True
     )
 
-    microphone: Mapped["Microphone"] = relationship(back_populates="allocations")
-    scene: Mapped["Scene"] = relationship(back_populates="mic_allocations")
-    character: Mapped["Character"] = relationship(back_populates="mic_allocations")
+    microphone: Mapped[Microphone] = relationship(back_populates="allocations")
+    scene: Mapped[Scene] = relationship(back_populates="mic_allocations")
+    character: Mapped[Character] = relationship(back_populates="mic_allocations")

--- a/server/models/script.py
+++ b/server/models/script.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import enum
 import gzip
@@ -41,11 +43,11 @@ class Script(db.Model):
         ForeignKey("script_revisions.id")
     )
 
-    revisions: Mapped[List["ScriptRevision"]] = relationship(
+    revisions: Mapped[List[ScriptRevision]] = relationship(
         primaryjoin="ScriptRevision.script_id == Script.id", back_populates="script"
     )
-    show: Mapped["Show"] = relationship(foreign_keys=[show_id])
-    stage_direction_styles: Mapped[List["StageDirectionStyle"]] = relationship(
+    show: Mapped[Show] = relationship(foreign_keys=[show_id])
+    stage_direction_styles: Mapped[List[StageDirectionStyle]] = relationship(
         cascade="all, delete-orphan", back_populates="script"
     )
 
@@ -64,19 +66,19 @@ class ScriptRevision(db.Model):
         ForeignKey("script_revisions.id", ondelete="SET NULL")
     )
 
-    previous_revision: Mapped["ScriptRevision"] = relationship(
+    previous_revision: Mapped[ScriptRevision] = relationship(
         foreign_keys=[previous_revision_id]
     )
-    script: Mapped["Script"] = relationship(
+    script: Mapped[Script] = relationship(
         foreign_keys=[script_id], back_populates="revisions"
     )
-    line_associations: Mapped[List["ScriptLineRevisionAssociation"]] = relationship(
+    line_associations: Mapped[List[ScriptLineRevisionAssociation]] = relationship(
         cascade="all, delete", back_populates="revision"
     )
-    line_part_cuts: Mapped[List["ScriptCuts"]] = relationship(
+    line_part_cuts: Mapped[List[ScriptCuts]] = relationship(
         cascade="all, delete-orphan", back_populates="revision"
     )
-    cue_associations: Mapped[List["CueAssociation"]] = relationship(
+    cue_associations: Mapped[List[CueAssociation]] = relationship(
         cascade="all, delete-orphan", back_populates="revision"
     )
 
@@ -130,17 +132,17 @@ class ScriptLine(db.Model):
         ForeignKey("stage_direction_styles.id", ondelete="SET NULL")
     )
 
-    act: Mapped["Act"] = relationship(back_populates="lines")
-    scene: Mapped["Scene"] = relationship(back_populates="lines")
-    revision_associations: Mapped[List["ScriptLineRevisionAssociation"]] = relationship(
+    act: Mapped[Act] = relationship(back_populates="lines")
+    scene: Mapped[Scene] = relationship(back_populates="lines")
+    revision_associations: Mapped[List[ScriptLineRevisionAssociation]] = relationship(
         foreign_keys="[ScriptLineRevisionAssociation.line_id]",
         cascade="all, delete",
         back_populates="line",
     )
-    cue_associations: Mapped[List["CueAssociation"]] = relationship(
+    cue_associations: Mapped[List[CueAssociation]] = relationship(
         foreign_keys="[CueAssociation.line_id]", viewonly=True, back_populates="line"
     )
-    line_parts: Mapped[List["ScriptLinePart"]] = relationship(
+    line_parts: Mapped[List[ScriptLinePart]] = relationship(
         cascade="all, delete-orphan", back_populates="line"
     )
 
@@ -158,14 +160,14 @@ class ScriptLineRevisionAssociation(db.Model, DeleteMixin):
     next_line_id: Mapped[int | None] = mapped_column(ForeignKey("script_lines.id"))
     previous_line_id: Mapped[int | None] = mapped_column(ForeignKey("script_lines.id"))
 
-    revision: Mapped["ScriptRevision"] = relationship(
+    revision: Mapped[ScriptRevision] = relationship(
         foreign_keys=[revision_id], back_populates="line_associations"
     )
-    line: Mapped["ScriptLine"] = relationship(
+    line: Mapped[ScriptLine] = relationship(
         foreign_keys=[line_id], back_populates="revision_associations"
     )
-    next_line: Mapped["ScriptLine"] = relationship(foreign_keys=[next_line_id])
-    previous_line: Mapped["ScriptLine"] = relationship(foreign_keys=[previous_line_id])
+    next_line: Mapped[ScriptLine] = relationship(foreign_keys=[next_line_id])
+    previous_line: Mapped[ScriptLine] = relationship(foreign_keys=[previous_line_id])
 
     def pre_delete(self, session):
         pass
@@ -259,12 +261,12 @@ class ScriptLinePart(db.Model):
     )
     line_text: Mapped[str | None] = mapped_column(String)
 
-    line: Mapped["ScriptLine"] = relationship(
+    line: Mapped[ScriptLine] = relationship(
         foreign_keys=[line_id], back_populates="line_parts"
     )
-    character: Mapped["Character"] = relationship()
-    character_group: Mapped["CharacterGroup"] = relationship()
-    line_part_cuts: Mapped["ScriptCuts"] = relationship(
+    character: Mapped[Character] = relationship()
+    character_group: Mapped[CharacterGroup] = relationship()
+    line_part_cuts: Mapped[ScriptCuts] = relationship(
         cascade="all, delete-orphan", back_populates="line_part"
     )
 
@@ -279,10 +281,10 @@ class ScriptCuts(db.Model):
         ForeignKey("script_revisions.id"), primary_key=True, index=True
     )
 
-    line_part: Mapped["ScriptLinePart"] = relationship(
+    line_part: Mapped[ScriptLinePart] = relationship(
         foreign_keys=[line_part_id], back_populates="line_part_cuts"
     )
-    revision: Mapped["ScriptRevision"] = relationship(
+    revision: Mapped[ScriptRevision] = relationship(
         foreign_keys=[revision_id], back_populates="line_part_cuts"
     )
 
@@ -313,7 +315,7 @@ class StageDirectionStyle(db.Model, DeleteMixin):
     enable_background_colour: Mapped[bool | None] = mapped_column(Boolean)
     background_colour: Mapped[str | None] = mapped_column(String)
 
-    script: Mapped["Script"] = relationship(
+    script: Mapped[Script] = relationship(
         foreign_keys=[script_id], back_populates="stage_direction_styles"
     )
 
@@ -344,10 +346,10 @@ class CompiledScript(db.Model):
     )
     data_path: Mapped[str | None] = mapped_column(String)
 
-    script_revision: Mapped["ScriptRevision"] = relationship(foreign_keys=[revision_id])
+    script_revision: Mapped[ScriptRevision] = relationship(foreign_keys=[revision_id])
 
     @classmethod
-    async def compile_script(cls, application: "DigiScriptServer", revision_id):
+    async def compile_script(cls, application: DigiScriptServer, revision_id):
         line_schema = get_registry().get_schema_by_model(ScriptLine)()
         with application.get_db().sessionmaker() as session:
             revision: ScriptRevision = session.get(ScriptRevision, revision_id)

--- a/server/models/session.py
+++ b/server/models/session.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from functools import partial
 from typing import TYPE_CHECKING
@@ -26,8 +28,8 @@ class Session(db.Model):
         ForeignKey("user.id", ondelete="SET NULL"), index=True
     )
 
-    user: Mapped["User"] = relationship(back_populates="sessions")
-    live_session: Mapped["ShowSession"] = relationship(
+    user: Mapped[User] = relationship(back_populates="sessions")
+    live_session: Mapped[ShowSession] = relationship(
         foreign_keys="[ShowSession.client_internal_id]",
         back_populates="client",
     )
@@ -66,16 +68,16 @@ class ShowSession(db.Model):
         ForeignKey("showinterval.id", ondelete="SET NULL")
     )
 
-    show: Mapped["Show"] = relationship(uselist=False, foreign_keys=[show_id])
-    revision: Mapped["ScriptRevision"] = relationship(
+    show: Mapped[Show] = relationship(uselist=False, foreign_keys=[show_id])
+    revision: Mapped[ScriptRevision] = relationship(
         uselist=False, foreign_keys=[script_revision_id]
     )
-    user: Mapped["User"] = relationship(uselist=False, foreign_keys=[user_id])
-    client: Mapped["Session"] = relationship(
+    user: Mapped[User] = relationship(uselist=False, foreign_keys=[user_id])
+    client: Mapped[Session] = relationship(
         foreign_keys=[client_internal_id],
         back_populates="live_session",
     )
-    tags: Mapped[list["SessionTag"]] = relationship(
+    tags: Mapped[list[SessionTag]] = relationship(
         secondary=session_tag_association_table, back_populates="sessions"
     )
 
@@ -105,7 +107,7 @@ class SessionTag(db.Model):
     tag: Mapped[str] = mapped_column(String(255))
     colour: Mapped[str] = mapped_column(String(16))
 
-    show: Mapped["Show"] = relationship(uselist=False, foreign_keys=[show_id])
-    sessions: Mapped[list["ShowSession"]] = relationship(
+    show: Mapped[Show] = relationship(uselist=False, foreign_keys=[show_id])
+    sessions: Mapped[list[ShowSession]] = relationship(
         secondary=session_tag_association_table, back_populates="tags"
     )

--- a/server/models/show.py
+++ b/server/models/show.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import enum
 from typing import TYPE_CHECKING, List
@@ -60,23 +62,21 @@ class Show(db.Model):
     script_mode: Mapped[ShowScriptType] = mapped_column(ShowScriptTypeCol)
 
     # Relationships
-    first_act: Mapped["Act"] = relationship(foreign_keys=[first_act_id])
-    current_session: Mapped["ShowSession"] = relationship(
+    first_act: Mapped[Act] = relationship(foreign_keys=[first_act_id])
+    current_session: Mapped[ShowSession] = relationship(
         foreign_keys=[current_session_id]
     )
 
-    cast_list: Mapped[List["Cast"]] = relationship(cascade="all, delete-orphan")
-    character_list: Mapped[List["Character"]] = relationship(
+    cast_list: Mapped[List[Cast]] = relationship(cascade="all, delete-orphan")
+    character_list: Mapped[List[Character]] = relationship(cascade="all, delete-orphan")
+    character_group_list: Mapped[List[CharacterGroup]] = relationship(
         cascade="all, delete-orphan"
     )
-    character_group_list: Mapped[List["CharacterGroup"]] = relationship(
-        cascade="all, delete-orphan"
-    )
-    act_list: Mapped[List["Act"]] = relationship(
+    act_list: Mapped[List[Act]] = relationship(
         primaryjoin="Show.id == Act.show_id", cascade="all, delete-orphan"
     )
-    scene_list: Mapped[List["Scene"]] = relationship(cascade="all, delete-orphan")
-    cue_type_list: Mapped[List["CueType"]] = relationship(cascade="all, delete-orphan")
+    scene_list: Mapped[List[Scene]] = relationship(cascade="all, delete-orphan")
+    cue_type_list: Mapped[List[CueType]] = relationship(cascade="all, delete-orphan")
 
 
 class Cast(db.Model):
@@ -88,9 +88,7 @@ class Cast(db.Model):
     last_name: Mapped[str | None] = mapped_column()
 
     # Relationships
-    character_list: Mapped[List["Character"]] = relationship(
-        back_populates="cast_member"
-    )
+    character_list: Mapped[List[Character]] = relationship(back_populates="cast_member")
 
 
 character_group_association_table = Table(
@@ -110,12 +108,12 @@ class Character(db.Model):
     name: Mapped[str | None] = mapped_column()
     description: Mapped[str | None] = mapped_column()
 
-    cast_member: Mapped["Cast"] = relationship(back_populates="character_list")
-    character_groups: Mapped[List["CharacterGroup"]] = relationship(
+    cast_member: Mapped[Cast] = relationship(back_populates="character_list")
+    character_groups: Mapped[List[CharacterGroup]] = relationship(
         secondary=character_group_association_table,
         back_populates="characters",
     )
-    mic_allocations: Mapped[List["MicrophoneAllocation"]] = relationship(
+    mic_allocations: Mapped[List[MicrophoneAllocation]] = relationship(
         cascade="all, delete-orphan", back_populates="character"
     )
 
@@ -129,7 +127,7 @@ class CharacterGroup(db.Model):
     name: Mapped[str | None] = mapped_column()
     description: Mapped[str | None] = mapped_column()
 
-    characters: Mapped[List["Character"]] = relationship(
+    characters: Mapped[List[Character]] = relationship(
         secondary=character_group_association_table,
         back_populates="character_groups",
     )
@@ -145,22 +143,22 @@ class Act(db.Model):
     first_scene_id: Mapped[int | None] = mapped_column(ForeignKey("scene.id"))
     previous_act_id: Mapped[int | None] = mapped_column(ForeignKey("act.id"))
 
-    first_scene: Mapped["Scene"] = relationship(foreign_keys=[first_scene_id])
-    previous_act: Mapped["Act"] = relationship(
+    first_scene: Mapped[Scene] = relationship(foreign_keys=[first_scene_id])
+    previous_act: Mapped[Act] = relationship(
         remote_side="[Act.id]",
         back_populates="next_act",
         foreign_keys=[previous_act_id],
     )
-    next_act: Mapped["Act"] = relationship(
+    next_act: Mapped[Act] = relationship(
         back_populates="previous_act",
         foreign_keys="[Act.previous_act_id]",
     )
-    scene_list: Mapped[List["Scene"]] = relationship(
+    scene_list: Mapped[List[Scene]] = relationship(
         back_populates="act",
         cascade="all, delete-orphan",
         foreign_keys="[Scene.act_id]",
     )
-    lines: Mapped[List["ScriptLine"]] = relationship(
+    lines: Mapped[List[ScriptLine]] = relationship(
         back_populates="act", cascade="all, delete-orphan"
     )
 
@@ -174,23 +172,23 @@ class Scene(db.Model):
     name: Mapped[str | None] = mapped_column()
     previous_scene_id: Mapped[int | None] = mapped_column(ForeignKey("scene.id"))
 
-    act: Mapped["Act"] = relationship(
+    act: Mapped[Act] = relationship(
         back_populates="scene_list",
         foreign_keys=[act_id],
         post_update=True,
     )
-    previous_scene: Mapped["Scene"] = relationship(
+    previous_scene: Mapped[Scene] = relationship(
         remote_side="[Scene.id]",
         back_populates="next_scene",
         foreign_keys=[previous_scene_id],
     )
-    next_scene: Mapped["Scene"] = relationship(
+    next_scene: Mapped[Scene] = relationship(
         back_populates="previous_scene",
         foreign_keys="[Scene.previous_scene_id]",
     )
-    lines: Mapped[List["ScriptLine"]] = relationship(
+    lines: Mapped[List[ScriptLine]] = relationship(
         back_populates="scene", cascade="all, delete-orphan"
     )
-    mic_allocations: Mapped[List["MicrophoneAllocation"]] = relationship(
+    mic_allocations: Mapped[List[MicrophoneAllocation]] = relationship(
         cascade="all, delete-orphan", back_populates="scene"
     )

--- a/server/models/user.py
+++ b/server/models/user.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import enum
 import json
@@ -71,7 +73,7 @@ class User(db.Model):
     requires_password_change: Mapped[bool] = mapped_column(default=False)
     token_version: Mapped[int] = mapped_column(default=0)
 
-    sessions: Mapped[List["Session"]] = relationship(back_populates="user")
+    sessions: Mapped[List[Session]] = relationship(back_populates="user")
 
 
 class UserSettings(db.Model):

--- a/server/rbac/rbac.py
+++ b/server/rbac/rbac.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, List, Optional
 
 from models.models import db
@@ -12,7 +14,7 @@ if TYPE_CHECKING:
 
 
 class RBACController:
-    def __init__(self, app: "DigiScriptServer"):
+    def __init__(self, app: DigiScriptServer):
         self.app = app
         self._rbac_db = RBACDatabase(app.get_db(), app)
         self._display_fields = {}

--- a/server/rbac/rbac_db.py
+++ b/server/rbac/rbac_db.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 from collections import defaultdict
 from copy import deepcopy
@@ -85,7 +87,7 @@ def _get_mapping_columns(
 
 
 class RBACDatabase:
-    def __init__(self, _db: DigiSQLAlchemy, app: "DigiScriptServer"):
+    def __init__(self, _db: DigiSQLAlchemy, app: DigiScriptServer):
         self._db: DigiSQLAlchemy = _db
         self._app = app
         self._mappings = {}

--- a/server/registry/schema.py
+++ b/server/registry/schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Optional
 
 from marshmallow_sqlalchemy import SQLAlchemySchema
@@ -19,7 +21,7 @@ class SchemaRegistry:
     def get_schema_by_model(self, key) -> Optional[SQLAlchemySchema]:
         return self._backward_registry.get(key, None)
 
-    def get_model_by_schema(self, key) -> "db.Model":
+    def get_model_by_schema(self, key) -> db.Model:
         return self._forward_registry.get(key, None)
 
 


### PR DESCRIPTION
## Summary
- Add `from __future__ import annotations` (PEP 563) to all 10 server-side files that use `TYPE_CHECKING` or string-quoted forward references
- Remove all unnecessary string quotes from `Mapped[...]` type annotations, function parameter annotations, and return type annotations
- Applies `ruff format` reformatting where line lengths changed (show.py)

## Test plan
- [x] `ruff check server/` passes with no errors
- [x] `ruff format server/` reports no changes needed
- [x] `pytest` — all 313 tests pass
- [x] Verified SQLAlchemy models work correctly with deferred annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)