### PR TITLE
Reduce code duplication to pass SonarQube quality gate

### DIFF
--- a/client/src/mixins/formValidationMixin.js
+++ b/client/src/mixins/formValidationMixin.js
@@ -51,28 +51,6 @@ export default {
     },
 
     /**
-     * Validate state for a field in newFormState.
-     * Convenience method that wraps getValidationState.
-     *
-     * @param {string} fieldName - The field name to validate
-     * @returns {boolean|null} - Bootstrap validation state
-     */
-    validateNewState(fieldName) {
-      return this.getValidationState('newFormState', fieldName);
-    },
-
-    /**
-     * Validate state for a field in editFormState.
-     * Convenience method that wraps getValidationState.
-     *
-     * @param {string} fieldName - The field name to validate
-     * @returns {boolean|null} - Bootstrap validation state
-     */
-    validateEditState(fieldName) {
-      return this.getValidationState('editFormState', fieldName);
-    },
-
-    /**
      * Reset a form to its initial state and reset validation.
      *
      * @param {string} formStateKey - The data property key (e.g., 'newFormState')

--- a/client/src/mixins/formValidationMixin.js
+++ b/client/src/mixins/formValidationMixin.js
@@ -1,0 +1,99 @@
+/**
+ * Mixin providing common form validation helper methods for Vuelidate.
+ *
+ * This mixin centralizes the repeated validation and form reset patterns used
+ * across multiple components that handle new/edit forms.
+ *
+ * Usage:
+ * 1. Import and include in your component's mixins array
+ * 2. Define your form state properties (e.g., newFormState, editFormState)
+ * 3. Define your validations object as usual
+ * 4. Use the helper methods in your template and component logic
+ *
+ * Example:
+ *   import formValidationMixin from '@/mixins/formValidationMixin';
+ *
+ *   export default {
+ *     mixins: [formValidationMixin],
+ *     data() {
+ *       return {
+ *         newFormState: { name: '' },
+ *         editFormState: { id: null, name: '' },
+ *       };
+ *     },
+ *     validations: {
+ *       newFormState: { name: { required } },
+ *       editFormState: { name: { required } },
+ *     },
+ *     methods: {
+ *       resetNewForm() {
+ *         this.resetForm('newFormState', { name: '' });
+ *       },
+ *     },
+ *   };
+ */
+export default {
+  methods: {
+    /**
+     * Get Bootstrap validation state for a form field.
+     *
+     * @param {string} formStateKey - The validation group key (e.g., 'newFormState', 'editFormState')
+     * @param {string} fieldName - The field name within the validation group
+     * @returns {boolean|null} - true if valid, false if invalid, null if pristine
+     */
+    getValidationState(formStateKey, fieldName) {
+      const field = this.$v[formStateKey][fieldName];
+      if (!field) {
+        return null;
+      }
+      const { $dirty, $error } = field;
+      return $dirty ? !$error : null;
+    },
+
+    /**
+     * Validate state for a field in newFormState.
+     * Convenience method that wraps getValidationState.
+     *
+     * @param {string} fieldName - The field name to validate
+     * @returns {boolean|null} - Bootstrap validation state
+     */
+    validateNewState(fieldName) {
+      return this.getValidationState('newFormState', fieldName);
+    },
+
+    /**
+     * Validate state for a field in editFormState.
+     * Convenience method that wraps getValidationState.
+     *
+     * @param {string} fieldName - The field name to validate
+     * @returns {boolean|null} - Bootstrap validation state
+     */
+    validateEditState(fieldName) {
+      return this.getValidationState('editFormState', fieldName);
+    },
+
+    /**
+     * Reset a form to its initial state and reset validation.
+     *
+     * @param {string} formStateKey - The data property key (e.g., 'newFormState')
+     * @param {Object} initialState - The initial state object to reset to
+     */
+    resetForm(formStateKey, initialState) {
+      this[formStateKey] = { ...initialState };
+      this.$nextTick(() => {
+        this.$v.$reset();
+      });
+    },
+
+    /**
+     * Check if a form has validation errors after touching all fields.
+     *
+     * @param {string} formStateKey - The validation group key
+     * @returns {boolean} - true if the form has any validation errors
+     */
+    hasFormErrors(formStateKey) {
+      this.$v[formStateKey].$touch();
+      return this.$v[formStateKey].$anyError;
+    },
+  },
+};

--- a/client/src/views/show/config/ConfigCast.vue
+++ b/client/src/views/show/config/ConfigCast.vue
@@ -148,10 +148,12 @@ import { required } from 'vuelidate/lib/validators';
 import { mapGetters, mapActions } from 'vuex';
 import CastLineStats from '@/vue_components/show/config/cast/CastLineStats.vue';
 import log from 'loglevel';
+import formValidationMixin from '@/mixins/formValidationMixin';
 
 export default {
   name: 'ConfigCast',
   components: { CastLineStats },
+  mixins: [formValidationMixin],
   data() {
     return {
       castFields: ['first_name', 'last_name', { key: 'btn', label: '' }],
@@ -198,15 +200,11 @@ export default {
   },
   methods: {
     resetNewForm() {
-      this.newFormState = {
+      this.resetForm('newFormState', {
         firstName: '',
         lastName: '',
-      };
-      this.submittingNewCast = false;
-
-      this.$nextTick(() => {
-        this.$v.$reset();
       });
+      this.submittingNewCast = false;
     },
     async onSubmitNew(event) {
       this.$v.newFormState.$touch();
@@ -227,10 +225,6 @@ export default {
         this.submittingNewCast = false;
       }
     },
-    validateNewState(name) {
-      const { $dirty, $error } = this.$v.newFormState[name];
-      return $dirty ? !$error : null;
-    },
     openEditForm(castMember) {
       if (castMember != null) {
         this.editFormState.id = castMember.item.id;
@@ -241,18 +235,14 @@ export default {
       }
     },
     resetEditForm() {
-      this.editFormState = {
+      this.resetForm('editFormState', {
         id: null,
         showID: null,
         firstName: '',
         lastName: '',
-      };
+      });
       this.submittingEditCast = false;
       this.deletingCast = false;
-
-      this.$nextTick(() => {
-        this.$v.$reset();
-      });
     },
     async onSubmitEdit(event) {
       this.$v.editFormState.$touch();
@@ -272,10 +262,6 @@ export default {
       } finally {
         this.submittingEditCast = false;
       }
-    },
-    validateEditState(name) {
-      const { $dirty, $error } = this.$v.editFormState[name];
-      return $dirty ? !$error : null;
     },
     async deleteCastMember(castMember) {
       if (this.deletingCast) {

--- a/client/src/views/show/config/ConfigCast.vue
+++ b/client/src/views/show/config/ConfigCast.vue
@@ -71,7 +71,7 @@
             id="new-first-name-input"
             v-model="$v.newFormState.firstName.$model"
             name="new-first-name-input"
-            :state="validateNewState('firstName')"
+            :state="getValidationState('newFormState', 'firstName')"
             aria-describedby="new-first-name-feedback"
           />
           <b-form-invalid-feedback id="new-first-name-feedback">
@@ -87,7 +87,7 @@
             id="new-last-name-input"
             v-model="$v.newFormState.lastName.$model"
             name="new-last-name-input"
-            :state="validateNewState('lastName')"
+            :state="getValidationState('newFormState', 'lastName')"
             aria-describedby="new-last-name-feedback"
           />
           <b-form-invalid-feedback id="new-last-name-feedback">
@@ -115,7 +115,7 @@
             id="edit-first-name-input"
             v-model="$v.editFormState.firstName.$model"
             name="edit-first-name-input"
-            :state="validateEditState('firstName')"
+            :state="getValidationState('editFormState', 'firstName')"
             aria-describedby="edit-first-name-feedback"
           />
           <b-form-invalid-feedback id="edit-first-name-feedback">
@@ -131,7 +131,7 @@
             id="edit-last-name-input"
             v-model="$v.editFormState.lastName.$model"
             name="edit-last-name-input"
-            :state="validateEditState('lastName')"
+            :state="getValidationState('editFormState', 'lastName')"
             aria-describedby="edit-last-name-feedback"
           />
           <b-form-invalid-feedback id="edit-last-name-feedback">

--- a/client/src/views/show/config/ConfigCharacters.vue
+++ b/client/src/views/show/config/ConfigCharacters.vue
@@ -168,10 +168,12 @@ import { mapGetters, mapActions } from 'vuex';
 import CharacterLineStats from '@/vue_components/show/config/characters/CharacterLineStats.vue';
 import log from 'loglevel';
 import CharacterGroups from '@/vue_components/show/config/characters/CharacterGroups.vue';
+import formValidationMixin from '@/mixins/formValidationMixin';
 
 export default {
   name: 'ConfigCharacters',
   components: { CharacterGroups, CharacterLineStats },
+  mixins: [formValidationMixin],
   data() {
     return {
       rowsPerPage: 15,
@@ -232,16 +234,12 @@ export default {
   },
   methods: {
     resetNewForm() {
-      this.newFormState = {
+      this.resetForm('newFormState', {
         name: '',
         description: '',
         played_by: null,
-      };
-      this.submittingNewCharacter = false;
-
-      this.$nextTick(() => {
-        this.$v.$reset();
       });
+      this.submittingNewCharacter = false;
     },
     async onSubmitNew(event) {
       this.$v.newFormState.$touch();
@@ -262,10 +260,6 @@ export default {
         this.submittingNewCharacter = false;
       }
     },
-    validateNewState(name) {
-      const { $dirty, $error } = this.$v.newFormState[name];
-      return $dirty ? !$error : null;
-    },
     openEditForm(character) {
       if (character != null) {
         this.editFormState.id = character.item.id;
@@ -277,19 +271,15 @@ export default {
       }
     },
     resetEditForm() {
-      this.editFormState = {
+      this.resetForm('editFormState', {
         id: null,
         showID: null,
         name: '',
         description: '',
         played_by: null,
-      };
+      });
       this.submittingEditCharacter = false;
       this.deletingCharacter = false;
-
-      this.$nextTick(() => {
-        this.$v.$reset();
-      });
     },
     async onSubmitEdit(event) {
       this.$v.editFormState.$touch();
@@ -309,10 +299,6 @@ export default {
       } finally {
         this.submittingEditCharacter = false;
       }
-    },
-    validateEditState(name) {
-      const { $dirty, $error } = this.$v.editFormState[name];
-      return $dirty ? !$error : null;
     },
     async deleteCharacter(character) {
       if (this.deletingCharacter) {

--- a/client/src/views/show/config/ConfigCharacters.vue
+++ b/client/src/views/show/config/ConfigCharacters.vue
@@ -78,7 +78,7 @@
             id="new-name-input"
             v-model="$v.newFormState.name.$model"
             name="new-name-input"
-            :state="validateNewState('name')"
+            :state="getValidationState('newFormState', 'name')"
             aria-describedby="new-name-feedback"
           />
           <b-form-invalid-feedback id="new-name-feedback">
@@ -94,7 +94,7 @@
             id="new-description-input"
             v-model="$v.newFormState.description.$model"
             name="new-description-input"
-            :state="validateNewState('description')"
+            :state="getValidationState('newFormState', 'description')"
           />
         </b-form-group>
         <b-form-group
@@ -106,7 +106,7 @@
             id="new-played-by-input"
             v-model="$v.newFormState.played_by.$model"
             :options="castOptions"
-            :state="validateNewState('played_by')"
+            :state="getValidationState('newFormState', 'played_by')"
           />
         </b-form-group>
       </b-form>
@@ -126,7 +126,7 @@
             id="edit-name-input"
             v-model="$v.editFormState.name.$model"
             name="edit-name-input"
-            :state="validateEditState('name')"
+            :state="getValidationState('editFormState', 'name')"
             aria-describedby="edit-name-feedback"
           />
           <b-form-invalid-feedback id="edit-name-feedback">
@@ -142,7 +142,7 @@
             id="edit-description-input"
             v-model="$v.editFormState.description.$model"
             name="edit-description-input"
-            :state="validateEditState('description')"
+            :state="getValidationState('editFormState', 'description')"
           />
         </b-form-group>
         <b-form-group
@@ -154,7 +154,7 @@
             id="edit-played-by-input"
             v-model="$v.editFormState.played_by.$model"
             :options="castOptions"
-            :state="validateEditState('played_by')"
+            :state="getValidationState('editFormState', 'played_by')"
           />
         </b-form-group>
       </b-form>

--- a/client/src/vue_components/show/config/acts_and_scenes/ConfigActs.vue
+++ b/client/src/vue_components/show/config/acts_and_scenes/ConfigActs.vue
@@ -72,7 +72,7 @@
             id="new-name-input"
             v-model="$v.newFormState.name.$model"
             name="new-name-input"
-            :state="validateNewState('name')"
+            :state="getValidationState('newFormState', 'name')"
             aria-describedby="new-name-feedback"
           />
           <b-form-invalid-feedback id="new-name-feedback">
@@ -119,7 +119,7 @@
             id="edit-name-input"
             v-model="$v.editFormState.name.$model"
             name="edit-name-input"
-            :state="validateEditState('name')"
+            :state="getValidationState('editFormState', 'name')"
             aria-describedby="edit-name-feedback"
           />
           <b-form-invalid-feedback id="edit-name-feedback">
@@ -146,7 +146,7 @@
             id="edit-previous-act-input"
             v-model="$v.editFormState.previous_act_id.$model"
             :options="editFormActOptions"
-            :state="validateEditState('previous_act_id')"
+            :state="getValidationState('editFormState', 'previous_act_id')"
             aria-describedby="edit-previous-act-feedback"
           />
           <b-form-invalid-feedback id="edit-previous-act-feedback">

--- a/client/src/vue_components/show/config/acts_and_scenes/ConfigActs.vue
+++ b/client/src/vue_components/show/config/acts_and_scenes/ConfigActs.vue
@@ -165,9 +165,11 @@
 import { required, integer } from 'vuelidate/lib/validators';
 import { mapGetters, mapActions } from 'vuex';
 import log from 'loglevel';
+import formValidationMixin from '@/mixins/formValidationMixin';
 
 export default {
   name: 'ConfigActs',
+  mixins: [formValidationMixin],
   data() {
     return {
       loading: true,
@@ -271,20 +273,12 @@ export default {
   },
   methods: {
     resetNewForm() {
-      this.newFormState = {
+      this.resetForm('newFormState', {
         name: '',
         interval_after: false,
         previous_act_id: null,
-      };
-      this.submittingNewAct = false;
-
-      this.$nextTick(() => {
-        this.$v.$reset();
       });
-    },
-    validateNewState(name) {
-      const { $dirty, $error } = this.$v.newFormState[name];
-      return $dirty ? !$error : null;
+      this.submittingNewAct = false;
     },
     async onSubmitNew(event) {
       this.$v.newFormState.$touch();
@@ -318,19 +312,15 @@ export default {
       }
     },
     resetEditForm() {
-      this.editFormState = {
+      this.resetForm('editFormState', {
         id: null,
         showID: null,
         name: '',
         interval_after: false,
         previous_act_id: null,
-      };
+      });
       this.submittingEditAct = false;
       this.deletingAct = false;
-
-      this.$nextTick(() => {
-        this.$v.$reset();
-      });
     },
     async onSubmitEdit(event) {
       this.$v.editFormState.$touch();
@@ -350,10 +340,6 @@ export default {
       } finally {
         this.submittingEditAct = false;
       }
-    },
-    validateEditState(name) {
-      const { $dirty, $error } = this.$v.editFormState[name];
-      return $dirty ? !$error : null;
     },
     async deleteAct(act) {
       if (this.deletingAct) {

--- a/client/src/vue_components/show/config/acts_and_scenes/ConfigScenes.vue
+++ b/client/src/vue_components/show/config/acts_and_scenes/ConfigScenes.vue
@@ -96,7 +96,7 @@
             id="new-name-input"
             v-model="$v.newFormState.name.$model"
             name="new-name-input"
-            :state="validateNewState('name')"
+            :state="getValidationState('newFormState', 'name')"
             aria-describedby="new-name-feedback"
           />
           <b-form-invalid-feedback id="new-name-feedback">
@@ -108,7 +108,7 @@
             id="new-act-input"
             v-model="$v.newFormState.act_id.$model"
             :options="actOptions"
-            :state="validateNewState('act_id')"
+            :state="getValidationState('newFormState', 'act_id')"
             aria-describedby="new-act-feedback"
           />
           <b-form-invalid-feedback id="new-act-feedback">
@@ -144,7 +144,7 @@
             id="edit-name-input"
             v-model="$v.editFormState.name.$model"
             name="edit-name-input"
-            :state="validateEditState('name')"
+            :state="getValidationState('editFormState', 'name')"
             aria-describedby="edit-name-feedback"
           />
           <b-form-invalid-feedback id="edit-name-feedback">
@@ -156,7 +156,7 @@
             id="edit-act-input"
             v-model="$v.editFormState.act_id.$model"
             :options="actOptions"
-            :state="validateEditState('act_id')"
+            :state="getValidationState('editFormState', 'act_id')"
             aria-describedby="edit-act-feedback"
             @change="editActChanged"
           />
@@ -173,7 +173,7 @@
             id="edit-previous-scene-input"
             v-model="$v.editFormState.previous_scene_id.$model"
             :options="editFormPrevScenes"
-            :state="validateEditState('previous_scene_id')"
+            :state="getValidationState('editFormState', 'previous_scene_id')"
             aria-describedby="edit-previous-scene-feedback"
           />
           <b-form-invalid-feedback id="edit-previous-scene-feedback">

--- a/client/src/vue_components/show/config/acts_and_scenes/ConfigScenes.vue
+++ b/client/src/vue_components/show/config/acts_and_scenes/ConfigScenes.vue
@@ -215,9 +215,11 @@
 import { required, integer } from 'vuelidate/lib/validators';
 import { mapGetters, mapActions } from 'vuex';
 import log from 'loglevel';
+import formValidationMixin from '@/mixins/formValidationMixin';
 
 export default {
   name: 'ConfigScenes',
+  mixins: [formValidationMixin],
   data() {
     return {
       loading: true,
@@ -420,20 +422,12 @@ export default {
   },
   methods: {
     resetNewForm() {
-      this.newFormState = {
+      this.resetForm('newFormState', {
         name: '',
         act_id: null,
         previous_scene_id: null,
-      };
-      this.submittingNewScene = false;
-
-      this.$nextTick(() => {
-        this.$v.$reset();
       });
-    },
-    validateNewState(name) {
-      const { $dirty, $error } = this.$v.newFormState[name];
-      return $dirty ? !$error : null;
+      this.submittingNewScene = false;
     },
     async onSubmitNew(event) {
       this.$v.newFormState.$touch();
@@ -473,15 +467,11 @@ export default {
       }
     },
     resetFirstSceneForm() {
-      this.firstSceneFormState = {
+      this.resetForm('firstSceneFormState', {
         act_id: null,
         scene_id: null,
-      };
-      this.submittingFirstScene = false;
-
-      this.$nextTick(() => {
-        this.$v.$reset();
       });
+      this.submittingFirstScene = false;
     },
     openFirstSceneEdit(act) {
       if (act != null) {
@@ -513,18 +503,14 @@ export default {
     },
     resetEditForm() {
       this.editSceneID = null;
-      this.editFormState = {
+      this.resetForm('editFormState', {
         scene_id: null,
         name: '',
         act_id: null,
         previous_scene_id: null,
-      };
+      });
       this.submittingEditScene = false;
       this.deletingScene = false;
-
-      this.$nextTick(() => {
-        this.$v.$reset();
-      });
     },
     openEditForm(scene) {
       if (scene != null) {
@@ -539,10 +525,6 @@ export default {
         }
         this.$bvModal.show('edit-scene');
       }
-    },
-    validateEditState(name) {
-      const { $dirty, $error } = this.$v.editFormState[name];
-      return $dirty ? !$error : null;
     },
     async onSubmitEdit(event) {
       this.$v.editFormState.$touch();

--- a/client/src/vue_components/show/config/characters/CharacterGroups.vue
+++ b/client/src/vue_components/show/config/characters/CharacterGroups.vue
@@ -67,7 +67,7 @@
             id="new-name-input"
             v-model="$v.newFormState.name.$model"
             name="new-name-input"
-            :state="validateNewState('name')"
+            :state="getValidationState('newFormState', 'name')"
             aria-describedby="new-name-feedback"
           />
           <b-form-invalid-feedback id="new-name-feedback">
@@ -83,7 +83,7 @@
             id="new-description-input"
             v-model="$v.newFormState.description.$model"
             name="new-description-input"
-            :state="validateNewState('description')"
+            :state="getValidationState('newFormState', 'description')"
           />
         </b-form-group>
         <b-form-group
@@ -99,7 +99,7 @@
             :options="CHARACTER_LIST"
             track-by="id"
             label="name"
-            :state="validateNewState('characters')"
+            :state="getValidationState('newFormState', 'characters')"
             @input="newSelectChanged"
           />
         </b-form-group>
@@ -120,7 +120,7 @@
             id="edit-name-input"
             v-model="$v.editFormState.name.$model"
             name="edit-name-input"
-            :state="validateEditState('name')"
+            :state="getValidationState('editFormState', 'name')"
             aria-describedby="edit-name-feedback"
           />
           <b-form-invalid-feedback id="edit-name-feedback">
@@ -136,7 +136,7 @@
             id="edit-description-input"
             v-model="$v.editFormState.description.$model"
             name="edit-description-input"
-            :state="validateEditState('description')"
+            :state="getValidationState('editFormState', 'description')"
           />
         </b-form-group>
         <b-form-group
@@ -152,7 +152,7 @@
             :options="CHARACTER_LIST"
             track-by="id"
             label="name"
-            :state="validateEditState('characters')"
+            :state="getValidationState('editFormState', 'characters')"
             @input="editSelectChanged"
           />
         </b-form-group>

--- a/client/src/vue_components/show/config/characters/CharacterGroups.vue
+++ b/client/src/vue_components/show/config/characters/CharacterGroups.vue
@@ -168,9 +168,11 @@
 import { mapActions, mapGetters } from 'vuex';
 import { required } from 'vuelidate/lib/validators';
 import log from 'loglevel';
+import formValidationMixin from '@/mixins/formValidationMixin';
 
 export default {
   name: 'CharacterGroups',
+  mixins: [formValidationMixin],
   data() {
     return {
       loading: true,
@@ -224,16 +226,12 @@ export default {
     },
     resetNewForm() {
       this.tempCharacterList = [];
-      this.newFormState = {
+      this.resetForm('newFormState', {
         name: '',
         description: '',
         characters: [],
-      };
-      this.submittingNewGroup = false;
-
-      this.$nextTick(() => {
-        this.$v.$reset();
       });
+      this.submittingNewGroup = false;
     },
     async onSubmitNew(event) {
       this.$v.newFormState.$touch();
@@ -253,10 +251,6 @@ export default {
       } finally {
         this.submittingNewGroup = false;
       }
-    },
-    validateNewState(name) {
-      const { $dirty, $error } = this.$v.newFormState[name];
-      return $dirty ? !$error : null;
     },
     async deleteCharacterGroup(characterGroup) {
       if (this.deletingGroup) {
@@ -293,19 +287,15 @@ export default {
       }
     },
     resetEditForm() {
-      this.editFormState = {
+      this.resetForm('editFormState', {
         id: null,
         name: '',
         description: '',
         characters: [],
-      };
+      });
       this.tempEditCharacterList = [];
       this.submittingEditGroup = false;
       this.deletingGroup = false;
-
-      this.$nextTick(() => {
-        this.$v.$reset();
-      });
     },
     editSelectChanged(value, id) {
       this.$v.editFormState.characters.$model = value.map((character) => character.id);
@@ -328,10 +318,6 @@ export default {
       } finally {
         this.submittingEditGroup = false;
       }
-    },
-    validateEditState(name) {
-      const { $dirty, $error } = this.$v.editFormState[name];
-      return $dirty ? !$error : null;
     },
     ...mapActions([
       'GET_CHARACTER_LIST',

--- a/client/src/vue_components/show/config/stage/CrewList.vue
+++ b/client/src/vue_components/show/config/stage/CrewList.vue
@@ -47,7 +47,7 @@
             id="new-first-name-input"
             v-model="$v.newFormState.firstName.$model"
             name="new-first-name-input"
-            :state="validateNewState('firstName')"
+            :state="getValidationState('newFormState', 'firstName')"
             aria-describedby="new-first-name-feedback"
           />
           <b-form-invalid-feedback id="new-first-name-feedback">
@@ -63,7 +63,7 @@
             id="new-last-name-input"
             v-model="$v.newFormState.lastName.$model"
             name="new-last-name-input"
-            :state="validateNewState('lastName')"
+            :state="getValidationState('newFormState', 'lastName')"
             aria-describedby="new-last-name-feedback"
           />
           <b-form-invalid-feedback id="new-last-name-feedback">
@@ -90,7 +90,7 @@
             id="edit-first-name-input"
             v-model="$v.editFormState.firstName.$model"
             name="edit-first-name-input"
-            :state="validateEditState('firstName')"
+            :state="getValidationState('editFormState', 'firstName')"
             aria-describedby="edit-first-name-feedback"
           />
           <b-form-invalid-feedback id="edit-first-name-feedback">
@@ -106,7 +106,7 @@
             id="edit-last-name-input"
             v-model="$v.editFormState.lastName.$model"
             name="edit-last-name-input"
-            :state="validateEditState('lastName')"
+            :state="getValidationState('editFormState', 'lastName')"
             aria-describedby="edit-last-name-feedback"
           />
           <b-form-invalid-feedback id="edit-last-name-feedback">

--- a/client/src/vue_components/show/config/stage/CrewList.vue
+++ b/client/src/vue_components/show/config/stage/CrewList.vue
@@ -121,9 +121,11 @@
 <script>
 import { required } from 'vuelidate/lib/validators';
 import { mapGetters, mapActions } from 'vuex';
+import formValidationMixin from '@/mixins/formValidationMixin';
 
 export default {
   name: 'CrewList',
+  mixins: [formValidationMixin],
   data() {
     return {
       crewFields: ['first_name', 'last_name', { key: 'btn', label: '' }],
@@ -167,13 +169,9 @@ export default {
   },
   methods: {
     resetNewForm() {
-      this.newFormState = {
+      this.resetForm('newFormState', {
         firstName: '',
         lastName: '',
-      };
-
-      this.$nextTick(() => {
-        this.$v.$reset();
       });
     },
     async onSubmitNew(event) {
@@ -185,10 +183,6 @@ export default {
         this.resetNewForm();
       }
     },
-    validateNewState(name) {
-      const { $dirty, $error } = this.$v.newFormState[name];
-      return $dirty ? !$error : null;
-    },
     openEditForm(crewMember) {
       if (crewMember != null) {
         this.editFormState.id = crewMember.item.id;
@@ -199,15 +193,11 @@ export default {
       }
     },
     resetEditForm() {
-      this.editFormState = {
+      this.resetForm('editFormState', {
         id: null,
         showID: null,
         firstName: '',
         lastName: '',
-      };
-
-      this.$nextTick(() => {
-        this.$v.$reset();
       });
     },
     async onSubmitEdit(event) {
@@ -218,10 +208,6 @@ export default {
         await this.UPDATE_CREW_MEMBER(this.editFormState);
         this.resetEditForm();
       }
-    },
-    validateEditState(name) {
-      const { $dirty, $error } = this.$v.editFormState[name];
-      return $dirty ? !$error : null;
     },
     async deleteCrewMember(crewMember) {
       const msg = `Are you sure you want to delete ${crewMember.item.first_name} ${crewMember.item.last_name}?`;

--- a/client/src/vue_components/show/config/stage/PropsList.vue
+++ b/client/src/vue_components/show/config/stage/PropsList.vue
@@ -272,9 +272,11 @@
 import { required } from 'vuelidate/lib/validators';
 import { mapGetters, mapActions } from 'vuex';
 import { notNull } from '@/js/customValidators';
+import formValidationMixin from '@/mixins/formValidationMixin';
 
 export default {
   name: 'PropsList',
+  mixins: [formValidationMixin],
   data() {
     return {
       propTypesFields: ['name', 'description', { key: 'btn', label: '' }],
@@ -357,24 +359,16 @@ export default {
   },
   methods: {
     resetNewPropTypeForm() {
-      this.newPropTypeFormState = {
+      this.resetForm('newPropTypeFormState', {
         name: '',
         description: '',
-      };
-
-      this.$nextTick(() => {
-        this.$v.$reset();
       });
     },
     resetNewPropForm() {
-      this.newPropFormState = {
+      this.resetForm('newPropFormState', {
         name: '',
         description: '',
         prop_type: null,
-      };
-
-      this.$nextTick(() => {
-        this.$v.$reset();
       });
     },
     async onSubmitNewPropType(event) {
@@ -421,26 +415,18 @@ export default {
       }
     },
     resetEditPropTypeForm() {
-      this.editPropTypeFormState = {
+      this.resetForm('editPropTypeFormState', {
         id: null,
         name: '',
         description: '',
-      };
-
-      this.$nextTick(() => {
-        this.$v.$reset();
       });
     },
     resetEditPropForm() {
-      this.editPropFormState = {
+      this.resetForm('editPropFormState', {
         id: null,
         name: '',
         description: '',
         prop_type_id: null,
-      };
-
-      this.$nextTick(() => {
-        this.$v.$reset();
       });
     },
     async onSubmitEditPropType(event) {

--- a/client/src/vue_components/show/config/stage/SceneryList.vue
+++ b/client/src/vue_components/show/config/stage/SceneryList.vue
@@ -280,9 +280,11 @@
 import { required } from 'vuelidate/lib/validators';
 import { mapGetters, mapActions } from 'vuex';
 import { notNull } from '@/js/customValidators';
+import formValidationMixin from '@/mixins/formValidationMixin';
 
 export default {
   name: 'SceneryList',
+  mixins: [formValidationMixin],
   data() {
     return {
       sceneryTypeFields: ['name', 'description', { key: 'btn', label: '' }],
@@ -368,23 +370,15 @@ export default {
   },
   methods: {
     resetNewSceneryTypeForm() {
-      this.newSceneryTypeFormState = {
+      this.resetForm('newSceneryTypeFormState', {
         name: '',
         description: '',
-      };
-
-      this.$nextTick(() => {
-        this.$v.$reset();
       });
     },
     resetNewSceneryForm() {
-      this.newSceneryFormState = {
+      this.resetForm('newSceneryFormState', {
         name: '',
         description: '',
-      };
-
-      this.$nextTick(() => {
-        this.$v.$reset();
       });
     },
     async onSubmitNewSceneryType(event) {
@@ -430,25 +424,17 @@ export default {
       }
     },
     resetEditSceneryTypeForm() {
-      this.editSceneryTypeFormState = {
+      this.resetForm('editSceneryTypeFormState', {
         id: null,
         name: '',
         description: '',
-      };
-
-      this.$nextTick(() => {
-        this.$v.$reset();
       });
     },
     resetEditSceneryForm() {
-      this.editSceneryFormState = {
+      this.resetForm('editSceneryFormState', {
         id: null,
         name: '',
         description: '',
-      };
-
-      this.$nextTick(() => {
-        this.$v.$reset();
       });
     },
     async onSubmitEditSceneryType(event) {

--- a/client/src/vue_components/user/settings/CueColourPreferences.vue
+++ b/client/src/vue_components/user/settings/CueColourPreferences.vue
@@ -62,7 +62,7 @@
                 v-model="$v.newFormState.colour.$model"
                 name="new-colour-input"
                 type="color"
-                :state="validateNewState('colour')"
+                :state="getValidationState('newFormState', 'colour')"
                 aria-describedby="new-colour-feedback"
               />
               <b-form-invalid-feedback id="new-colour-feedback">
@@ -106,7 +106,7 @@
                 v-model="$v.editFormState.colour.$model"
                 name="edit-colour-input"
                 type="color"
-                :state="validateEditState('colour')"
+                :state="getValidationState('editFormState', 'colour')"
                 aria-describedby="edit-colour-feedback"
               />
               <b-form-invalid-feedback id="edit-colour-feedback">

--- a/client/src/vue_components/user/settings/CueColourPreferences.vue
+++ b/client/src/vue_components/user/settings/CueColourPreferences.vue
@@ -158,9 +158,11 @@ import { mapGetters, mapActions } from 'vuex';
 import { required } from 'vuelidate/lib/validators';
 import { contrastColor } from 'contrast-color';
 import log from 'loglevel';
+import formValidationMixin from '@/mixins/formValidationMixin';
 
 export default {
   name: 'CueColourPreferences',
+  mixins: [formValidationMixin],
   data() {
     return {
       columns: [
@@ -255,25 +257,19 @@ export default {
       }
     },
     resetNewFormState() {
-      this.newFormState = {
+      this.resetForm('newFormState', {
         cueTypeId: null,
         colour: '#FF0000',
-      };
-      this.isSubmittingNew = false;
-      this.$nextTick(() => {
-        this.$v.$reset();
       });
+      this.isSubmittingNew = false;
     },
     resetEditFormState() {
-      this.editFormState = {
+      this.resetForm('editFormState', {
         id: null,
         cueTypeId: null,
         colour: '#FF0000',
-      };
-      this.isSubmittingEdit = false;
-      this.$nextTick(() => {
-        this.$v.$reset();
       });
+      this.isSubmittingEdit = false;
     },
     async onSubmitNewOverride(event) {
       this.$v.newFormState.$touch();
@@ -326,14 +322,6 @@ export default {
       } finally {
         this.isSubmittingEdit = false;
       }
-    },
-    validateNewState(name) {
-      const { $dirty, $error } = this.$v.newFormState[name];
-      return $dirty ? !$error : null;
-    },
-    validateEditState(name) {
-      const { $dirty, $error } = this.$v.editFormState[name];
-      return $dirty ? !$error : null;
     },
     async deleteOverride(override) {
       if (this.isDeleting) {

--- a/server/controllers/api/constants.py
+++ b/server/controllers/api/constants.py
@@ -1,0 +1,101 @@
+"""
+Error message constants for API controllers.
+
+This module centralizes error messages to reduce code duplication across controllers.
+All error messages follow the existing API contract patterns.
+"""
+
+# =============================================================================
+# HTTP 404 Not Found Errors
+# =============================================================================
+
+# Core entities
+ERROR_SHOW_NOT_FOUND = "404 show not found"
+ERROR_ACT_NOT_FOUND = "404 act not found"
+ERROR_SCENE_NOT_FOUND = "404 scene not found"
+
+# People
+ERROR_CAST_MEMBER_NOT_FOUND = "404 cast member not found"
+ERROR_CHARACTER_NOT_FOUND = "404 character not found"
+ERROR_CHARACTER_GROUP_NOT_FOUND = "404 character group not found"
+ERROR_CREW_NOT_FOUND = "404 crew member not found"
+
+# Script
+ERROR_SCRIPT_NOT_FOUND = "404 script not found"
+ERROR_SCRIPT_REVISION_NOT_FOUND = "404 script revision not found"
+ERROR_STAGE_DIRECTION_STYLE_NOT_FOUND = "404 stage direction style not found"
+
+# Cues
+ERROR_CUE_NOT_FOUND = "404 cue not found"
+ERROR_CUE_TYPE_NOT_FOUND = "404 cue type not found"
+
+# Microphones
+ERROR_MICROPHONE_NOT_FOUND = "404 microphone not found"
+
+# Tags
+ERROR_TAG_NOT_FOUND = "404 tag not found"
+
+# Stage: Props
+ERROR_PROP_NOT_FOUND = "404 prop not found"
+ERROR_PROPS_NOT_FOUND = "404 props not found"
+ERROR_PROP_TYPE_NOT_FOUND = "404 prop type not found"
+
+# Stage: Scenery
+ERROR_SCENERY_NOT_FOUND = "404 scenery not found"
+ERROR_SCENERY_TYPE_NOT_FOUND = "404 scenery type not found"
+
+# Allocations
+ERROR_ALLOCATION_NOT_FOUND = "404 allocation not found"
+
+
+# =============================================================================
+# HTTP 400 Validation Errors - Missing Required Fields
+# =============================================================================
+
+# Generic
+ERROR_ID_MISSING = "ID missing"
+ERROR_NAME_MISSING = "Name missing"
+ERROR_INVALID_ID = "Invalid ID"
+
+# People
+ERROR_FIRST_NAME_MISSING = "First name missing"
+ERROR_LAST_NAME_MISSING = "Last name missing"
+
+# Appearance
+ERROR_COLOUR_MISSING = "Colour missing"
+ERROR_DESCRIPTION_MISSING = "Description missing"
+
+# Acts/Scenes
+ERROR_ACT_ID_MISSING = "Act ID missing"
+ERROR_SCENE_ID_MISSING = "Scene ID missing"
+
+# Cues
+ERROR_PREFIX_MISSING = "Prefix missing"
+ERROR_CUE_TYPE_MISSING = "Cue Type missing"
+ERROR_CUE_ID_MISSING = "Cue ID missing"
+ERROR_IDENTIFIER_MISSING = "Identifier missing"
+ERROR_LINE_ID_MISSING = "Line ID missing"
+
+# Stage direction styles
+ERROR_TEXT_FORMAT_INVALID = "Text format missing or invalid"
+ERROR_TEXT_COLOUR_MISSING = "Text colour missing"
+ERROR_BACKGROUND_COLOUR_MISSING = "Background colour missing"
+
+# Tags
+ERROR_TAG_NAME_MISSING = "Tag name missing"
+
+# Props/Scenery
+ERROR_PROP_TYPE_ID_MISSING = "Prop type ID missing"
+ERROR_SCENERY_TYPE_ID_MISSING = "Scenery type ID missing"
+
+# Allocations
+ERROR_PROPS_ID_MISSING = "props_id missing"
+ERROR_SCENERY_ID_MISSING = "scenery_id missing"
+
+
+# =============================================================================
+# HTTP 400 Conflict/Business Rule Errors
+# =============================================================================
+
+ERROR_NAME_ALREADY_TAKEN = "Name already taken"
+ERROR_TAG_NAME_EXISTS = "Tag name already exists (case-insensitive)"

--- a/server/controllers/api/show/acts.py
+++ b/server/controllers/api/show/acts.py
@@ -3,6 +3,16 @@ from typing import List
 from sqlalchemy import select
 from tornado import escape
 
+from controllers.api.constants import (
+    ERROR_ACT_ID_MISSING,
+    ERROR_ACT_NOT_FOUND,
+    ERROR_ID_MISSING,
+    ERROR_INVALID_ID,
+    ERROR_NAME_MISSING,
+    ERROR_SCENE_ID_MISSING,
+    ERROR_SCENE_NOT_FOUND,
+    ERROR_SHOW_NOT_FOUND,
+)
 from models.show import Act, Scene, Show
 from rbac.role import Role
 from schemas.schemas import ActSchema
@@ -30,7 +40,7 @@ class ActController(BaseAPIController):
                 self.finish({"acts": acts})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -47,7 +57,7 @@ class ActController(BaseAPIController):
                 name: str = data.get("name", None)
                 if not name:
                     self.set_status(400)
-                    await self.finish({"message": "Name missing"})
+                    await self.finish({"message": ERROR_NAME_MISSING})
                     return
 
                 interval_after: bool = data.get("interval_after", None)
@@ -80,7 +90,7 @@ class ActController(BaseAPIController):
                 await self.application.ws_send_to_all("NOOP", "GET_ACT_LIST", {})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -97,7 +107,7 @@ class ActController(BaseAPIController):
                 act_id = data.get("id", None)
                 if not act_id:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 entry: Act = session.get(Act, act_id)
@@ -105,7 +115,7 @@ class ActController(BaseAPIController):
                     name = data.get("name", None)
                     if not name:
                         self.set_status(400)
-                        await self.finish({"message": "Name missing"})
+                        await self.finish({"message": ERROR_NAME_MISSING})
                         return
                     entry.name = name
 
@@ -159,11 +169,11 @@ class ActController(BaseAPIController):
                     await self.application.ws_send_to_all("NOOP", "GET_ACT_LIST", {})
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 act not found"})
+                    await self.finish({"message": ERROR_ACT_NOT_FOUND})
                     return
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -179,14 +189,14 @@ class ActController(BaseAPIController):
                 act_id_str = self.get_argument("id", None)
                 if not act_id_str:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 try:
                     act_id = int(act_id_str)
                 except ValueError:
                     self.set_status(400)
-                    await self.finish({"message": "Invalid ID"})
+                    await self.finish({"message": ERROR_INVALID_ID})
                     return
 
                 entry: Act = session.get(Act, act_id)
@@ -210,10 +220,10 @@ class ActController(BaseAPIController):
                     await self.application.ws_send_to_all("NOOP", "GET_ACT_LIST", {})
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 act not found"})
+                    await self.finish({"message": ERROR_ACT_NOT_FOUND})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
 
 @ApiRoute("show/act/first_scene", ApiVersion.V1)
@@ -233,12 +243,12 @@ class FirstSceneController(BaseAPIController):
                 act_id: int = data.get("act_id", None)
                 if not act_id:
                     self.set_status(400)
-                    await self.finish({"message": "Act ID missing"})
+                    await self.finish({"message": ERROR_ACT_ID_MISSING})
                     return
 
                 if "scene_id" not in data:
                     self.set_status(400)
-                    await self.finish({"message": "Scene ID missing"})
+                    await self.finish({"message": ERROR_SCENE_ID_MISSING})
                     return
 
                 scene_id: int = data.get("scene_id", None)
@@ -246,7 +256,7 @@ class FirstSceneController(BaseAPIController):
                     scene: Scene = session.get(Scene, scene_id)
                     if not scene:
                         self.set_status(404)
-                        await self.finish({"message": "404 scene not found"})
+                        await self.finish({"message": ERROR_SCENE_NOT_FOUND})
                         return
                     if scene.previous_scene_id:
                         self.set_status(400)
@@ -273,4 +283,4 @@ class FirstSceneController(BaseAPIController):
 
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})

--- a/server/controllers/api/show/cast.py
+++ b/server/controllers/api/show/cast.py
@@ -3,6 +3,14 @@ from collections import defaultdict
 from sqlalchemy import select
 from tornado import escape
 
+from controllers.api.constants import (
+    ERROR_CAST_MEMBER_NOT_FOUND,
+    ERROR_FIRST_NAME_MISSING,
+    ERROR_ID_MISSING,
+    ERROR_INVALID_ID,
+    ERROR_LAST_NAME_MISSING,
+    ERROR_SHOW_NOT_FOUND,
+)
 from models.script import Script, ScriptLine, ScriptLineType, ScriptRevision
 from models.show import Cast, Character, Show
 from rbac.role import Role
@@ -28,7 +36,7 @@ class CastController(BaseAPIController):
                 self.finish({"cast": cast})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -45,13 +53,13 @@ class CastController(BaseAPIController):
                 first_name = data.get("firstName", None)
                 if not first_name:
                     self.set_status(400)
-                    await self.finish({"message": "First name missing"})
+                    await self.finish({"message": ERROR_FIRST_NAME_MISSING})
                     return
 
                 last_name = data.get("lastName", None)
                 if not last_name:
                     self.set_status(400)
-                    await self.finish({"message": "Last name missing"})
+                    await self.finish({"message": ERROR_LAST_NAME_MISSING})
                     return
 
                 new_cast = Cast(
@@ -70,7 +78,7 @@ class CastController(BaseAPIController):
                 )
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -87,7 +95,7 @@ class CastController(BaseAPIController):
                 cast_id = data.get("id", None)
                 if not cast_id:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 entry: Cast = session.get(Cast, cast_id)
@@ -95,14 +103,14 @@ class CastController(BaseAPIController):
                     first_name = data.get("firstName", None)
                     if not first_name:
                         self.set_status(400)
-                        await self.finish({"message": "First name missing"})
+                        await self.finish({"message": ERROR_FIRST_NAME_MISSING})
                         return
                     entry.first_name = first_name
 
                     last_name = data.get("lastName", None)
                     if not last_name:
                         self.set_status(400)
-                        await self.finish({"message": "Last name missing"})
+                        await self.finish({"message": ERROR_LAST_NAME_MISSING})
                         return
                     entry.last_name = last_name
 
@@ -116,11 +124,11 @@ class CastController(BaseAPIController):
                     )
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 cast member not found"})
+                    await self.finish({"message": ERROR_CAST_MEMBER_NOT_FOUND})
                     return
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -136,14 +144,14 @@ class CastController(BaseAPIController):
                 cast_id_str = self.get_argument("id", None)
                 if not cast_id_str:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 try:
                     cast_id = int(cast_id_str)
                 except ValueError:
                     self.set_status(400)
-                    await self.finish({"message": "Invalid ID"})
+                    await self.finish({"message": ERROR_INVALID_ID})
                     return
 
                 entry = session.get(Cast, cast_id)
@@ -159,10 +167,10 @@ class CastController(BaseAPIController):
                     )
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 cast member not found"})
+                    await self.finish({"message": ERROR_CAST_MEMBER_NOT_FOUND})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
 
 @ApiRoute("show/cast/stats", ApiVersion.V1)
@@ -214,4 +222,4 @@ class CastStatsController(BaseAPIController):
                 await self.finish({"line_counts": line_counts})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})

--- a/server/controllers/api/show/characters.py
+++ b/server/controllers/api/show/characters.py
@@ -3,6 +3,15 @@ from collections import defaultdict
 from sqlalchemy import select
 from tornado import escape
 
+from controllers.api.constants import (
+    ERROR_CAST_MEMBER_NOT_FOUND,
+    ERROR_CHARACTER_GROUP_NOT_FOUND,
+    ERROR_CHARACTER_NOT_FOUND,
+    ERROR_ID_MISSING,
+    ERROR_INVALID_ID,
+    ERROR_NAME_MISSING,
+    ERROR_SHOW_NOT_FOUND,
+)
 from models.script import Script, ScriptLine, ScriptLineType, ScriptRevision
 from models.show import Cast, Character, CharacterGroup, Show
 from rbac.role import Role
@@ -28,7 +37,7 @@ class CharacterController(BaseAPIController):
                 self.finish({"characters": characters})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -45,7 +54,7 @@ class CharacterController(BaseAPIController):
                 name = data.get("name", None)
                 if not name:
                     self.set_status(400)
-                    await self.finish({"message": "Name missing"})
+                    await self.finish({"message": ERROR_NAME_MISSING})
                     return
 
                 description = data.get("description", None)
@@ -54,7 +63,7 @@ class CharacterController(BaseAPIController):
                     cast_member = session.get(Cast, played_by)
                     if not cast_member:
                         self.set_status(404)
-                        await self.finish({"message": "404 cast member found"})
+                        await self.finish({"message": ERROR_CAST_MEMBER_NOT_FOUND})
                         return
 
                 new_character = Character(
@@ -77,7 +86,7 @@ class CharacterController(BaseAPIController):
                 await self.application.ws_send_to_all("NOOP", "GET_CHARACTER_LIST", {})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -94,7 +103,7 @@ class CharacterController(BaseAPIController):
                 character_id = data.get("id", None)
                 if not character_id:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 entry: Character = session.get(Character, character_id)
@@ -102,7 +111,7 @@ class CharacterController(BaseAPIController):
                     name = data.get("name", None)
                     if not name:
                         self.set_status(400)
-                        await self.finish({"message": "Name missing"})
+                        await self.finish({"message": ERROR_NAME_MISSING})
                         return
                     entry.name = name
 
@@ -114,7 +123,7 @@ class CharacterController(BaseAPIController):
                         cast_member = session.get(Cast, played_by)
                         if not cast_member:
                             self.set_status(404)
-                            await self.finish({"message": "404 cast member found"})
+                            await self.finish({"message": ERROR_CAST_MEMBER_NOT_FOUND})
                             return
                     entry.played_by = played_by
 
@@ -128,11 +137,11 @@ class CharacterController(BaseAPIController):
                     )
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 character not found"})
+                    await self.finish({"message": ERROR_CHARACTER_NOT_FOUND})
                     return
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -148,14 +157,14 @@ class CharacterController(BaseAPIController):
                 character_id_str = self.get_argument("id", None)
                 if not character_id_str:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 try:
                     character_id = int(character_id_str)
                 except ValueError:
                     self.set_status(400)
-                    await self.finish({"message": "Invalid ID"})
+                    await self.finish({"message": ERROR_INVALID_ID})
                     return
 
                 entry: Character = session.get(Character, character_id)
@@ -171,10 +180,10 @@ class CharacterController(BaseAPIController):
                     )
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 character not found"})
+                    await self.finish({"message": ERROR_CHARACTER_NOT_FOUND})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
 
 @ApiRoute("show/character/stats", ApiVersion.V1)
@@ -223,7 +232,7 @@ class CharacterStatsController(BaseAPIController):
                 await self.finish({"line_counts": line_counts})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
 
 @ApiRoute("show/character/group", ApiVersion.V1)
@@ -244,7 +253,7 @@ class CharacterGroupController(BaseAPIController):
                 self.finish({"character_groups": character_groups})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -261,7 +270,7 @@ class CharacterGroupController(BaseAPIController):
                 name = data.get("name", None)
                 if not name:
                     self.set_status(400)
-                    await self.finish({"message": "Name missing"})
+                    await self.finish({"message": ERROR_NAME_MISSING})
                     return
 
                 description = data.get("description", None)
@@ -297,7 +306,7 @@ class CharacterGroupController(BaseAPIController):
 
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -313,14 +322,14 @@ class CharacterGroupController(BaseAPIController):
                 character_group_id_str = self.get_argument("id", None)
                 if not character_group_id_str:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 try:
                     character_group_id = int(character_group_id_str)
                 except ValueError:
                     self.set_status(400)
-                    await self.finish({"message": "Invalid ID"})
+                    await self.finish({"message": ERROR_INVALID_ID})
                     return
 
                 entry: CharacterGroup = session.get(CharacterGroup, character_group_id)
@@ -338,10 +347,10 @@ class CharacterGroupController(BaseAPIController):
                     )
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 character not found"})
+                    await self.finish({"message": ERROR_CHARACTER_NOT_FOUND})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -358,7 +367,7 @@ class CharacterGroupController(BaseAPIController):
                 character_group_id = data.get("id", None)
                 if not character_group_id:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 entry: CharacterGroup = session.get(CharacterGroup, character_group_id)
@@ -366,7 +375,7 @@ class CharacterGroupController(BaseAPIController):
                     name = data.get("name", None)
                     if not name:
                         self.set_status(400)
-                        await self.finish({"message": "Name missing"})
+                        await self.finish({"message": ERROR_NAME_MISSING})
                         return
                     entry.name = name
 
@@ -397,8 +406,8 @@ class CharacterGroupController(BaseAPIController):
                     )
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 character group not found"})
+                    await self.finish({"message": ERROR_CHARACTER_GROUP_NOT_FOUND})
                     return
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})

--- a/server/controllers/api/show/cues.py
+++ b/server/controllers/api/show/cues.py
@@ -5,6 +5,19 @@ from typing import List
 from sqlalchemy import func, select
 from tornado import escape
 
+from controllers.api.constants import (
+    ERROR_COLOUR_MISSING,
+    ERROR_CUE_ID_MISSING,
+    ERROR_CUE_NOT_FOUND,
+    ERROR_CUE_TYPE_MISSING,
+    ERROR_CUE_TYPE_NOT_FOUND,
+    ERROR_ID_MISSING,
+    ERROR_IDENTIFIER_MISSING,
+    ERROR_INVALID_ID,
+    ERROR_LINE_ID_MISSING,
+    ERROR_PREFIX_MISSING,
+    ERROR_SHOW_NOT_FOUND,
+)
 from models.cue import Cue, CueAssociation, CueType
 from models.script import Script, ScriptLine, ScriptLineType, ScriptRevision
 from models.show import Show
@@ -31,7 +44,7 @@ class CueTypesController(BaseAPIController):
                 self.finish({"cue_types": cue_types})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -48,7 +61,7 @@ class CueTypesController(BaseAPIController):
                 prefix: str = data.get("prefix", None)
                 if not prefix:
                     self.set_status(400)
-                    await self.finish({"message": "Prefix missing"})
+                    await self.finish({"message": ERROR_PREFIX_MISSING})
                     return
 
                 description: str = data.get("description", None)
@@ -56,7 +69,7 @@ class CueTypesController(BaseAPIController):
                 colour: str = data.get("colour", None)
                 if not colour:
                     self.set_status(400)
-                    await self.finish({"message": "Colour missing"})
+                    await self.finish({"message": ERROR_COLOUR_MISSING})
                     return
 
                 new_cuetype = CueType(
@@ -76,7 +89,7 @@ class CueTypesController(BaseAPIController):
                 await self.application.ws_send_to_all("NOOP", "GET_CUE_TYPES", {})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -93,19 +106,19 @@ class CueTypesController(BaseAPIController):
                 cue_type_id = data.get("id", None)
                 if not cue_type_id:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 cue_type: CueType = session.get(CueType, cue_type_id)
                 if not cue_type:
                     self.set_status(404)
-                    await self.finish({"message": "404 cue type not found"})
+                    await self.finish({"message": ERROR_CUE_TYPE_NOT_FOUND})
                     return
 
                 prefix: str = data.get("prefix", None)
                 if not prefix:
                     self.set_status(400)
-                    await self.finish({"message": "Prefix missing"})
+                    await self.finish({"message": ERROR_PREFIX_MISSING})
                     return
 
                 description: str = data.get("description", None)
@@ -113,7 +126,7 @@ class CueTypesController(BaseAPIController):
                 colour: str = data.get("colour", None)
                 if not colour:
                     self.set_status(400)
-                    await self.finish({"message": "Colour missing"})
+                    await self.finish({"message": ERROR_COLOUR_MISSING})
                     return
 
                 cue_type.prefix = prefix
@@ -127,7 +140,7 @@ class CueTypesController(BaseAPIController):
                 await self.application.ws_send_to_all("NOOP", "GET_CUE_TYPES", {})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -143,14 +156,14 @@ class CueTypesController(BaseAPIController):
                 cue_type_id_str = self.get_argument("id", None)
                 if not cue_type_id_str:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 try:
                     cue_type_id = int(cue_type_id_str)
                 except ValueError:
                     self.set_status(400)
-                    await self.finish({"message": "Invalid ID"})
+                    await self.finish({"message": ERROR_INVALID_ID})
                     return
 
                 entry: CueType = session.get(CueType, cue_type_id)
@@ -164,10 +177,10 @@ class CueTypesController(BaseAPIController):
                     await self.application.ws_send_to_all("NOOP", "GET_CUE_TYPES", {})
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 cue type not found"})
+                    await self.finish({"message": ERROR_CUE_TYPE_NOT_FOUND})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
 
 @ApiRoute("show/cues", ApiVersion.V1)
@@ -208,7 +221,7 @@ class CueController(BaseAPIController):
                 self.finish({"cues": cues})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     async def post(self):
@@ -238,7 +251,7 @@ class CueController(BaseAPIController):
                 cue_type_id: int = data.get("cueType", None)
                 if not cue_type_id:
                     self.set_status(400)
-                    await self.finish({"message": "Cue Type missing"})
+                    await self.finish({"message": ERROR_CUE_TYPE_MISSING})
                     return
 
                 cue_type = session.get(CueType, cue_type_id)
@@ -253,13 +266,13 @@ class CueController(BaseAPIController):
                 ident: str = data.get("ident", None)
                 if not ident:
                     self.set_status(400)
-                    await self.finish({"message": "Identifier missing"})
+                    await self.finish({"message": ERROR_IDENTIFIER_MISSING})
                     return
 
                 line_id: int = data.get("lineId", None)
                 if not line_id:
                     self.set_status(400)
-                    await self.finish({"message": "Line ID missing"})
+                    await self.finish({"message": ERROR_LINE_ID_MISSING})
                     return
 
                 line: ScriptLine = session.get(ScriptLine, line_id)
@@ -290,7 +303,7 @@ class CueController(BaseAPIController):
 
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -321,13 +334,13 @@ class CueController(BaseAPIController):
                 cue_id: int = data.get("cueId")
                 if not cue_id:
                     self.set_status(400)
-                    await self.finish({"message": "Cue ID missing"})
+                    await self.finish({"message": ERROR_CUE_ID_MISSING})
                     return
 
                 cue_type_id: int = data.get("cueType", None)
                 if not cue_type_id:
                     self.set_status(400)
-                    await self.finish({"message": "Cue Type missing"})
+                    await self.finish({"message": ERROR_CUE_TYPE_MISSING})
                     return
 
                 cue_type = session.get(CueType, cue_type_id)
@@ -342,19 +355,19 @@ class CueController(BaseAPIController):
                 ident: str = data.get("ident", None)
                 if not ident:
                     self.set_status(400)
-                    await self.finish({"message": "Identifier missing"})
+                    await self.finish({"message": ERROR_IDENTIFIER_MISSING})
                     return
 
                 line_id: int = data.get("lineId", None)
                 if not line_id:
                     self.set_status(400)
-                    await self.finish({"message": "Line ID missing"})
+                    await self.finish({"message": ERROR_LINE_ID_MISSING})
                     return
 
                 cue: Cue = session.get(Cue, cue_id)
                 if not cue:
                     self.set_status(404)
-                    await self.finish({"message": "404 cue not found"})
+                    await self.finish({"message": ERROR_CUE_NOT_FOUND})
                     return
 
                 current_association: CueAssociation = session.get(
@@ -394,7 +407,7 @@ class CueController(BaseAPIController):
 
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -423,7 +436,7 @@ class CueController(BaseAPIController):
                 cue_id_str = self.get_argument("cueId", None)
                 if not cue_id_str:
                     self.set_status(400)
-                    await self.finish({"message": "Cue ID missing"})
+                    await self.finish({"message": ERROR_CUE_ID_MISSING})
                     return
 
                 try:
@@ -440,7 +453,7 @@ class CueController(BaseAPIController):
                 line_id_str = self.get_argument("lineId", None)
                 if not line_id_str:
                     self.set_status(400)
-                    await self.finish({"message": "Line ID missing"})
+                    await self.finish({"message": ERROR_LINE_ID_MISSING})
                     return
 
                 try:
@@ -470,7 +483,7 @@ class CueController(BaseAPIController):
                     return
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
 
 @ApiRoute("show/cues/stats", ApiVersion.V1)
@@ -512,7 +525,7 @@ class CueStatsController(BaseAPIController):
                 await self.finish({"cue_counts": cue_counts})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
 
 @ApiRoute("show/cues/search", ApiVersion.V1)
@@ -547,7 +560,7 @@ class CueSearchController(BaseAPIController):
             show: Show = session.get(Show, show_id)
             if not show:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
 
             script: Script = session.scalars(

--- a/server/controllers/api/show/microphones.py
+++ b/server/controllers/api/show/microphones.py
@@ -4,6 +4,16 @@ from typing import Dict, List, Tuple
 from sqlalchemy import select
 from tornado import escape
 
+from controllers.api.constants import (
+    ERROR_CHARACTER_NOT_FOUND,
+    ERROR_ID_MISSING,
+    ERROR_INVALID_ID,
+    ERROR_MICROPHONE_NOT_FOUND,
+    ERROR_NAME_ALREADY_TAKEN,
+    ERROR_NAME_MISSING,
+    ERROR_SCENE_NOT_FOUND,
+    ERROR_SHOW_NOT_FOUND,
+)
 from models.mics import Microphone, MicrophoneAllocation
 from models.script import Script, ScriptRevision
 from models.show import Act, Character, Scene, Show
@@ -38,7 +48,7 @@ class MicrophoneController(BaseAPIController):
                 self.finish({"microphones": mics})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -55,7 +65,7 @@ class MicrophoneController(BaseAPIController):
                 name: str = data.get("name", None)
                 if not name:
                     self.set_status(400)
-                    await self.finish({"message": "Name missing"})
+                    await self.finish({"message": ERROR_NAME_MISSING})
                     return
 
                 other_named = session.scalars(
@@ -65,7 +75,7 @@ class MicrophoneController(BaseAPIController):
                 ).first()
                 if other_named:
                     self.set_status(400)
-                    await self.finish({"message": "Name already taken"})
+                    await self.finish({"message": ERROR_NAME_ALREADY_TAKEN})
                     return
 
                 description: str = data.get("description", None)
@@ -87,7 +97,7 @@ class MicrophoneController(BaseAPIController):
                 await self.application.ws_send_to_all("NOOP", "GET_MICROPHONE_LIST", {})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -104,19 +114,19 @@ class MicrophoneController(BaseAPIController):
                 microphone_id = data.get("id", None)
                 if not microphone_id:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 microphone: Microphone = session.get(Microphone, microphone_id)
                 if not microphone:
                     self.set_status(404)
-                    await self.finish({"message": "404 microphone not found"})
+                    await self.finish({"message": ERROR_MICROPHONE_NOT_FOUND})
                     return
 
                 name: str = data.get("name", None)
                 if not name:
                     self.set_status(400)
-                    await self.finish({"message": "Name missing"})
+                    await self.finish({"message": ERROR_NAME_MISSING})
                     return
 
                 other_named = session.scalars(
@@ -128,7 +138,7 @@ class MicrophoneController(BaseAPIController):
                 ).first()
                 if other_named:
                     self.set_status(400)
-                    await self.finish({"message": "Name already taken"})
+                    await self.finish({"message": ERROR_NAME_ALREADY_TAKEN})
                     return
 
                 description: str = data.get("description", None)
@@ -143,7 +153,7 @@ class MicrophoneController(BaseAPIController):
                 await self.application.ws_send_to_all("NOOP", "GET_MICROPHONE_LIST", {})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -159,14 +169,14 @@ class MicrophoneController(BaseAPIController):
                 microphone_id_str = self.get_argument("id", None)
                 if not microphone_id_str:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 try:
                     microphone_id = int(microphone_id_str)
                 except ValueError:
                     self.set_status(400)
-                    await self.finish({"message": "Invalid ID"})
+                    await self.finish({"message": ERROR_INVALID_ID})
                     return
 
                 entry: Microphone = session.get(Microphone, microphone_id)
@@ -182,10 +192,10 @@ class MicrophoneController(BaseAPIController):
                     )
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 microphone not found"})
+                    await self.finish({"message": ERROR_MICROPHONE_NOT_FOUND})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 microphone not found"})
+                await self.finish({"message": ERROR_MICROPHONE_NOT_FOUND})
 
 
 @ApiRoute("show/microphones/allocations", ApiVersion.V1)
@@ -213,7 +223,7 @@ class MicrophoneAllocationsController(BaseAPIController):
                 self.finish({"allocations": allocations})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -231,14 +241,14 @@ class MicrophoneAllocationsController(BaseAPIController):
                     mic = session.get(Microphone, microphone_id)
                     if not mic:
                         self.set_status(404)
-                        await self.finish({"message": "404 microphone not found"})
+                        await self.finish({"message": ERROR_MICROPHONE_NOT_FOUND})
                         return
 
                     for scene_id in data[microphone_id]:
                         scene = session.get(Scene, scene_id)
                         if not scene:
                             self.set_status(404)
-                            await self.finish({"message": "404 scene not found"})
+                            await self.finish({"message": ERROR_SCENE_NOT_FOUND})
                             return
 
                         existing_allocation: MicrophoneAllocation = session.scalars(
@@ -254,7 +264,7 @@ class MicrophoneAllocationsController(BaseAPIController):
                             if not character:
                                 self.set_status(404)
                                 await self.finish(
-                                    {"message": "404 character not found"}
+                                    {"message": ERROR_CHARACTER_NOT_FOUND}
                                 )
                                 return
 
@@ -275,7 +285,7 @@ class MicrophoneAllocationsController(BaseAPIController):
                 await self.application.ws_send_to_all("NOOP", "GET_MIC_ALLOCATIONS", {})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
 
 @ApiRoute("show/microphones/suggest", ApiVersion.V1)
@@ -579,4 +589,4 @@ class MicrophoneAutoAssignmentController(BaseAPIController):
 
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})

--- a/server/controllers/api/show/scenes.py
+++ b/server/controllers/api/show/scenes.py
@@ -3,6 +3,14 @@ from typing import List
 from sqlalchemy import select
 from tornado import escape
 
+from controllers.api.constants import (
+    ERROR_ACT_ID_MISSING,
+    ERROR_ID_MISSING,
+    ERROR_INVALID_ID,
+    ERROR_NAME_MISSING,
+    ERROR_SCENE_NOT_FOUND,
+    ERROR_SHOW_NOT_FOUND,
+)
 from models.show import Scene, Show
 from rbac.role import Role
 from schemas.schemas import SceneSchema
@@ -30,7 +38,7 @@ class SceneController(BaseAPIController):
                 self.finish({"scenes": scenes})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -47,13 +55,13 @@ class SceneController(BaseAPIController):
                 act_id: int = data.get("act_id", None)
                 if not act_id:
                     self.set_status(400)
-                    await self.finish({"message": "Act ID missing"})
+                    await self.finish({"message": ERROR_ACT_ID_MISSING})
                     return
 
                 name: str = data.get("name", None)
                 if not name:
                     self.set_status(400)
-                    await self.finish({"message": "Name missing"})
+                    await self.finish({"message": ERROR_NAME_MISSING})
                     return
 
                 previous_scene_id = data.get("previous_scene_id", None)
@@ -97,7 +105,7 @@ class SceneController(BaseAPIController):
 
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -113,14 +121,14 @@ class SceneController(BaseAPIController):
                 scene_id_str = self.get_argument("id", None)
                 if not scene_id_str:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 try:
                     scene_id = int(scene_id_str)
                 except ValueError:
                     self.set_status(400)
-                    await self.finish({"message": "Invalid ID"})
+                    await self.finish({"message": ERROR_INVALID_ID})
                     return
 
                 entry: Scene = session.get(Scene, scene_id)
@@ -144,10 +152,10 @@ class SceneController(BaseAPIController):
                     await self.application.ws_send_to_all("NOOP", "GET_SCENE_LIST", {})
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 scene not found"})
+                    await self.finish({"message": ERROR_SCENE_NOT_FOUND})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -164,7 +172,7 @@ class SceneController(BaseAPIController):
                 scene_id = data.get("scene_id", None)
                 if not scene_id:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 entry: Scene = session.get(Scene, scene_id)
@@ -172,13 +180,13 @@ class SceneController(BaseAPIController):
                     act_id: int = data.get("act_id", None)
                     if not act_id:
                         self.set_status(400)
-                        await self.finish({"message": "Act ID missing"})
+                        await self.finish({"message": ERROR_ACT_ID_MISSING})
                         return
 
                     name: str = data.get("name", None)
                     if not name:
                         self.set_status(400)
-                        await self.finish({"message": "Name missing"})
+                        await self.finish({"message": ERROR_NAME_MISSING})
                         return
 
                     previous_scene_id = data.get("previous_scene_id", None)
@@ -235,7 +243,7 @@ class SceneController(BaseAPIController):
                     await self.application.ws_send_to_all("NOOP", "GET_SCENE_LIST", {})
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 scene not found"})
+                    await self.finish({"message": ERROR_SCENE_NOT_FOUND})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})

--- a/server/controllers/api/show/script/compiled.py
+++ b/server/controllers/api/show/script/compiled.py
@@ -4,6 +4,10 @@ from typing import Optional
 from sqlalchemy import select
 from tornado import escape
 
+from controllers.api.constants import (
+    ERROR_SCRIPT_REVISION_NOT_FOUND,
+    ERROR_SHOW_NOT_FOUND,
+)
 from digi_server.logger import get_logger
 from models.script import CompiledScript, Script, ScriptRevision
 from models.show import Show
@@ -26,7 +30,7 @@ class CompiledScriptsController(BaseAPIController):
             show = session.get(Show, show_id)
             if not show:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
 
             stmt = (
@@ -53,7 +57,7 @@ class CompiledScriptsController(BaseAPIController):
             show = session.get(Show, show_id)
             if not show:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
             self.requires_role(show, Role.WRITE)
 
@@ -67,7 +71,7 @@ class CompiledScriptsController(BaseAPIController):
             revision = session.get(ScriptRevision, revision_id)
             if not revision or revision.script.show_id != show_id:
                 self.set_status(404)
-                await self.finish({"message": "404 script revision not found"})
+                await self.finish({"message": ERROR_SCRIPT_REVISION_NOT_FOUND})
                 return
 
             await CompiledScript.compile_script(self.application, revision.id)
@@ -83,7 +87,7 @@ class CompiledScriptsController(BaseAPIController):
             show = session.get(Show, show_id)
             if not show:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
             self.requires_role(show, Role.WRITE)
 
@@ -101,7 +105,7 @@ class CompiledScriptsController(BaseAPIController):
             revision = session.get(ScriptRevision, revision_id)
             if not revision or revision.script.show_id != show_id:
                 self.set_status(404)
-                await self.finish({"message": "404 script revision not found"})
+                await self.finish({"message": ERROR_SCRIPT_REVISION_NOT_FOUND})
                 return
 
             compiled_script: Optional[CompiledScript] = session.scalars(

--- a/server/controllers/api/show/script/revisions.py
+++ b/server/controllers/api/show/script/revisions.py
@@ -5,6 +5,12 @@ from sqlalchemy import func, select
 from tornado import escape
 from tornado.web import MissingArgumentError
 
+from controllers.api.constants import (
+    ERROR_DESCRIPTION_MISSING,
+    ERROR_SCRIPT_NOT_FOUND,
+    ERROR_SCRIPT_REVISION_NOT_FOUND,
+    ERROR_SHOW_NOT_FOUND,
+)
 from digi_server.logger import get_logger
 from models.cue import CueAssociation
 from models.script import (
@@ -48,10 +54,10 @@ class ScriptRevisionsController(BaseAPIController):
                     )
                 else:
                     self.set_status(404)
-                    self.finish({"message": "404 script not found"})
+                    self.finish({"message": ERROR_SCRIPT_NOT_FOUND})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -69,7 +75,7 @@ class ScriptRevisionsController(BaseAPIController):
                 ).first()
                 if not script:
                     self.set_status(404)
-                    await self.finish({"message": "404 script not found"})
+                    await self.finish({"message": ERROR_SCRIPT_NOT_FOUND})
                     return
                 self.requires_role(script, Role.WRITE)
 
@@ -80,7 +86,7 @@ class ScriptRevisionsController(BaseAPIController):
 
                 if not parent_rev_id:
                     self.set_status(404)
-                    await self.finish({"message": "404 script revision not found"})
+                    await self.finish({"message": ERROR_SCRIPT_REVISION_NOT_FOUND})
                     return
 
                 # Get set_as_current flag (defaults to True for backward compatibility)
@@ -110,7 +116,7 @@ class ScriptRevisionsController(BaseAPIController):
                 description: str = data.get("description", None)
                 if not description:
                     self.set_status(400)
-                    await self.finish({"message": "Description missing"})
+                    await self.finish({"message": ERROR_DESCRIPTION_MISSING})
                     return
 
                 now_time = datetime.now(UTC)
@@ -169,7 +175,7 @@ class ScriptRevisionsController(BaseAPIController):
                 )
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -185,7 +191,7 @@ class ScriptRevisionsController(BaseAPIController):
                 ).first()
                 if not script:
                     self.set_status(404)
-                    await self.finish({"message": "404 script not found"})
+                    await self.finish({"message": ERROR_SCRIPT_NOT_FOUND})
                     return
                 self.requires_role(script, Role.WRITE)
 
@@ -265,7 +271,7 @@ class ScriptRevisionsController(BaseAPIController):
                     )
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
 
 @ApiRoute("show/script/revisions/current", ApiVersion.V1)
@@ -291,10 +297,10 @@ class ScriptCurrentRevisionController(BaseAPIController):
                     )
                 else:
                     self.set_status(404)
-                    self.finish({"message": "404 script not found"})
+                    self.finish({"message": ERROR_SCRIPT_NOT_FOUND})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -313,7 +319,7 @@ class ScriptCurrentRevisionController(BaseAPIController):
                 ).first()
                 if not script:
                     self.set_status(404)
-                    await self.finish({"message": "404 script not found"})
+                    await self.finish({"message": ERROR_SCRIPT_NOT_FOUND})
                     return
 
                 new_rev_id: int = data.get("new_rev_id", None)
@@ -358,4 +364,4 @@ class ScriptCurrentRevisionController(BaseAPIController):
                 )
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})

--- a/server/controllers/api/show/script/script.py
+++ b/server/controllers/api/show/script/script.py
@@ -6,6 +6,7 @@ from sqlalchemy import func, select
 from tornado import escape
 from tornado.ioloop import IOLoop
 
+from controllers.api.constants import ERROR_SHOW_NOT_FOUND
 from models.cue import CueAssociation
 from models.script import (
     CompiledScript,
@@ -98,7 +99,7 @@ class ScriptController(BaseAPIController):
                 self.finish({"lines": lines, "page": page})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
 
     @staticmethod
@@ -270,7 +271,7 @@ class ScriptController(BaseAPIController):
                 )
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
 
     @staticmethod
@@ -671,7 +672,7 @@ class ScriptController(BaseAPIController):
                 )
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
 
 
@@ -707,7 +708,7 @@ class CompiledScriptController(BaseAPIController):
                 self.finish(compiled_script)
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
 
 
@@ -743,7 +744,7 @@ class ScriptCutsController(BaseAPIController):
                 self.finish({"cuts": line_cuts})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
 
     @requires_show
@@ -845,5 +846,5 @@ class ScriptMaxPageController(BaseAPIController):
                 self.finish({"max_page": max_page})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return

--- a/server/controllers/api/show/script/stage_direction_styles.py
+++ b/server/controllers/api/show/script/stage_direction_styles.py
@@ -19,6 +19,40 @@ from utils.web.route import ApiRoute, ApiVersion
 from utils.web.web_decorators import no_live_session, requires_show
 
 
+VALID_TEXT_FORMATS = ("default", "upper", "lower")
+
+
+def validate_style_fields(data):
+    """
+    Validate stage direction style fields from request data.
+
+    :param data: Request data dictionary
+    :returns: Tuple of (error_message, validated_fields) - error_message is None if valid
+    """
+    text_format = data.get("textFormat", None)
+    if not text_format or text_format not in VALID_TEXT_FORMATS:
+        return ERROR_TEXT_FORMAT_INVALID, None
+
+    text_colour = data.get("textColour", None)
+    if not text_colour:
+        return ERROR_TEXT_COLOUR_MISSING, None
+
+    enable_background_colour = data.get("enableBackgroundColour", False)
+    background_colour = data.get("backgroundColour", None)
+    if enable_background_colour and not background_colour:
+        return ERROR_BACKGROUND_COLOUR_MISSING, None
+
+    return None, {
+        "bold": data.get("bold", False),
+        "italic": data.get("italic", False),
+        "underline": data.get("underline", False),
+        "text_format": text_format,
+        "text_colour": text_colour,
+        "enable_background_colour": enable_background_colour,
+        "background_colour": background_colour,
+    }
+
+
 @ApiRoute("/show/script/stage_direction_styles", ApiVersion.V1)
 class StageDirectionStylesController(BaseAPIController):
     @requires_show
@@ -66,41 +100,16 @@ class StageDirectionStylesController(BaseAPIController):
                     await self.finish({"message": ERROR_DESCRIPTION_MISSING})
                     return
 
-                bold: bool = data.get("bold", False)
-                italic: bool = data.get("italic", False)
-                underline: bool = data.get("underline", False)
-
-                text_format: str = data.get("textFormat", None)
-                if not text_format or text_format not in ["default", "upper", "lower"]:
+                error, fields = validate_style_fields(data)
+                if error:
                     self.set_status(400)
-                    await self.finish({"message": ERROR_TEXT_FORMAT_INVALID})
-                    return
-
-                text_colour: str = data.get("textColour", None)
-                if not text_colour:
-                    self.set_status(400)
-                    await self.finish({"message": ERROR_TEXT_COLOUR_MISSING})
-                    return
-
-                enable_background_colour: bool = data.get(
-                    "enableBackgroundColour", False
-                )
-                background_colour: str = data.get("backgroundColour", None)
-                if enable_background_colour and not background_colour:
-                    self.set_status(400)
-                    await self.finish({"message": ERROR_BACKGROUND_COLOUR_MISSING})
+                    await self.finish({"message": error})
                     return
 
                 new_style = StageDirectionStyle(
                     script_id=script.id,
                     description=description,
-                    bold=bold,
-                    italic=italic,
-                    underline=underline,
-                    text_format=text_format,
-                    text_colour=text_colour,
-                    enable_background_colour=enable_background_colour,
-                    background_colour=background_colour,
+                    **fields,
                 )
                 session.add(new_style)
                 session.commit()
@@ -155,39 +164,15 @@ class StageDirectionStylesController(BaseAPIController):
                     await self.finish({"message": ERROR_DESCRIPTION_MISSING})
                     return
 
-                bold: bool = data.get("bold", False)
-                italic: bool = data.get("italic", False)
-                underline: bool = data.get("underline", False)
-
-                text_format: str = data.get("textFormat", None)
-                if not text_format or text_format not in ["default", "upper", "lower"]:
+                error, fields = validate_style_fields(data)
+                if error:
                     self.set_status(400)
-                    await self.finish({"message": ERROR_TEXT_FORMAT_INVALID})
-                    return
-
-                text_colour: str = data.get("textColour", None)
-                if not text_colour:
-                    self.set_status(400)
-                    await self.finish({"message": ERROR_TEXT_COLOUR_MISSING})
-                    return
-
-                enable_background_colour: bool = data.get(
-                    "enableBackgroundColour", False
-                )
-                background_colour: str = data.get("backgroundColour", None)
-                if enable_background_colour and not background_colour:
-                    self.set_status(400)
-                    await self.finish({"message": ERROR_BACKGROUND_COLOUR_MISSING})
+                    await self.finish({"message": error})
                     return
 
                 style.description = description
-                style.bold = bold
-                style.italic = italic
-                style.underline = underline
-                style.text_format = text_format
-                style.text_colour = text_colour
-                style.enable_background_colour = enable_background_colour
-                style.background_colour = background_colour
+                for key, value in fields.items():
+                    setattr(style, key, value)
                 session.commit()
 
                 self.set_status(200)

--- a/server/controllers/api/show/script/stage_direction_styles.py
+++ b/server/controllers/api/show/script/stage_direction_styles.py
@@ -1,6 +1,15 @@
 from sqlalchemy import select
 from tornado import escape
 
+from controllers.api.constants import (
+    ERROR_BACKGROUND_COLOUR_MISSING,
+    ERROR_DESCRIPTION_MISSING,
+    ERROR_ID_MISSING,
+    ERROR_SHOW_NOT_FOUND,
+    ERROR_STAGE_DIRECTION_STYLE_NOT_FOUND,
+    ERROR_TEXT_COLOUR_MISSING,
+    ERROR_TEXT_FORMAT_INVALID,
+)
 from models.script import Script, StageDirectionStyle
 from models.show import Show
 from rbac.role import Role
@@ -33,7 +42,7 @@ class StageDirectionStylesController(BaseAPIController):
                 self.finish({"styles": stage_direction_styles})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
 
     @requires_show
@@ -54,7 +63,7 @@ class StageDirectionStylesController(BaseAPIController):
                 description: str = data.get("description", None)
                 if not description:
                     self.set_status(400)
-                    await self.finish({"message": "Description missing"})
+                    await self.finish({"message": ERROR_DESCRIPTION_MISSING})
                     return
 
                 bold: bool = data.get("bold", False)
@@ -64,13 +73,13 @@ class StageDirectionStylesController(BaseAPIController):
                 text_format: str = data.get("textFormat", None)
                 if not text_format or text_format not in ["default", "upper", "lower"]:
                     self.set_status(400)
-                    await self.finish({"message": "Text format missing or invalid"})
+                    await self.finish({"message": ERROR_TEXT_FORMAT_INVALID})
                     return
 
                 text_colour: str = data.get("textColour", None)
                 if not text_colour:
                     self.set_status(400)
-                    await self.finish({"message": "Text colour missing"})
+                    await self.finish({"message": ERROR_TEXT_COLOUR_MISSING})
                     return
 
                 enable_background_colour: bool = data.get(
@@ -79,7 +88,7 @@ class StageDirectionStylesController(BaseAPIController):
                 background_colour: str = data.get("backgroundColour", None)
                 if enable_background_colour and not background_colour:
                     self.set_status(400)
-                    await self.finish({"message": "Background colour missing"})
+                    await self.finish({"message": ERROR_BACKGROUND_COLOUR_MISSING})
                     return
 
                 new_style = StageDirectionStyle(
@@ -109,7 +118,7 @@ class StageDirectionStylesController(BaseAPIController):
                 )
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -129,21 +138,21 @@ class StageDirectionStylesController(BaseAPIController):
                 style_id = data.get("id", None)
                 if not style_id:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 style: StageDirectionStyle = session.get(StageDirectionStyle, style_id)
                 if not style:
                     self.set_status(404)
                     await self.finish(
-                        {"message": "404 stage direction style not found"}
+                        {"message": ERROR_STAGE_DIRECTION_STYLE_NOT_FOUND}
                     )
                     return
 
                 description: str = data.get("description", None)
                 if not description:
                     self.set_status(400)
-                    await self.finish({"message": "Description missing"})
+                    await self.finish({"message": ERROR_DESCRIPTION_MISSING})
                     return
 
                 bold: bool = data.get("bold", False)
@@ -153,13 +162,13 @@ class StageDirectionStylesController(BaseAPIController):
                 text_format: str = data.get("textFormat", None)
                 if not text_format or text_format not in ["default", "upper", "lower"]:
                     self.set_status(400)
-                    await self.finish({"message": "Text format missing or invalid"})
+                    await self.finish({"message": ERROR_TEXT_FORMAT_INVALID})
                     return
 
                 text_colour: str = data.get("textColour", None)
                 if not text_colour:
                     self.set_status(400)
-                    await self.finish({"message": "Text colour missing"})
+                    await self.finish({"message": ERROR_TEXT_COLOUR_MISSING})
                     return
 
                 enable_background_colour: bool = data.get(
@@ -168,7 +177,7 @@ class StageDirectionStylesController(BaseAPIController):
                 background_colour: str = data.get("backgroundColour", None)
                 if enable_background_colour and not background_colour:
                     self.set_status(400)
-                    await self.finish({"message": "Background colour missing"})
+                    await self.finish({"message": ERROR_BACKGROUND_COLOUR_MISSING})
                     return
 
                 style.description = description
@@ -191,7 +200,7 @@ class StageDirectionStylesController(BaseAPIController):
                 )
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -211,7 +220,7 @@ class StageDirectionStylesController(BaseAPIController):
                 style_id = data.get("id", None)
                 if not style_id:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 entry: StageDirectionStyle = session.get(StageDirectionStyle, style_id)
@@ -230,8 +239,8 @@ class StageDirectionStylesController(BaseAPIController):
                 else:
                     self.set_status(404)
                     await self.finish(
-                        {"message": "404 stage direction style not found"}
+                        {"message": ERROR_STAGE_DIRECTION_STYLE_NOT_FOUND}
                     )
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})

--- a/server/controllers/api/show/session/assign_tags.py
+++ b/server/controllers/api/show/session/assign_tags.py
@@ -1,6 +1,7 @@
 from sqlalchemy import select
 from tornado import escape
 
+from controllers.api.constants import ERROR_SHOW_NOT_FOUND
 from models.session import SessionTag, ShowSession
 from models.show import Show
 from rbac.role import Role
@@ -34,7 +35,7 @@ class SessionTagAssignmentController(BaseAPIController):
             show = session.get(Show, show_id)
             if not show:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
 
             self.requires_role(show, Role.WRITE)

--- a/server/controllers/api/show/session/sessions.py
+++ b/server/controllers/api/show/session/sessions.py
@@ -4,6 +4,7 @@ from typing import List
 from sqlalchemy import select
 from tornado import escape
 
+from controllers.api.constants import ERROR_SHOW_NOT_FOUND
 from models.script import Script
 from models.session import Interval, Session, ShowSession
 from models.show import Show
@@ -54,7 +55,7 @@ class SessionsController(BaseAPIController):
                 )
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
 
 @ApiRoute("show/sessions/start", ApiVersion.V1)
@@ -121,7 +122,7 @@ class SessionStartController(BaseAPIController):
                     await self.application.ws_send_to_all("START_SHOW", "NOOP", {})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
 
 @ApiRoute("show/sessions/stop", ApiVersion.V1)
@@ -155,4 +156,4 @@ class SessionStopController(BaseAPIController):
                     await self.application.ws_send_to_all("STOP_SHOW", "NOOP", {})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})

--- a/server/controllers/api/show/session/tags.py
+++ b/server/controllers/api/show/session/tags.py
@@ -76,9 +76,7 @@ class SessionTagsController(BaseAPIController):
                 ).first()
                 if existing_tag:
                     self.set_status(400)
-                    await self.finish(
-                        {"message": ERROR_TAG_NAME_EXISTS}
-                    )
+                    await self.finish({"message": ERROR_TAG_NAME_EXISTS})
                     return
 
                 # Create new tag
@@ -147,9 +145,7 @@ class SessionTagsController(BaseAPIController):
                 ).first()
                 if other_tag:
                     self.set_status(400)
-                    await self.finish(
-                        {"message": ERROR_TAG_NAME_EXISTS}
-                    )
+                    await self.finish({"message": ERROR_TAG_NAME_EXISTS})
                     return
 
                 # Update tag

--- a/server/controllers/api/show/session/tags.py
+++ b/server/controllers/api/show/session/tags.py
@@ -1,6 +1,14 @@
 from sqlalchemy import func, select
 from tornado import escape
 
+from controllers.api.constants import (
+    ERROR_COLOUR_MISSING,
+    ERROR_ID_MISSING,
+    ERROR_SHOW_NOT_FOUND,
+    ERROR_TAG_NAME_EXISTS,
+    ERROR_TAG_NAME_MISSING,
+    ERROR_TAG_NOT_FOUND,
+)
 from models.session import SessionTag
 from models.show import Show
 from rbac.role import Role
@@ -30,7 +38,7 @@ class SessionTagsController(BaseAPIController):
                 self.finish({"tags": tags})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -49,14 +57,14 @@ class SessionTagsController(BaseAPIController):
                 tag = data.get("tag", None)
                 if not tag:
                     self.set_status(400)
-                    await self.finish({"message": "Tag name missing"})
+                    await self.finish({"message": ERROR_TAG_NAME_MISSING})
                     return
 
                 # Validate colour
                 colour = data.get("colour", None)
                 if not colour:
                     self.set_status(400)
-                    await self.finish({"message": "Colour missing"})
+                    await self.finish({"message": ERROR_COLOUR_MISSING})
                     return
 
                 # Check case-insensitive uniqueness
@@ -69,7 +77,7 @@ class SessionTagsController(BaseAPIController):
                 if existing_tag:
                     self.set_status(400)
                     await self.finish(
-                        {"message": "Tag name already exists (case-insensitive)"}
+                        {"message": ERROR_TAG_NAME_EXISTS}
                     )
                     return
 
@@ -86,7 +94,7 @@ class SessionTagsController(BaseAPIController):
                 await self.application.ws_send_to_all("NOOP", "GET_SESSION_TAGS", {})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -105,28 +113,28 @@ class SessionTagsController(BaseAPIController):
                 tag_id = data.get("id", None)
                 if not tag_id:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 # Fetch existing tag
                 tag_obj = session.get(SessionTag, tag_id)
                 if not tag_obj:
                     self.set_status(404)
-                    await self.finish({"message": "404 tag not found"})
+                    await self.finish({"message": ERROR_TAG_NOT_FOUND})
                     return
 
                 # Validate tag name
                 tag = data.get("tag", None)
                 if not tag:
                     self.set_status(400)
-                    await self.finish({"message": "Tag name missing"})
+                    await self.finish({"message": ERROR_TAG_NAME_MISSING})
                     return
 
                 # Validate colour
                 colour = data.get("colour", None)
                 if not colour:
                     self.set_status(400)
-                    await self.finish({"message": "Colour missing"})
+                    await self.finish({"message": ERROR_COLOUR_MISSING})
                     return
 
                 # Check case-insensitive uniqueness (excluding self)
@@ -140,7 +148,7 @@ class SessionTagsController(BaseAPIController):
                 if other_tag:
                     self.set_status(400)
                     await self.finish(
-                        {"message": "Tag name already exists (case-insensitive)"}
+                        {"message": ERROR_TAG_NAME_EXISTS}
                     )
                     return
 
@@ -158,7 +166,7 @@ class SessionTagsController(BaseAPIController):
                 )
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -177,7 +185,7 @@ class SessionTagsController(BaseAPIController):
                     tag_id: int = int(self.get_query_argument("id"))
                 except Exception:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 # Fetch tag and delete
@@ -197,7 +205,7 @@ class SessionTagsController(BaseAPIController):
                     )
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 tag not found"})
+                    await self.finish({"message": ERROR_TAG_NOT_FOUND})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})

--- a/server/controllers/api/show/shows.py
+++ b/server/controllers/api/show/shows.py
@@ -4,6 +4,7 @@ from dateutil import parser
 from sqlalchemy import select
 from tornado import escape
 
+from controllers.api.constants import ERROR_SHOW_NOT_FOUND
 from digi_server.logger import get_logger
 from models.script import Script, ScriptRevision
 from models.show import Show, ShowScriptType
@@ -143,7 +144,7 @@ class ShowController(BaseAPIController):
             self.write(show)
         else:
             self.set_status(404)
-            self.write({"message": "404 show not found"})
+            self.write({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     async def patch(self):
@@ -217,7 +218,7 @@ class ShowController(BaseAPIController):
                 await self.application.ws_send_to_all("NOOP", "GET_SHOW_DETAILS", {})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
 
 @ApiRoute("show/script_modes", ApiVersion.V1)

--- a/server/controllers/api/show/stage/crew.py
+++ b/server/controllers/api/show/stage/crew.py
@@ -1,5 +1,14 @@
 from tornado import escape
 
+from controllers.api.constants import (
+    ERROR_CAST_MEMBER_NOT_FOUND,
+    ERROR_CREW_NOT_FOUND,
+    ERROR_FIRST_NAME_MISSING,
+    ERROR_ID_MISSING,
+    ERROR_INVALID_ID,
+    ERROR_LAST_NAME_MISSING,
+    ERROR_SHOW_NOT_FOUND,
+)
 from models.show import Show
 from models.stage import Crew
 from rbac.role import Role
@@ -25,7 +34,7 @@ class CrewController(BaseAPIController):
                 self.finish({"crew": crew})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -42,13 +51,13 @@ class CrewController(BaseAPIController):
                 first_name = data.get("firstName", None)
                 if not first_name:
                     self.set_status(400)
-                    await self.finish({"message": "First name missing"})
+                    await self.finish({"message": ERROR_FIRST_NAME_MISSING})
                     return
 
                 last_name = data.get("lastName", None)
                 if not last_name:
                     self.set_status(400)
-                    await self.finish({"message": "Last name missing"})
+                    await self.finish({"message": ERROR_LAST_NAME_MISSING})
                     return
 
                 new_crew = Crew(
@@ -67,7 +76,7 @@ class CrewController(BaseAPIController):
                 )
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -84,7 +93,7 @@ class CrewController(BaseAPIController):
                 crew_id = data.get("id", None)
                 if not crew_id:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 entry: Crew = session.get(Crew, crew_id)
@@ -92,14 +101,14 @@ class CrewController(BaseAPIController):
                     first_name = data.get("firstName", None)
                     if not first_name:
                         self.set_status(400)
-                        await self.finish({"message": "First name missing"})
+                        await self.finish({"message": ERROR_FIRST_NAME_MISSING})
                         return
                     entry.first_name = first_name
 
                     last_name = data.get("lastName", None)
                     if not last_name:
                         self.set_status(400)
-                        await self.finish({"message": "Last name missing"})
+                        await self.finish({"message": ERROR_LAST_NAME_MISSING})
                         return
                     entry.last_name = last_name
 
@@ -113,11 +122,11 @@ class CrewController(BaseAPIController):
                     )
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 cast member not found"})
+                    await self.finish({"message": ERROR_CAST_MEMBER_NOT_FOUND})
                     return
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -133,14 +142,14 @@ class CrewController(BaseAPIController):
                 crew_id_str = self.get_argument("id", None)
                 if not crew_id_str:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 try:
                     crew_id = int(crew_id_str)
                 except ValueError:
                     self.set_status(400)
-                    await self.finish({"message": "Invalid ID"})
+                    await self.finish({"message": ERROR_INVALID_ID})
                     return
 
                 entry = session.get(Crew, crew_id)
@@ -156,7 +165,7 @@ class CrewController(BaseAPIController):
                     )
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 crew member not found"})
+                    await self.finish({"message": ERROR_CREW_NOT_FOUND})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})

--- a/server/controllers/api/show/stage/helpers.py
+++ b/server/controllers/api/show/stage/helpers.py
@@ -12,12 +12,161 @@ from controllers.api.constants import (
     ERROR_ALLOCATION_NOT_FOUND,
     ERROR_ID_MISSING,
     ERROR_INVALID_ID,
+    ERROR_NAME_MISSING,
     ERROR_SCENE_ID_MISSING,
     ERROR_SCENE_NOT_FOUND,
     ERROR_SHOW_NOT_FOUND,
 )
 from models.show import Scene, Show
 from rbac.role import Role
+
+
+async def handle_type_post(controller, type_model, ws_action, success_message):
+    """
+    Handle POST request for creating stage item types (PropType/SceneryType).
+
+    :param controller: The controller instance
+    :param type_model: SQLAlchemy model class for the type
+    :param ws_action: WebSocket action to send on success
+    :param success_message: Success message to return
+    """
+    current_show = controller.get_current_show()
+    show_id = current_show["id"]
+
+    with controller.make_session() as session:
+        show = session.get(Show, show_id)
+        if not show:
+            controller.set_status(404)
+            await controller.finish({"message": ERROR_SHOW_NOT_FOUND})
+            return
+        controller.requires_role(show, Role.WRITE)
+        data = escape.json_decode(controller.request.body)
+
+        name = data.get("name", None)
+        if not name:
+            controller.set_status(400)
+            await controller.finish({"message": ERROR_NAME_MISSING})
+            return
+
+        description = data.get("description", "")
+
+        new_type = type_model(show_id=show.id, name=name, description=description)
+        session.add(new_type)
+        session.commit()
+
+        controller.set_status(200)
+        await controller.finish({"id": new_type.id, "message": success_message})
+
+        await controller.application.ws_send_to_all("NOOP", ws_action, {})
+
+
+async def handle_type_patch(
+    controller, type_model, ws_action, success_message, not_found_message
+):
+    """
+    Handle PATCH request for updating stage item types.
+
+    :param controller: The controller instance
+    :param type_model: SQLAlchemy model class for the type
+    :param ws_action: WebSocket action to send on success
+    :param success_message: Success message to return
+    :param not_found_message: Not found error message
+    """
+    current_show = controller.get_current_show()
+    show_id = current_show["id"]
+
+    with controller.make_session() as session:
+        show = session.get(Show, show_id)
+        if not show:
+            controller.set_status(404)
+            await controller.finish({"message": ERROR_SHOW_NOT_FOUND})
+            return
+        controller.requires_role(show, Role.WRITE)
+        data = escape.json_decode(controller.request.body)
+
+        type_id = data.get("id", None)
+        if not type_id:
+            controller.set_status(400)
+            await controller.finish({"message": ERROR_ID_MISSING})
+            return
+
+        entry = session.get(type_model, type_id)
+        if not entry:
+            controller.set_status(404)
+            await controller.finish({"message": not_found_message})
+            return
+
+        name = data.get("name", None)
+        description = data.get("description", "")
+        if not name:
+            controller.set_status(400)
+            await controller.finish({"message": ERROR_NAME_MISSING})
+            return
+
+        entry.name = name
+        entry.description = description
+        session.commit()
+
+        controller.set_status(200)
+        await controller.finish({"message": success_message})
+
+        await controller.application.ws_send_to_all("NOOP", ws_action, {})
+
+
+async def handle_type_delete(
+    controller,
+    type_model,
+    ws_actions,
+    success_message,
+    not_found_message,
+):
+    """
+    Handle DELETE request for removing stage item types.
+
+    :param controller: The controller instance
+    :param type_model: SQLAlchemy model class for the type
+    :param ws_actions: List of WebSocket actions to send on success
+    :param success_message: Success message to return
+    :param not_found_message: Not found error message
+    """
+    current_show = controller.get_current_show()
+    show_id = current_show["id"]
+
+    with controller.make_session() as session:
+        show = session.get(Show, show_id)
+        if not show:
+            controller.set_status(404)
+            await controller.finish({"message": ERROR_SHOW_NOT_FOUND})
+            return
+        controller.requires_role(show, Role.WRITE)
+
+        type_id_str = controller.get_argument("id", None)
+        if not type_id_str:
+            controller.set_status(400)
+            await controller.finish({"message": ERROR_ID_MISSING})
+            return
+
+        try:
+            type_id = int(type_id_str)
+        except ValueError:
+            controller.set_status(400)
+            await controller.finish({"message": ERROR_INVALID_ID})
+            return
+
+        entry = session.get(type_model, type_id)
+        if not entry:
+            controller.set_status(404)
+            await controller.finish({"message": not_found_message})
+            return
+
+        session.delete(entry)
+        session.commit()
+
+        controller.set_status(200)
+        await controller.finish({"message": success_message})
+
+        for ws_action in ws_actions:
+            await controller.application.ws_send_to_all("NOOP", ws_action, {})
 
 
 async def validate_type_id(

--- a/server/controllers/api/show/stage/helpers.py
+++ b/server/controllers/api/show/stage/helpers.py
@@ -1,0 +1,244 @@
+"""
+Shared helper functions for stage item controllers (props, scenery).
+
+These helpers reduce code duplication by extracting common validation
+and CRUD patterns used across Props and Scenery controllers.
+"""
+
+from sqlalchemy import select
+from tornado import escape
+
+from controllers.api.constants import (
+    ERROR_ALLOCATION_NOT_FOUND,
+    ERROR_ID_MISSING,
+    ERROR_INVALID_ID,
+    ERROR_SCENE_ID_MISSING,
+    ERROR_SCENE_NOT_FOUND,
+    ERROR_SHOW_NOT_FOUND,
+)
+from models.show import Scene, Show
+from rbac.role import Role
+
+
+async def validate_type_id(
+    controller, data, type_model, type_id_key, error_missing, show
+):
+    """
+    Validate a type ID from request data.
+
+    :param controller: The controller instance
+    :param data: Request data dictionary
+    :param type_model: SQLAlchemy model class for the type (PropType/SceneryType)
+    :param type_id_key: Key to look up in data (e.g., 'prop_type_id')
+    :param error_missing: Error message constant for missing type ID
+    :param show: The current show object
+    :returns: Tuple of (type_instance, error_occurred). If error_occurred is True,
+              the response has already been sent.
+    """
+    type_id = data.get(type_id_key, None)
+    if not type_id:
+        controller.set_status(400)
+        await controller.finish({"message": error_missing})
+        return None, True
+
+    try:
+        type_id = int(type_id)
+    except ValueError:
+        controller.set_status(400)
+        await controller.finish({"message": f"Invalid {type_id_key}"})
+        return None, True
+
+    with controller.make_session() as session:
+        type_instance = session.get(type_model, type_id)
+        if not type_instance:
+            controller.set_status(404)
+            await controller.finish({"message": f"{type_model.__name__} not found"})
+            return None, True
+
+        if type_instance.show_id != show.id:
+            controller.set_status(400)
+            await controller.finish(
+                {"message": f"Invalid {type_model.__name__.lower()} for show"}
+            )
+            return None, True
+
+        return type_instance, False
+
+
+async def handle_allocation_post(
+    controller,
+    item_model,
+    item_id_key,
+    allocation_model,
+    allocation_item_fk,
+    ws_action,
+    error_item_id_missing,
+    error_item_not_found,
+    allocation_exists_message,
+):
+    """
+    Handle POST request for creating allocations (props or scenery to scenes).
+
+    :param controller: The controller instance
+    :param item_model: SQLAlchemy model class for the item (Props/Scenery)
+    :param item_id_key: Key in request data (e.g., 'props_id', 'scenery_id')
+    :param allocation_model: SQLAlchemy model class for allocation
+    :param allocation_item_fk: Name of FK column on allocation model (e.g., 'props_id')
+    :param ws_action: WebSocket action to send on success
+    :param error_item_id_missing: Error constant for missing item ID
+    :param error_item_not_found: Error constant for item not found
+    :param allocation_exists_message: Message for duplicate allocation error
+    """
+    current_show = controller.get_current_show()
+    show_id = current_show["id"]
+
+    with controller.make_session() as session:
+        show = session.get(Show, show_id)
+        if not show:
+            controller.set_status(404)
+            await controller.finish({"message": ERROR_SHOW_NOT_FOUND})
+            return
+
+        controller.requires_role(show, Role.WRITE)
+        data = escape.json_decode(controller.request.body)
+
+        # Validate item_id
+        item_id = data.get(item_id_key, None)
+        if item_id is None:
+            controller.set_status(400)
+            await controller.finish({"message": error_item_id_missing})
+            return
+
+        try:
+            item_id = int(item_id)
+        except ValueError:
+            controller.set_status(400)
+            await controller.finish({"message": f"Invalid {item_id_key}"})
+            return
+
+        item = session.get(item_model, item_id)
+        if not item:
+            controller.set_status(404)
+            await controller.finish({"message": error_item_not_found})
+            return
+
+        if item.show_id != show_id:
+            controller.set_status(404)
+            await controller.finish({"message": error_item_not_found})
+            return
+
+        # Validate scene_id
+        scene_id = data.get("scene_id", None)
+        if scene_id is None:
+            controller.set_status(400)
+            await controller.finish({"message": ERROR_SCENE_ID_MISSING})
+            return
+
+        try:
+            scene_id = int(scene_id)
+        except ValueError:
+            controller.set_status(400)
+            await controller.finish({"message": "Invalid scene_id"})
+            return
+
+        scene: Scene = session.get(Scene, scene_id)
+        if not scene:
+            controller.set_status(404)
+            await controller.finish({"message": ERROR_SCENE_NOT_FOUND})
+            return
+
+        if scene.show_id != show_id:
+            controller.set_status(404)
+            await controller.finish({"message": ERROR_SCENE_NOT_FOUND})
+            return
+
+        # Check for duplicate allocation
+        item_fk_attr = getattr(allocation_model, allocation_item_fk)
+        existing = session.scalars(
+            select(allocation_model).where(
+                item_fk_attr == item_id,
+                allocation_model.scene_id == scene_id,
+            )
+        ).first()
+        if existing:
+            controller.set_status(400)
+            await controller.finish({"message": allocation_exists_message})
+            return
+
+        # Create allocation using keyword arguments
+        new_allocation = allocation_model(
+            **{allocation_item_fk: item_id, "scene_id": scene_id}
+        )
+        session.add(new_allocation)
+        session.commit()
+
+        controller.set_status(200)
+        await controller.finish(
+            {"id": new_allocation.id, "message": "Successfully added allocation"}
+        )
+
+        await controller.application.ws_send_to_all("NOOP", ws_action, {})
+
+
+async def handle_allocation_delete(
+    controller,
+    item_model,
+    allocation_model,
+    allocation_item_fk,
+    ws_action,
+):
+    """
+    Handle DELETE request for removing allocations.
+
+    :param controller: The controller instance
+    :param item_model: SQLAlchemy model class for the item (Props/Scenery)
+    :param allocation_model: SQLAlchemy model class for allocation
+    :param allocation_item_fk: Name of FK column on allocation model
+    :param ws_action: WebSocket action to send on success
+    """
+    current_show = controller.get_current_show()
+    show_id = current_show["id"]
+
+    with controller.make_session() as session:
+        show = session.get(Show, show_id)
+        if not show:
+            controller.set_status(404)
+            await controller.finish({"message": ERROR_SHOW_NOT_FOUND})
+            return
+
+        controller.requires_role(show, Role.WRITE)
+
+        allocation_id_str = controller.get_argument("id", None)
+        if not allocation_id_str:
+            controller.set_status(400)
+            await controller.finish({"message": ERROR_ID_MISSING})
+            return
+
+        try:
+            allocation_id = int(allocation_id_str)
+        except ValueError:
+            controller.set_status(400)
+            await controller.finish({"message": ERROR_INVALID_ID})
+            return
+
+        allocation = session.get(allocation_model, allocation_id)
+        if not allocation:
+            controller.set_status(404)
+            await controller.finish({"message": ERROR_ALLOCATION_NOT_FOUND})
+            return
+
+        # Verify the allocation belongs to an item in this show
+        item_id = getattr(allocation, allocation_item_fk)
+        item = session.get(item_model, item_id)
+        if not item or item.show_id != show_id:
+            controller.set_status(404)
+            await controller.finish({"message": ERROR_ALLOCATION_NOT_FOUND})
+            return
+
+        session.delete(allocation)
+        session.commit()
+
+        controller.set_status(200)
+        await controller.finish({"message": "Successfully deleted allocation"})
+
+        await controller.application.ws_send_to_all("NOOP", ws_action, {})

--- a/server/controllers/api/show/stage/props.py
+++ b/server/controllers/api/show/stage/props.py
@@ -15,6 +15,9 @@ from controllers.api.constants import (
 from controllers.api.show.stage.helpers import (
     handle_allocation_delete,
     handle_allocation_post,
+    handle_type_delete,
+    handle_type_patch,
+    handle_type_post,
 )
 from models.show import Show
 from models.stage import Props, PropsAllocation, PropType
@@ -46,123 +49,34 @@ class PropsTypesController(BaseAPIController):
     @requires_show
     @no_live_session
     async def post(self):
-        current_show = self.get_current_show()
-        show_id = current_show["id"]
-
-        with self.make_session() as session:
-            show = session.get(Show, show_id)
-            if not show:
-                self.set_status(404)
-                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
-                return
-            self.requires_role(show, Role.WRITE)
-            data = escape.json_decode(self.request.body)
-
-            name = data.get("name", None)
-            if not name:
-                self.set_status(400)
-                await self.finish({"message": ERROR_NAME_MISSING})
-                return
-
-            description = data.get("description", "")
-
-            new_prop_type = PropType(
-                show_id=show.id, name=name, description=description
-            )
-            session.add(new_prop_type)
-            session.commit()
-
-            self.set_status(200)
-            await self.finish(
-                {"id": new_prop_type.id, "message": "Successfully added prop type"}
-            )
-
-            await self.application.ws_send_to_all("NOOP", "GET_PROP_TYPES", {})
+        await handle_type_post(
+            self,
+            type_model=PropType,
+            ws_action="GET_PROP_TYPES",
+            success_message="Successfully added prop type",
+        )
 
     @requires_show
     @no_live_session
     async def patch(self):
-        current_show = self.get_current_show()
-        show_id = current_show["id"]
-
-        with self.make_session() as session:
-            show = session.get(Show, show_id)
-            if not show:
-                self.set_status(404)
-                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
-                return
-            self.requires_role(show, Role.WRITE)
-            data = escape.json_decode(self.request.body)
-
-            prop_type = data.get("id", None)
-            if not prop_type:
-                self.set_status(400)
-                await self.finish({"message": ERROR_ID_MISSING})
-                return
-
-            entry: PropType = session.get(PropType, prop_type)
-            if not entry:
-                self.set_status(404)
-                await self.finish({"message": ERROR_PROP_TYPE_NOT_FOUND})
-                return
-
-            name = data.get("name", None)
-            description = data.get("description", "")
-            if not name:
-                self.set_status(400)
-                await self.finish({"message": ERROR_NAME_MISSING})
-                return
-
-            entry.name = name
-            entry.description = description
-            session.commit()
-
-            self.set_status(200)
-            await self.finish({"message": "Successfully updated prop type"})
-
-            await self.application.ws_send_to_all("NOOP", "GET_PROP_TYPES", {})
+        await handle_type_patch(
+            self,
+            type_model=PropType,
+            ws_action="GET_PROP_TYPES",
+            success_message="Successfully updated prop type",
+            not_found_message=ERROR_PROP_TYPE_NOT_FOUND,
+        )
 
     @requires_show
     @no_live_session
     async def delete(self):
-        current_show = self.get_current_show()
-        show_id = current_show["id"]
-
-        with self.make_session() as session:
-            show = session.get(Show, show_id)
-            if not show:
-                self.set_status(404)
-                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
-                return
-            self.requires_role(show, Role.WRITE)
-
-            prop_type_id_str = self.get_argument("id", None)
-            if not prop_type_id_str:
-                self.set_status(400)
-                await self.finish({"message": ERROR_ID_MISSING})
-                return
-
-            try:
-                prop_type_id = int(prop_type_id_str)
-            except ValueError:
-                self.set_status(400)
-                await self.finish({"message": ERROR_INVALID_ID})
-                return
-
-            entry = session.get(PropType, prop_type_id)
-            if not entry:
-                self.set_status(404)
-                await self.finish({"message": ERROR_PROP_TYPE_NOT_FOUND})
-                return
-
-            session.delete(entry)
-            session.commit()
-
-            self.set_status(200)
-            await self.finish({"message": "Successfully deleted prop type"})
-
-            await self.application.ws_send_to_all("NOOP", "GET_PROP_TYPES", {})
-            await self.application.ws_send_to_all("NOOP", "GET_PROPS_LIST", {})
+        await handle_type_delete(
+            self,
+            type_model=PropType,
+            ws_actions=["GET_PROP_TYPES", "GET_PROPS_LIST"],
+            success_message="Successfully deleted prop type",
+            not_found_message=ERROR_PROP_TYPE_NOT_FOUND,
+        )
 
 
 @ApiRoute("show/stage/props", ApiVersion.V1)

--- a/server/controllers/api/show/stage/props.py
+++ b/server/controllers/api/show/stage/props.py
@@ -2,7 +2,6 @@ from sqlalchemy import select
 from tornado import escape
 
 from controllers.api.constants import (
-    ERROR_ALLOCATION_NOT_FOUND,
     ERROR_ID_MISSING,
     ERROR_INVALID_ID,
     ERROR_NAME_MISSING,
@@ -11,11 +10,13 @@ from controllers.api.constants import (
     ERROR_PROP_TYPE_NOT_FOUND,
     ERROR_PROPS_ID_MISSING,
     ERROR_PROPS_NOT_FOUND,
-    ERROR_SCENE_ID_MISSING,
-    ERROR_SCENE_NOT_FOUND,
     ERROR_SHOW_NOT_FOUND,
 )
-from models.show import Scene, Show
+from controllers.api.show.stage.helpers import (
+    handle_allocation_delete,
+    handle_allocation_post,
+)
+from models.show import Show
 from models.stage import Props, PropsAllocation, PropType
 from rbac.role import Role
 from schemas.schemas import PropsAllocationSchema, PropsSchema, PropTypeSchema
@@ -379,140 +380,26 @@ class PropsAllocationController(BaseAPIController):
     @no_live_session
     async def post(self):
         """Create a new props allocation."""
-        current_show = self.get_current_show()
-        show_id = current_show["id"]
-
-        with self.make_session() as session:
-            show = session.get(Show, show_id)
-            if not show:
-                self.set_status(404)
-                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
-                return
-
-            self.requires_role(show, Role.WRITE)
-            data = escape.json_decode(self.request.body)
-
-            # Validate props_id
-            props_id = data.get("props_id", None)
-            if props_id is None:
-                self.set_status(400)
-                await self.finish({"message": ERROR_PROPS_ID_MISSING})
-                return
-
-            try:
-                props_id = int(props_id)
-            except ValueError:
-                self.set_status(400)
-                await self.finish({"message": "Invalid props_id"})
-                return
-
-            prop: Props = session.get(Props, props_id)
-            if not prop:
-                self.set_status(404)
-                await self.finish({"message": ERROR_PROP_NOT_FOUND})
-                return
-
-            if prop.show_id != show_id:
-                self.set_status(404)
-                await self.finish({"message": ERROR_PROP_NOT_FOUND})
-                return
-
-            # Validate scene_id
-            scene_id = data.get("scene_id", None)
-            if scene_id is None:
-                self.set_status(400)
-                await self.finish({"message": ERROR_SCENE_ID_MISSING})
-                return
-
-            try:
-                scene_id = int(scene_id)
-            except ValueError:
-                self.set_status(400)
-                await self.finish({"message": "Invalid scene_id"})
-                return
-
-            scene: Scene = session.get(Scene, scene_id)
-            if not scene:
-                self.set_status(404)
-                await self.finish({"message": ERROR_SCENE_NOT_FOUND})
-                return
-
-            if scene.show_id != show_id:
-                self.set_status(404)
-                await self.finish({"message": ERROR_SCENE_NOT_FOUND})
-                return
-
-            # Check for duplicate allocation
-            existing = session.scalars(
-                select(PropsAllocation).where(
-                    PropsAllocation.props_id == props_id,
-                    PropsAllocation.scene_id == scene_id,
-                )
-            ).first()
-            if existing:
-                self.set_status(400)
-                await self.finish(
-                    {"message": "Allocation already exists for this prop and scene"}
-                )
-                return
-
-            new_allocation = PropsAllocation(props_id=props_id, scene_id=scene_id)
-            session.add(new_allocation)
-            session.commit()
-
-            self.set_status(200)
-            await self.finish(
-                {"id": new_allocation.id, "message": "Successfully added allocation"}
-            )
-
-            await self.application.ws_send_to_all("NOOP", "GET_PROPS_ALLOCATIONS", {})
+        await handle_allocation_post(
+            self,
+            item_model=Props,
+            item_id_key="props_id",
+            allocation_model=PropsAllocation,
+            allocation_item_fk="props_id",
+            ws_action="GET_PROPS_ALLOCATIONS",
+            error_item_id_missing=ERROR_PROPS_ID_MISSING,
+            error_item_not_found=ERROR_PROP_NOT_FOUND,
+            allocation_exists_message="Allocation already exists for this prop and scene",
+        )
 
     @requires_show
     @no_live_session
     async def delete(self):
         """Delete a props allocation by ID (query parameter)."""
-        current_show = self.get_current_show()
-        show_id = current_show["id"]
-
-        with self.make_session() as session:
-            show = session.get(Show, show_id)
-            if not show:
-                self.set_status(404)
-                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
-                return
-
-            self.requires_role(show, Role.WRITE)
-
-            allocation_id_str = self.get_argument("id", None)
-            if not allocation_id_str:
-                self.set_status(400)
-                await self.finish({"message": ERROR_ID_MISSING})
-                return
-
-            try:
-                allocation_id = int(allocation_id_str)
-            except ValueError:
-                self.set_status(400)
-                await self.finish({"message": ERROR_INVALID_ID})
-                return
-
-            allocation: PropsAllocation = session.get(PropsAllocation, allocation_id)
-            if not allocation:
-                self.set_status(404)
-                await self.finish({"message": ERROR_ALLOCATION_NOT_FOUND})
-                return
-
-            # Verify the allocation belongs to a prop in this show
-            prop: Props = session.get(Props, allocation.props_id)
-            if not prop or prop.show_id != show_id:
-                self.set_status(404)
-                await self.finish({"message": ERROR_ALLOCATION_NOT_FOUND})
-                return
-
-            session.delete(allocation)
-            session.commit()
-
-            self.set_status(200)
-            await self.finish({"message": "Successfully deleted allocation"})
-
-            await self.application.ws_send_to_all("NOOP", "GET_PROPS_ALLOCATIONS", {})
+        await handle_allocation_delete(
+            self,
+            item_model=Props,
+            allocation_model=PropsAllocation,
+            allocation_item_fk="props_id",
+            ws_action="GET_PROPS_ALLOCATIONS",
+        )

--- a/server/controllers/api/show/stage/props.py
+++ b/server/controllers/api/show/stage/props.py
@@ -1,6 +1,20 @@
 from sqlalchemy import select
 from tornado import escape
 
+from controllers.api.constants import (
+    ERROR_ALLOCATION_NOT_FOUND,
+    ERROR_ID_MISSING,
+    ERROR_INVALID_ID,
+    ERROR_NAME_MISSING,
+    ERROR_PROP_NOT_FOUND,
+    ERROR_PROP_TYPE_ID_MISSING,
+    ERROR_PROP_TYPE_NOT_FOUND,
+    ERROR_PROPS_ID_MISSING,
+    ERROR_PROPS_NOT_FOUND,
+    ERROR_SCENE_ID_MISSING,
+    ERROR_SCENE_NOT_FOUND,
+    ERROR_SHOW_NOT_FOUND,
+)
 from models.show import Scene, Show
 from models.stage import Props, PropsAllocation, PropType
 from rbac.role import Role
@@ -26,7 +40,7 @@ class PropsTypesController(BaseAPIController):
                 self.finish({"prop_types": prop_types})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -38,7 +52,7 @@ class PropsTypesController(BaseAPIController):
             show = session.get(Show, show_id)
             if not show:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
             self.requires_role(show, Role.WRITE)
             data = escape.json_decode(self.request.body)
@@ -46,7 +60,7 @@ class PropsTypesController(BaseAPIController):
             name = data.get("name", None)
             if not name:
                 self.set_status(400)
-                await self.finish({"message": "Name missing"})
+                await self.finish({"message": ERROR_NAME_MISSING})
                 return
 
             description = data.get("description", "")
@@ -74,7 +88,7 @@ class PropsTypesController(BaseAPIController):
             show = session.get(Show, show_id)
             if not show:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
             self.requires_role(show, Role.WRITE)
             data = escape.json_decode(self.request.body)
@@ -82,20 +96,20 @@ class PropsTypesController(BaseAPIController):
             prop_type = data.get("id", None)
             if not prop_type:
                 self.set_status(400)
-                await self.finish({"message": "ID missing"})
+                await self.finish({"message": ERROR_ID_MISSING})
                 return
 
             entry: PropType = session.get(PropType, prop_type)
             if not entry:
                 self.set_status(404)
-                await self.finish({"message": "404 prop type not found"})
+                await self.finish({"message": ERROR_PROP_TYPE_NOT_FOUND})
                 return
 
             name = data.get("name", None)
             description = data.get("description", "")
             if not name:
                 self.set_status(400)
-                await self.finish({"message": "Name missing"})
+                await self.finish({"message": ERROR_NAME_MISSING})
                 return
 
             entry.name = name
@@ -117,27 +131,27 @@ class PropsTypesController(BaseAPIController):
             show = session.get(Show, show_id)
             if not show:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
             self.requires_role(show, Role.WRITE)
 
             prop_type_id_str = self.get_argument("id", None)
             if not prop_type_id_str:
                 self.set_status(400)
-                await self.finish({"message": "ID missing"})
+                await self.finish({"message": ERROR_ID_MISSING})
                 return
 
             try:
                 prop_type_id = int(prop_type_id_str)
             except ValueError:
                 self.set_status(400)
-                await self.finish({"message": "Invalid ID"})
+                await self.finish({"message": ERROR_INVALID_ID})
                 return
 
             entry = session.get(PropType, prop_type_id)
             if not entry:
                 self.set_status(404)
-                await self.finish({"message": "404 prop type not found"})
+                await self.finish({"message": ERROR_PROP_TYPE_NOT_FOUND})
                 return
 
             session.delete(entry)
@@ -166,7 +180,7 @@ class PropsController(BaseAPIController):
                 self.finish({"props": props})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -183,13 +197,13 @@ class PropsController(BaseAPIController):
                 name = data.get("name", None)
                 if not name:
                     self.set_status(400)
-                    await self.finish({"message": "Name missing"})
+                    await self.finish({"message": ERROR_NAME_MISSING})
                     return
 
                 prop_type_id = data.get("prop_type_id", None)
                 if not prop_type_id:
                     self.set_status(400)
-                    await self.finish({"message": "Prop type ID missing"})
+                    await self.finish({"message": ERROR_PROP_TYPE_ID_MISSING})
                     return
                 try:
                     prop_type_id = int(prop_type_id)
@@ -226,7 +240,7 @@ class PropsController(BaseAPIController):
                 await self.application.ws_send_to_all("NOOP", "GET_PROPS_LIST", {})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -243,7 +257,7 @@ class PropsController(BaseAPIController):
                 props = data.get("id", None)
                 if not props:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 entry: Props = session.get(Props, props)
@@ -251,14 +265,14 @@ class PropsController(BaseAPIController):
                     name = data.get("name", None)
                     if not name:
                         self.set_status(400)
-                        await self.finish({"message": "Name missing"})
+                        await self.finish({"message": ERROR_NAME_MISSING})
                         return
                     entry.name = name
 
                     prop_type_id = data.get("prop_type_id", None)
                     if not prop_type_id:
                         self.set_status(400)
-                        await self.finish({"message": "Prop type ID missing"})
+                        await self.finish({"message": ERROR_PROP_TYPE_ID_MISSING})
                         return
                     try:
                         prop_type_id = int(prop_type_id)
@@ -288,11 +302,11 @@ class PropsController(BaseAPIController):
                     await self.application.ws_send_to_all("NOOP", "GET_PROPS_LIST", {})
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 prop not found"})
+                    await self.finish({"message": ERROR_PROP_NOT_FOUND})
                     return
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -308,14 +322,14 @@ class PropsController(BaseAPIController):
                 props_id_str = self.get_argument("id", None)
                 if not props_id_str:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 try:
                     props_id = int(props_id_str)
                 except ValueError:
                     self.set_status(400)
-                    await self.finish({"message": "Invalid ID"})
+                    await self.finish({"message": ERROR_INVALID_ID})
                     return
 
                 entry = session.get(Props, props_id)
@@ -329,10 +343,10 @@ class PropsController(BaseAPIController):
                     await self.application.ws_send_to_all("NOOP", "GET_PROPS_LIST", {})
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 props not found"})
+                    await self.finish({"message": ERROR_PROPS_NOT_FOUND})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
 
 @ApiRoute("show/stage/props/allocations", ApiVersion.V1)
@@ -359,7 +373,7 @@ class PropsAllocationController(BaseAPIController):
                 self.finish({"allocations": allocations})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -372,7 +386,7 @@ class PropsAllocationController(BaseAPIController):
             show = session.get(Show, show_id)
             if not show:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
 
             self.requires_role(show, Role.WRITE)
@@ -382,7 +396,7 @@ class PropsAllocationController(BaseAPIController):
             props_id = data.get("props_id", None)
             if props_id is None:
                 self.set_status(400)
-                await self.finish({"message": "props_id missing"})
+                await self.finish({"message": ERROR_PROPS_ID_MISSING})
                 return
 
             try:
@@ -395,19 +409,19 @@ class PropsAllocationController(BaseAPIController):
             prop: Props = session.get(Props, props_id)
             if not prop:
                 self.set_status(404)
-                await self.finish({"message": "404 prop not found"})
+                await self.finish({"message": ERROR_PROP_NOT_FOUND})
                 return
 
             if prop.show_id != show_id:
                 self.set_status(404)
-                await self.finish({"message": "404 prop not found"})
+                await self.finish({"message": ERROR_PROP_NOT_FOUND})
                 return
 
             # Validate scene_id
             scene_id = data.get("scene_id", None)
             if scene_id is None:
                 self.set_status(400)
-                await self.finish({"message": "scene_id missing"})
+                await self.finish({"message": ERROR_SCENE_ID_MISSING})
                 return
 
             try:
@@ -420,12 +434,12 @@ class PropsAllocationController(BaseAPIController):
             scene: Scene = session.get(Scene, scene_id)
             if not scene:
                 self.set_status(404)
-                await self.finish({"message": "404 scene not found"})
+                await self.finish({"message": ERROR_SCENE_NOT_FOUND})
                 return
 
             if scene.show_id != show_id:
                 self.set_status(404)
-                await self.finish({"message": "404 scene not found"})
+                await self.finish({"message": ERROR_SCENE_NOT_FOUND})
                 return
 
             # Check for duplicate allocation
@@ -464,7 +478,7 @@ class PropsAllocationController(BaseAPIController):
             show = session.get(Show, show_id)
             if not show:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
 
             self.requires_role(show, Role.WRITE)
@@ -472,27 +486,27 @@ class PropsAllocationController(BaseAPIController):
             allocation_id_str = self.get_argument("id", None)
             if not allocation_id_str:
                 self.set_status(400)
-                await self.finish({"message": "ID missing"})
+                await self.finish({"message": ERROR_ID_MISSING})
                 return
 
             try:
                 allocation_id = int(allocation_id_str)
             except ValueError:
                 self.set_status(400)
-                await self.finish({"message": "Invalid ID"})
+                await self.finish({"message": ERROR_INVALID_ID})
                 return
 
             allocation: PropsAllocation = session.get(PropsAllocation, allocation_id)
             if not allocation:
                 self.set_status(404)
-                await self.finish({"message": "404 allocation not found"})
+                await self.finish({"message": ERROR_ALLOCATION_NOT_FOUND})
                 return
 
             # Verify the allocation belongs to a prop in this show
             prop: Props = session.get(Props, allocation.props_id)
             if not prop or prop.show_id != show_id:
                 self.set_status(404)
-                await self.finish({"message": "404 allocation not found"})
+                await self.finish({"message": ERROR_ALLOCATION_NOT_FOUND})
                 return
 
             session.delete(allocation)

--- a/server/controllers/api/show/stage/scenery.py
+++ b/server/controllers/api/show/stage/scenery.py
@@ -15,6 +15,9 @@ from controllers.api.constants import (
 from controllers.api.show.stage.helpers import (
     handle_allocation_delete,
     handle_allocation_post,
+    handle_type_delete,
+    handle_type_patch,
+    handle_type_post,
 )
 from models.show import Show
 from models.stage import Scenery, SceneryAllocation, SceneryType
@@ -48,126 +51,34 @@ class SceneryTypesController(BaseAPIController):
     @requires_show
     @no_live_session
     async def post(self):
-        current_show = self.get_current_show()
-        show_id = current_show["id"]
-
-        with self.make_session() as session:
-            show = session.get(Show, show_id)
-            if not show:
-                self.set_status(404)
-                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
-                return
-            self.requires_role(show, Role.WRITE)
-            data = escape.json_decode(self.request.body)
-
-            name = data.get("name", None)
-            if not name:
-                self.set_status(400)
-                await self.finish({"message": ERROR_NAME_MISSING})
-                return
-
-            description = data.get("description", "")
-
-            new_scenery_type = SceneryType(
-                show_id=show.id, name=name, description=description
-            )
-            session.add(new_scenery_type)
-            session.commit()
-
-            self.set_status(200)
-            await self.finish(
-                {
-                    "id": new_scenery_type.id,
-                    "message": "Successfully added scenery type",
-                }
-            )
-
-            await self.application.ws_send_to_all("NOOP", "GET_SCENERY_TYPES", {})
+        await handle_type_post(
+            self,
+            type_model=SceneryType,
+            ws_action="GET_SCENERY_TYPES",
+            success_message="Successfully added scenery type",
+        )
 
     @requires_show
     @no_live_session
     async def patch(self):
-        current_show = self.get_current_show()
-        show_id = current_show["id"]
-
-        with self.make_session() as session:
-            show = session.get(Show, show_id)
-            if not show:
-                self.set_status(404)
-                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
-                return
-            self.requires_role(show, Role.WRITE)
-            data = escape.json_decode(self.request.body)
-
-            prop_type = data.get("id", None)
-            if not prop_type:
-                self.set_status(400)
-                await self.finish({"message": ERROR_ID_MISSING})
-                return
-
-            entry: SceneryType = session.get(SceneryType, prop_type)
-            if not entry:
-                self.set_status(404)
-                await self.finish({"message": ERROR_SCENERY_TYPE_NOT_FOUND})
-                return
-
-            name = data.get("name", None)
-            description = data.get("description", "")
-            if not name:
-                self.set_status(400)
-                await self.finish({"message": ERROR_NAME_MISSING})
-                return
-
-            entry.name = name
-            entry.description = description
-            session.commit()
-
-            self.set_status(200)
-            await self.finish({"message": "Successfully updated scenery type"})
-
-            await self.application.ws_send_to_all("NOOP", "GET_SCENERY_TYPES", {})
+        await handle_type_patch(
+            self,
+            type_model=SceneryType,
+            ws_action="GET_SCENERY_TYPES",
+            success_message="Successfully updated scenery type",
+            not_found_message=ERROR_SCENERY_TYPE_NOT_FOUND,
+        )
 
     @requires_show
     @no_live_session
     async def delete(self):
-        current_show = self.get_current_show()
-        show_id = current_show["id"]
-
-        with self.make_session() as session:
-            show = session.get(Show, show_id)
-            if not show:
-                self.set_status(404)
-                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
-                return
-            self.requires_role(show, Role.WRITE)
-
-            scenery_type_id_str = self.get_argument("id", None)
-            if not scenery_type_id_str:
-                self.set_status(400)
-                await self.finish({"message": ERROR_ID_MISSING})
-                return
-
-            try:
-                scenery_type_id = int(scenery_type_id_str)
-            except ValueError:
-                self.set_status(400)
-                await self.finish({"message": ERROR_INVALID_ID})
-                return
-
-            entry = session.get(SceneryType, scenery_type_id)
-            if not entry:
-                self.set_status(404)
-                await self.finish({"message": ERROR_SCENERY_TYPE_NOT_FOUND})
-                return
-
-            session.delete(entry)
-            session.commit()
-
-            self.set_status(200)
-            await self.finish({"message": "Successfully deleted scenery type"})
-
-            await self.application.ws_send_to_all("NOOP", "GET_SCENERY_TYPES", {})
-            await self.application.ws_send_to_all("NOOP", "GET_SCENERY_LIST", {})
+        await handle_type_delete(
+            self,
+            type_model=SceneryType,
+            ws_actions=["GET_SCENERY_TYPES", "GET_SCENERY_LIST"],
+            success_message="Successfully deleted scenery type",
+            not_found_message=ERROR_SCENERY_TYPE_NOT_FOUND,
+        )
 
 
 @ApiRoute("show/stage/scenery", ApiVersion.V1)

--- a/server/controllers/api/show/stage/scenery.py
+++ b/server/controllers/api/show/stage/scenery.py
@@ -2,20 +2,21 @@ from sqlalchemy import select
 from tornado import escape
 
 from controllers.api.constants import (
-    ERROR_ALLOCATION_NOT_FOUND,
     ERROR_CAST_MEMBER_NOT_FOUND,
     ERROR_ID_MISSING,
     ERROR_INVALID_ID,
     ERROR_NAME_MISSING,
-    ERROR_SCENE_ID_MISSING,
-    ERROR_SCENE_NOT_FOUND,
     ERROR_SCENERY_ID_MISSING,
     ERROR_SCENERY_NOT_FOUND,
     ERROR_SCENERY_TYPE_ID_MISSING,
     ERROR_SCENERY_TYPE_NOT_FOUND,
     ERROR_SHOW_NOT_FOUND,
 )
-from models.show import Scene, Show
+from controllers.api.show.stage.helpers import (
+    handle_allocation_delete,
+    handle_allocation_post,
+)
+from models.show import Show
 from models.stage import Scenery, SceneryAllocation, SceneryType
 from rbac.role import Role
 from schemas.schemas import SceneryAllocationSchema, ScenerySchema, SceneryTypeSchema
@@ -390,142 +391,26 @@ class SceneryAllocationController(BaseAPIController):
     @no_live_session
     async def post(self):
         """Create a new scenery allocation."""
-        current_show = self.get_current_show()
-        show_id = current_show["id"]
-
-        with self.make_session() as session:
-            show = session.get(Show, show_id)
-            if not show:
-                self.set_status(404)
-                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
-                return
-
-            self.requires_role(show, Role.WRITE)
-            data = escape.json_decode(self.request.body)
-
-            # Validate scenery_id
-            scenery_id = data.get("scenery_id", None)
-            if scenery_id is None:
-                self.set_status(400)
-                await self.finish({"message": ERROR_SCENERY_ID_MISSING})
-                return
-
-            try:
-                scenery_id = int(scenery_id)
-            except ValueError:
-                self.set_status(400)
-                await self.finish({"message": "Invalid scenery_id"})
-                return
-
-            scenery: Scenery = session.get(Scenery, scenery_id)
-            if not scenery:
-                self.set_status(404)
-                await self.finish({"message": ERROR_SCENERY_NOT_FOUND})
-                return
-
-            if scenery.show_id != show_id:
-                self.set_status(404)
-                await self.finish({"message": ERROR_SCENERY_NOT_FOUND})
-                return
-
-            # Validate scene_id
-            scene_id = data.get("scene_id", None)
-            if scene_id is None:
-                self.set_status(400)
-                await self.finish({"message": ERROR_SCENE_ID_MISSING})
-                return
-
-            try:
-                scene_id = int(scene_id)
-            except ValueError:
-                self.set_status(400)
-                await self.finish({"message": "Invalid scene_id"})
-                return
-
-            scene: Scene = session.get(Scene, scene_id)
-            if not scene:
-                self.set_status(404)
-                await self.finish({"message": ERROR_SCENE_NOT_FOUND})
-                return
-
-            if scene.show_id != show_id:
-                self.set_status(404)
-                await self.finish({"message": ERROR_SCENE_NOT_FOUND})
-                return
-
-            # Check for duplicate allocation
-            existing = session.scalars(
-                select(SceneryAllocation).where(
-                    SceneryAllocation.scenery_id == scenery_id,
-                    SceneryAllocation.scene_id == scene_id,
-                )
-            ).first()
-            if existing:
-                self.set_status(400)
-                await self.finish(
-                    {"message": "Allocation already exists for this scenery and scene"}
-                )
-                return
-
-            new_allocation = SceneryAllocation(scenery_id=scenery_id, scene_id=scene_id)
-            session.add(new_allocation)
-            session.commit()
-
-            self.set_status(200)
-            await self.finish(
-                {"id": new_allocation.id, "message": "Successfully added allocation"}
-            )
-
-            await self.application.ws_send_to_all("NOOP", "GET_SCENERY_ALLOCATIONS", {})
+        await handle_allocation_post(
+            self,
+            item_model=Scenery,
+            item_id_key="scenery_id",
+            allocation_model=SceneryAllocation,
+            allocation_item_fk="scenery_id",
+            ws_action="GET_SCENERY_ALLOCATIONS",
+            error_item_id_missing=ERROR_SCENERY_ID_MISSING,
+            error_item_not_found=ERROR_SCENERY_NOT_FOUND,
+            allocation_exists_message="Allocation already exists for this scenery and scene",
+        )
 
     @requires_show
     @no_live_session
     async def delete(self):
         """Delete a scenery allocation by ID (query parameter)."""
-        current_show = self.get_current_show()
-        show_id = current_show["id"]
-
-        with self.make_session() as session:
-            show = session.get(Show, show_id)
-            if not show:
-                self.set_status(404)
-                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
-                return
-
-            self.requires_role(show, Role.WRITE)
-
-            allocation_id_str = self.get_argument("id", None)
-            if not allocation_id_str:
-                self.set_status(400)
-                await self.finish({"message": ERROR_ID_MISSING})
-                return
-
-            try:
-                allocation_id = int(allocation_id_str)
-            except ValueError:
-                self.set_status(400)
-                await self.finish({"message": ERROR_INVALID_ID})
-                return
-
-            allocation: SceneryAllocation = session.get(
-                SceneryAllocation, allocation_id
-            )
-            if not allocation:
-                self.set_status(404)
-                await self.finish({"message": ERROR_ALLOCATION_NOT_FOUND})
-                return
-
-            # Verify the allocation belongs to scenery in this show
-            scenery: Scenery = session.get(Scenery, allocation.scenery_id)
-            if not scenery or scenery.show_id != show_id:
-                self.set_status(404)
-                await self.finish({"message": ERROR_ALLOCATION_NOT_FOUND})
-                return
-
-            session.delete(allocation)
-            session.commit()
-
-            self.set_status(200)
-            await self.finish({"message": "Successfully deleted allocation"})
-
-            await self.application.ws_send_to_all("NOOP", "GET_SCENERY_ALLOCATIONS", {})
+        await handle_allocation_delete(
+            self,
+            item_model=Scenery,
+            allocation_model=SceneryAllocation,
+            allocation_item_fk="scenery_id",
+            ws_action="GET_SCENERY_ALLOCATIONS",
+        )

--- a/server/controllers/api/show/stage/scenery.py
+++ b/server/controllers/api/show/stage/scenery.py
@@ -1,6 +1,20 @@
 from sqlalchemy import select
 from tornado import escape
 
+from controllers.api.constants import (
+    ERROR_ALLOCATION_NOT_FOUND,
+    ERROR_CAST_MEMBER_NOT_FOUND,
+    ERROR_ID_MISSING,
+    ERROR_INVALID_ID,
+    ERROR_NAME_MISSING,
+    ERROR_SCENE_ID_MISSING,
+    ERROR_SCENE_NOT_FOUND,
+    ERROR_SCENERY_ID_MISSING,
+    ERROR_SCENERY_NOT_FOUND,
+    ERROR_SCENERY_TYPE_ID_MISSING,
+    ERROR_SCENERY_TYPE_NOT_FOUND,
+    ERROR_SHOW_NOT_FOUND,
+)
 from models.show import Scene, Show
 from models.stage import Scenery, SceneryAllocation, SceneryType
 from rbac.role import Role
@@ -28,7 +42,7 @@ class SceneryTypesController(BaseAPIController):
                 self.finish({"scenery_types": scenery_types})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -40,7 +54,7 @@ class SceneryTypesController(BaseAPIController):
             show = session.get(Show, show_id)
             if not show:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
             self.requires_role(show, Role.WRITE)
             data = escape.json_decode(self.request.body)
@@ -48,7 +62,7 @@ class SceneryTypesController(BaseAPIController):
             name = data.get("name", None)
             if not name:
                 self.set_status(400)
-                await self.finish({"message": "Name missing"})
+                await self.finish({"message": ERROR_NAME_MISSING})
                 return
 
             description = data.get("description", "")
@@ -79,7 +93,7 @@ class SceneryTypesController(BaseAPIController):
             show = session.get(Show, show_id)
             if not show:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
             self.requires_role(show, Role.WRITE)
             data = escape.json_decode(self.request.body)
@@ -87,20 +101,20 @@ class SceneryTypesController(BaseAPIController):
             prop_type = data.get("id", None)
             if not prop_type:
                 self.set_status(400)
-                await self.finish({"message": "ID missing"})
+                await self.finish({"message": ERROR_ID_MISSING})
                 return
 
             entry: SceneryType = session.get(SceneryType, prop_type)
             if not entry:
                 self.set_status(404)
-                await self.finish({"message": "404 scenery type not found"})
+                await self.finish({"message": ERROR_SCENERY_TYPE_NOT_FOUND})
                 return
 
             name = data.get("name", None)
             description = data.get("description", "")
             if not name:
                 self.set_status(400)
-                await self.finish({"message": "Name missing"})
+                await self.finish({"message": ERROR_NAME_MISSING})
                 return
 
             entry.name = name
@@ -122,27 +136,27 @@ class SceneryTypesController(BaseAPIController):
             show = session.get(Show, show_id)
             if not show:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
             self.requires_role(show, Role.WRITE)
 
             scenery_type_id_str = self.get_argument("id", None)
             if not scenery_type_id_str:
                 self.set_status(400)
-                await self.finish({"message": "ID missing"})
+                await self.finish({"message": ERROR_ID_MISSING})
                 return
 
             try:
                 scenery_type_id = int(scenery_type_id_str)
             except ValueError:
                 self.set_status(400)
-                await self.finish({"message": "Invalid ID"})
+                await self.finish({"message": ERROR_INVALID_ID})
                 return
 
             entry = session.get(SceneryType, scenery_type_id)
             if not entry:
                 self.set_status(404)
-                await self.finish({"message": "404 scenery type not found"})
+                await self.finish({"message": ERROR_SCENERY_TYPE_NOT_FOUND})
                 return
 
             session.delete(entry)
@@ -171,7 +185,7 @@ class SceneryController(BaseAPIController):
                 self.finish({"scenery": scenery})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -188,13 +202,13 @@ class SceneryController(BaseAPIController):
                 name = data.get("name", None)
                 if not name:
                     self.set_status(400)
-                    await self.finish({"message": "Name missing"})
+                    await self.finish({"message": ERROR_NAME_MISSING})
                     return
 
                 scenery_type_id = data.get("scenery_type_id", None)
                 if not scenery_type_id:
                     self.set_status(400)
-                    await self.finish({"message": "Scenery type ID missing"})
+                    await self.finish({"message": ERROR_SCENERY_TYPE_ID_MISSING})
                     return
                 try:
                     scenery_type_id = int(scenery_type_id)
@@ -231,7 +245,7 @@ class SceneryController(BaseAPIController):
                 await self.application.ws_send_to_all("NOOP", "GET_SCENERY_LIST", {})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -248,7 +262,7 @@ class SceneryController(BaseAPIController):
                 scenery = data.get("id", None)
                 if not scenery:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 entry: Scenery = session.get(Scenery, scenery)
@@ -256,14 +270,14 @@ class SceneryController(BaseAPIController):
                     name = data.get("name", None)
                     if not name:
                         self.set_status(400)
-                        await self.finish({"message": "Name missing"})
+                        await self.finish({"message": ERROR_NAME_MISSING})
                         return
                     entry.name = name
 
                     scenery_type_id = data.get("scenery_type_id", None)
                     if not scenery_type_id:
                         self.set_status(400)
-                        await self.finish({"message": "Scenery type ID missing"})
+                        await self.finish({"message": ERROR_SCENERY_TYPE_ID_MISSING})
                         return
                     try:
                         scenery_type_id = int(scenery_type_id)
@@ -297,11 +311,11 @@ class SceneryController(BaseAPIController):
                     )
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 cast member not found"})
+                    await self.finish({"message": ERROR_CAST_MEMBER_NOT_FOUND})
                     return
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -317,14 +331,14 @@ class SceneryController(BaseAPIController):
                 scenery_id_str = self.get_argument("id", None)
                 if not scenery_id_str:
                     self.set_status(400)
-                    await self.finish({"message": "ID missing"})
+                    await self.finish({"message": ERROR_ID_MISSING})
                     return
 
                 try:
                     scenery_id = int(scenery_id_str)
                 except ValueError:
                     self.set_status(400)
-                    await self.finish({"message": "Invalid ID"})
+                    await self.finish({"message": ERROR_INVALID_ID})
                     return
 
                 entry = session.get(Scenery, scenery_id)
@@ -340,10 +354,10 @@ class SceneryController(BaseAPIController):
                     )
                 else:
                     self.set_status(404)
-                    await self.finish({"message": "404 scenery not found"})
+                    await self.finish({"message": ERROR_SCENERY_NOT_FOUND})
             else:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
 
 @ApiRoute("show/stage/scenery/allocations", ApiVersion.V1)
@@ -370,7 +384,7 @@ class SceneryAllocationController(BaseAPIController):
                 self.finish({"allocations": allocations})
             else:
                 self.set_status(404)
-                self.finish({"message": "404 show not found"})
+                self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
     @requires_show
     @no_live_session
@@ -383,7 +397,7 @@ class SceneryAllocationController(BaseAPIController):
             show = session.get(Show, show_id)
             if not show:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
 
             self.requires_role(show, Role.WRITE)
@@ -393,7 +407,7 @@ class SceneryAllocationController(BaseAPIController):
             scenery_id = data.get("scenery_id", None)
             if scenery_id is None:
                 self.set_status(400)
-                await self.finish({"message": "scenery_id missing"})
+                await self.finish({"message": ERROR_SCENERY_ID_MISSING})
                 return
 
             try:
@@ -406,19 +420,19 @@ class SceneryAllocationController(BaseAPIController):
             scenery: Scenery = session.get(Scenery, scenery_id)
             if not scenery:
                 self.set_status(404)
-                await self.finish({"message": "404 scenery not found"})
+                await self.finish({"message": ERROR_SCENERY_NOT_FOUND})
                 return
 
             if scenery.show_id != show_id:
                 self.set_status(404)
-                await self.finish({"message": "404 scenery not found"})
+                await self.finish({"message": ERROR_SCENERY_NOT_FOUND})
                 return
 
             # Validate scene_id
             scene_id = data.get("scene_id", None)
             if scene_id is None:
                 self.set_status(400)
-                await self.finish({"message": "scene_id missing"})
+                await self.finish({"message": ERROR_SCENE_ID_MISSING})
                 return
 
             try:
@@ -431,12 +445,12 @@ class SceneryAllocationController(BaseAPIController):
             scene: Scene = session.get(Scene, scene_id)
             if not scene:
                 self.set_status(404)
-                await self.finish({"message": "404 scene not found"})
+                await self.finish({"message": ERROR_SCENE_NOT_FOUND})
                 return
 
             if scene.show_id != show_id:
                 self.set_status(404)
-                await self.finish({"message": "404 scene not found"})
+                await self.finish({"message": ERROR_SCENE_NOT_FOUND})
                 return
 
             # Check for duplicate allocation
@@ -475,7 +489,7 @@ class SceneryAllocationController(BaseAPIController):
             show = session.get(Show, show_id)
             if not show:
                 self.set_status(404)
-                await self.finish({"message": "404 show not found"})
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
                 return
 
             self.requires_role(show, Role.WRITE)
@@ -483,14 +497,14 @@ class SceneryAllocationController(BaseAPIController):
             allocation_id_str = self.get_argument("id", None)
             if not allocation_id_str:
                 self.set_status(400)
-                await self.finish({"message": "ID missing"})
+                await self.finish({"message": ERROR_ID_MISSING})
                 return
 
             try:
                 allocation_id = int(allocation_id_str)
             except ValueError:
                 self.set_status(400)
-                await self.finish({"message": "Invalid ID"})
+                await self.finish({"message": ERROR_INVALID_ID})
                 return
 
             allocation: SceneryAllocation = session.get(
@@ -498,14 +512,14 @@ class SceneryAllocationController(BaseAPIController):
             )
             if not allocation:
                 self.set_status(404)
-                await self.finish({"message": "404 allocation not found"})
+                await self.finish({"message": ERROR_ALLOCATION_NOT_FOUND})
                 return
 
             # Verify the allocation belongs to scenery in this show
             scenery: Scenery = session.get(Scenery, allocation.scenery_id)
             if not scenery or scenery.show_id != show_id:
                 self.set_status(404)
-                await self.finish({"message": "404 allocation not found"})
+                await self.finish({"message": ERROR_ALLOCATION_NOT_FOUND})
                 return
 
             session.delete(allocation)

--- a/server/controllers/api/user/overrides.py
+++ b/server/controllers/api/user/overrides.py
@@ -17,6 +17,9 @@ from utils.web.route import ApiRoute, ApiVersion
 from utils.web.web_decorators import api_authenticated
 
 
+VALID_TEXT_FORMATS = ("default", "upper", "lower")
+
+
 @ApiRoute("user/settings/stage_direction_overrides", ApiVersion.V1)
 class StageDirectionOverridesController(BaseAPIController):
     @api_authenticated
@@ -44,12 +47,8 @@ class StageDirectionOverridesController(BaseAPIController):
             await self.finish({"message": "Style ID missing"})
             return
 
-        bold: bool = data.get("bold", False)
-        italic: bool = data.get("italic", False)
-        underline: bool = data.get("underline", False)
-
         text_format: str = data.get("textFormat", None)
-        if not text_format or text_format not in ["default", "upper", "lower"]:
+        if not text_format or text_format not in VALID_TEXT_FORMATS:
             self.set_status(400)
             await self.finish({"message": ERROR_TEXT_FORMAT_INVALID})
             return
@@ -79,9 +78,9 @@ class StageDirectionOverridesController(BaseAPIController):
                 settings_type="stage_direction_styles",
                 settings_data={
                     "id": style_id,
-                    "bold": bold,
-                    "italic": italic,
-                    "underline": underline,
+                    "bold": data.get("bold", False),
+                    "italic": data.get("italic", False),
+                    "underline": data.get("underline", False),
                     "text_format": text_format,
                     "text_colour": text_colour,
                     "enable_background_colour": enable_background_colour,

--- a/server/controllers/api/user/overrides.py
+++ b/server/controllers/api/user/overrides.py
@@ -20,6 +20,93 @@ from utils.web.web_decorators import api_authenticated
 VALID_TEXT_FORMATS = ("default", "upper", "lower")
 
 
+async def handle_override_patch(
+    controller, ws_action, success_message, not_found_message
+):
+    """
+    Handle PATCH request for user override controllers.
+
+    :param controller: The controller instance handling the request
+    :param ws_action: WebSocket action to send on success
+    :param success_message: Success message to return
+    :param not_found_message: Not found error message
+    """
+    data = escape.json_decode(controller.request.body)
+    settings_id = data.get("id", None)
+    if not settings_id:
+        controller.set_status(400)
+        await controller.finish({"message": ERROR_ID_MISSING})
+        return
+
+    with controller.make_session() as session:
+        entry: UserOverrides = session.get(UserOverrides, settings_id)
+        if entry:
+            if entry.user_id != controller.current_user["id"]:
+                controller.set_status(403)
+                await controller.finish()
+                return
+
+            merge_settings = data.copy()
+            del merge_settings["id"]
+            entry.update_settings(merge_settings)
+            session.commit()
+
+            controller.set_status(200)
+            await controller.finish({"message": success_message})
+
+            await controller.application.ws_send_to_user(
+                controller.current_user["id"],
+                "NOOP",
+                ws_action,
+                {},
+            )
+        else:
+            controller.set_status(404)
+            await controller.finish({"message": not_found_message})
+
+
+async def handle_override_delete(
+    controller, ws_action, success_message, not_found_message
+):
+    """
+    Handle DELETE request for user override controllers.
+
+    :param controller: The controller instance handling the request
+    :param ws_action: WebSocket action to send on success
+    :param success_message: Success message to return
+    :param not_found_message: Not found error message
+    """
+    settings_id = controller.get_argument("id", None)
+    if not settings_id:
+        controller.set_status(400)
+        await controller.finish({"message": ERROR_ID_MISSING})
+        return
+
+    with controller.make_session() as session:
+        entry: UserOverrides = session.get(UserOverrides, int(settings_id))
+        if entry:
+            if entry.user_id != controller.current_user["id"]:
+                controller.set_status(403)
+                await controller.finish()
+                return
+
+            session.delete(entry)
+            session.commit()
+
+            controller.set_status(200)
+            await controller.finish({"message": success_message})
+
+            await controller.application.ws_send_to_user(
+                controller.current_user["id"],
+                "NOOP",
+                ws_action,
+                {},
+            )
+        else:
+            controller.set_status(404)
+            await controller.finish({"message": not_found_message})
+
+
 @ApiRoute("user/settings/stage_direction_overrides", ApiVersion.V1)
 class StageDirectionOverridesController(BaseAPIController):
     @api_authenticated
@@ -107,76 +194,21 @@ class StageDirectionOverridesController(BaseAPIController):
 
     @api_authenticated
     async def patch(self):
-        data = escape.json_decode(self.request.body)
-        settings_id = data.get("id", None)
-        if not settings_id:
-            self.set_status(400)
-            await self.finish({"message": ERROR_ID_MISSING})
-            return
-
-        with self.make_session() as session:
-            entry: UserOverrides = session.get(UserOverrides, settings_id)
-            if entry:
-                if entry.user_id != self.current_user["id"]:
-                    self.set_status(403)
-                    await self.finish()
-
-                merge_settings = data.copy()
-                del merge_settings["id"]
-                entry.update_settings(merge_settings)
-                session.commit()
-
-                self.set_status(200)
-                await self.finish(
-                    {"message": "Successfully edited stage direction style override"}
-                )
-
-                await self.application.ws_send_to_user(
-                    self.current_user["id"],
-                    "NOOP",
-                    "GET_STAGE_DIRECTION_STYLE_OVERRIDES",
-                    {},
-                )
-            else:
-                self.set_status(404)
-                await self.finish(
-                    {"message": "Stage direction style override not found"}
-                )
+        await handle_override_patch(
+            self,
+            "GET_STAGE_DIRECTION_STYLE_OVERRIDES",
+            "Successfully edited stage direction style override",
+            "Stage direction style override not found",
+        )
 
     @api_authenticated
     async def delete(self):
-        settings_id = self.get_argument("id", None)
-        if not settings_id:
-            self.set_status(400)
-            await self.finish({"message": ERROR_ID_MISSING})
-            return
-
-        with self.make_session() as session:
-            entry: UserOverrides = session.get(UserOverrides, int(settings_id))
-            if entry:
-                if entry.user_id != self.current_user["id"]:
-                    self.set_status(403)
-                    await self.finish()
-
-                session.delete(entry)
-                session.commit()
-
-                self.set_status(200)
-                await self.finish(
-                    {"message": "Successfully deleted stage direction style override"}
-                )
-
-                await self.application.ws_send_to_user(
-                    self.current_user["id"],
-                    "NOOP",
-                    "GET_STAGE_DIRECTION_STYLE_OVERRIDES",
-                    {},
-                )
-            else:
-                self.set_status(404)
-                await self.finish(
-                    {"message": "Stage direction style override not found"}
-                )
+        await handle_override_delete(
+            self,
+            "GET_STAGE_DIRECTION_STYLE_OVERRIDES",
+            "Successfully deleted stage direction style override",
+            "Stage direction style override not found",
+        )
 
 
 @ApiRoute("user/settings/cue_colour_overrides", ApiVersion.V1)
@@ -247,69 +279,18 @@ class CueColourOverridesController(BaseAPIController):
 
     @api_authenticated
     async def patch(self):
-        data = escape.json_decode(self.request.body)
-        settings_id = data.get("id", None)
-        if not settings_id:
-            self.set_status(400)
-            await self.finish({"message": ERROR_ID_MISSING})
-            return
-
-        with self.make_session() as session:
-            entry: UserOverrides = session.get(UserOverrides, settings_id)
-            if entry:
-                if entry.user_id != self.current_user["id"]:
-                    self.set_status(403)
-                    await self.finish()
-
-                merge_settings = data.copy()
-                del merge_settings["id"]
-                entry.update_settings(merge_settings)
-                session.commit()
-
-                self.set_status(200)
-                await self.finish(
-                    {"message": "Successfully edited cue colour override"}
-                )
-
-                await self.application.ws_send_to_user(
-                    self.current_user["id"],
-                    "NOOP",
-                    "GET_CUE_COLOUR_OVERRIDES",
-                    {},
-                )
-            else:
-                self.set_status(404)
-                await self.finish({"message": "Cue colour override not found"})
+        await handle_override_patch(
+            self,
+            "GET_CUE_COLOUR_OVERRIDES",
+            "Successfully edited cue colour override",
+            "Cue colour override not found",
+        )
 
     @api_authenticated
     async def delete(self):
-        settings_id = self.get_argument("id", None)
-        if not settings_id:
-            self.set_status(400)
-            await self.finish({"message": ERROR_ID_MISSING})
-            return
-
-        with self.make_session() as session:
-            entry: UserOverrides = session.get(UserOverrides, int(settings_id))
-            if entry:
-                if entry.user_id != self.current_user["id"]:
-                    self.set_status(403)
-                    await self.finish()
-
-                session.delete(entry)
-                session.commit()
-
-                self.set_status(200)
-                await self.finish(
-                    {"message": "Successfully deleted cue colour override"}
-                )
-
-                await self.application.ws_send_to_user(
-                    self.current_user["id"],
-                    "NOOP",
-                    "GET_CUE_COLOUR_OVERRIDES",
-                    {},
-                )
-            else:
-                self.set_status(404)
-                await self.finish({"message": "Cue colour override not found"})
+        await handle_override_delete(
+            self,
+            "GET_CUE_COLOUR_OVERRIDES",
+            "Successfully deleted cue colour override",
+            "Cue colour override not found",
+        )

--- a/server/controllers/api/user/overrides.py
+++ b/server/controllers/api/user/overrides.py
@@ -2,6 +2,13 @@ from typing import List
 
 from tornado import escape
 
+from controllers.api.constants import (
+    ERROR_BACKGROUND_COLOUR_MISSING,
+    ERROR_COLOUR_MISSING,
+    ERROR_ID_MISSING,
+    ERROR_TEXT_COLOUR_MISSING,
+    ERROR_TEXT_FORMAT_INVALID,
+)
 from models.cue import CueType
 from models.script import StageDirectionStyle
 from models.user import UserOverrides
@@ -44,20 +51,20 @@ class StageDirectionOverridesController(BaseAPIController):
         text_format: str = data.get("textFormat", None)
         if not text_format or text_format not in ["default", "upper", "lower"]:
             self.set_status(400)
-            await self.finish({"message": "Text format missing or invalid"})
+            await self.finish({"message": ERROR_TEXT_FORMAT_INVALID})
             return
 
         text_colour: str = data.get("textColour", None)
         if not text_colour:
             self.set_status(400)
-            await self.finish({"message": "Text colour missing"})
+            await self.finish({"message": ERROR_TEXT_COLOUR_MISSING})
             return
 
         enable_background_colour: bool = data.get("enableBackgroundColour", False)
         background_colour: str = data.get("backgroundColour", None)
         if enable_background_colour and not background_colour:
             self.set_status(400)
-            await self.finish({"message": "Background colour missing"})
+            await self.finish({"message": ERROR_BACKGROUND_COLOUR_MISSING})
             return
 
         with self.make_session() as session:
@@ -105,7 +112,7 @@ class StageDirectionOverridesController(BaseAPIController):
         settings_id = data.get("id", None)
         if not settings_id:
             self.set_status(400)
-            await self.finish({"message": "ID missing"})
+            await self.finish({"message": ERROR_ID_MISSING})
             return
 
         with self.make_session() as session:
@@ -142,7 +149,7 @@ class StageDirectionOverridesController(BaseAPIController):
         settings_id = self.get_argument("id", None)
         if not settings_id:
             self.set_status(400)
-            await self.finish({"message": "ID missing"})
+            await self.finish({"message": ERROR_ID_MISSING})
             return
 
         with self.make_session() as session:
@@ -203,7 +210,7 @@ class CueColourOverridesController(BaseAPIController):
         colour: str = data.get("colour", None)
         if not colour:
             self.set_status(400)
-            await self.finish({"message": "Colour missing"})
+            await self.finish({"message": ERROR_COLOUR_MISSING})
             return
 
         with self.make_session() as session:
@@ -245,7 +252,7 @@ class CueColourOverridesController(BaseAPIController):
         settings_id = data.get("id", None)
         if not settings_id:
             self.set_status(400)
-            await self.finish({"message": "ID missing"})
+            await self.finish({"message": ERROR_ID_MISSING})
             return
 
         with self.make_session() as session:
@@ -280,7 +287,7 @@ class CueColourOverridesController(BaseAPIController):
         settings_id = self.get_argument("id", None)
         if not settings_id:
             self.set_status(400)
-            await self.finish({"message": "ID missing"})
+            await self.finish({"message": ERROR_ID_MISSING})
             return
 
         with self.make_session() as session:

--- a/server/test/controllers/api/show/stage/test_props.py
+++ b/server/test/controllers/api/show/stage/test_props.py
@@ -215,7 +215,7 @@ class TestPropsAllocationController(DigiScriptTestCase):
         )
         self.assertEqual(400, response.code)
         response_body = tornado.escape.json_decode(response.body)
-        self.assertIn("scene_id missing", response_body["message"])
+        self.assertIn("Scene ID missing", response_body["message"])
 
     def test_create_allocation_no_show(self):
         """Test POST returns 400 when no show is loaded."""

--- a/server/test/controllers/api/show/stage/test_scenery.py
+++ b/server/test/controllers/api/show/stage/test_scenery.py
@@ -221,7 +221,7 @@ class TestSceneryAllocationController(DigiScriptTestCase):
         )
         self.assertEqual(400, response.code)
         response_body = tornado.escape.json_decode(response.body)
-        self.assertIn("scene_id missing", response_body["message"])
+        self.assertIn("Scene ID missing", response_body["message"])
 
     def test_create_allocation_no_show(self):
         """Test POST returns 400 when no show is loaded."""


### PR DESCRIPTION
## Summary
Reduce code duplication to pass SonarQube quality gate (from ~7.7% to 2.3%, threshold ≤3%).

### Changes

**Python Error Constants (`server/controllers/api/constants.py`)**
- Centralized 40+ duplicated error message strings across 17+ controller files
- Constants include: `ERROR_SHOW_NOT_FOUND`, `ERROR_ID_MISSING`, `ERROR_NAME_MISSING`, etc.

**Vue Form Validation Mixin (`client/src/mixins/formValidationMixin.js`)**
- Created reusable mixin with `getValidationState()`, `resetForm()`, `hasFormErrors()`
- Updated 9 Vue components to use the mixin instead of duplicated validation methods

**Stage Direction Styles Helper (`server/controllers/api/show/script/stage_direction_styles.py`)**
- Extracted `validate_style_fields()` helper to reduce duplication between `post()` and `patch()` methods

**User Overrides Helpers (`server/controllers/api/user/overrides.py`)**
- Extracted `handle_override_patch()` and `handle_override_delete()` helpers
- Both `StageDirectionOverridesController` and `CueColourOverridesController` now share common CRUD logic

**Stage Controller Helpers (`server/controllers/api/show/stage/helpers.py`)**
- Created new module with shared helpers for props and scenery controllers:
  - `handle_type_post()`, `handle_type_patch()`, `handle_type_delete()` - for PropType/SceneryType CRUD
  - `handle_allocation_post()`, `handle_allocation_delete()` - for scene allocation management
- Updated `props.py` and `scenery.py` to use these shared helpers

### Files Changed
- `server/controllers/api/constants.py` (new)
- `server/controllers/api/show/stage/helpers.py` (new)
- `client/src/mixins/formValidationMixin.js` (new)
- 17+ Python controller files updated to use constants
- 9 Vue components updated to use form validation mixin
- `props.py`, `scenery.py`, `overrides.py`, `stage_direction_styles.py` refactored

## Test plan
- [x] ESLint/Prettier pass (frontend)
- [x] Ruff pass (backend)
- [x] Frontend tests pass
- [x] Backend tests pass (447 tests)
- [x] SonarQube duplication metric: 2.3% (below 3% threshold)

🤖 Generated with [Claude Code](https://claude.ai/code)