### PR TITLE
Fix script revision linked list corruption and add FK constraints

### DIFF
--- a/server/alembic_config/versions/c2f8d4a6e0b3_repair_script_revision_linked_lists.py
+++ b/server/alembic_config/versions/c2f8d4a6e0b3_repair_script_revision_linked_lists.py
@@ -1,0 +1,241 @@
+"""repair_script_revision_linked_lists
+
+Revision ID: c2f8d4a6e0b3
+Revises: c1db8c1f4e37
+Create Date: 2026-02-25 00:00:00.000000
+
+Repairs broken ScriptLineRevisionAssociation linked list pointers.
+
+For each revision, walks pages using bridge detection (same logic as the
+GET /api/v1/show/script?page=N endpoint):
+  - Bridge line of page N = the line whose previous_line_id points to a
+    line on page N-1 (looked up from script_lines directly, not from the
+    revision associations — the previous line may have been removed from
+    this revision while still existing in script_lines).
+  - Walks next_line_id within each page to build page-local order.
+
+Rebuilds next_line_id / previous_line_id for all pointer mismatches.
+Deletes true orphans (lines not reachable by any page-local walk).
+
+FK constraints are added in the subsequent migration
+(d3e9f0c1a2b4_add_script_revision_fk_constraints.py), which must run
+against clean data — that is why the repair is committed first.
+"""
+
+from collections import defaultdict
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c2f8d4a6e0b3"
+down_revision: Union[str, None] = "c1db8c1f4e37"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers: page walk + repair logic (mirrors diagnose_linked_list.py)
+# ---------------------------------------------------------------------------
+
+
+def _page_walk(conn, revision_id):
+    """Walk pages using bridge detection. Returns {page: [line_id, ...]}.
+
+    Bridge detection: the first line of page N is the line whose
+    previous_line_id points to a line on page N-1 (read directly from
+    script_lines, not from the association — the previous line may have been
+    removed from this revision while still existing in script_lines).
+    """
+    rows = conn.execute(
+        sa.text(
+            """
+            SELECT a.line_id, a.next_line_id, a.previous_line_id,
+                   l.page AS line_page,
+                   lp.page AS prev_page
+            FROM script_line_revision_association a
+            JOIN script_lines l ON l.id = a.line_id
+            LEFT JOIN script_lines lp ON lp.id = a.previous_line_id
+            WHERE a.revision_id = :rev_id
+            """
+        ),
+        {"rev_id": revision_id},
+    ).fetchall()
+
+    # Group associations by page
+    by_page = defaultdict(dict)
+    for row in rows:
+        line_id = row[0]
+        next_line_id = row[1]
+        prev_line_id = row[2]
+        page = row[3] if row[3] is not None else 0
+        prev_page = row[4]
+
+        by_page[page][line_id] = {
+            "next": next_line_id,
+            "prev": prev_line_id,
+            "prev_page": prev_page,
+        }
+
+    result = {}
+
+    for page in sorted(by_page.keys()):
+        page_lines = by_page[page]
+
+        # Find the bridge line (first line on this page):
+        #   - previous_line_id IS NULL  (global head), or
+        #   - previous_line.page == page - 1  (cross-page pointer)
+        first_line_id = None
+        for line_id, d in page_lines.items():
+            prev_id = d["prev"]
+            prev_page = d["prev_page"]
+            if prev_id is None or (prev_page is not None and prev_page == page - 1):
+                first_line_id = line_id
+                break
+
+        if first_line_id is None:
+            result[page] = []
+            continue
+
+        # Walk within this page following next_line_id
+        ordered = []
+        current = first_line_id
+        seen = set()
+        while current is not None and current in page_lines:
+            if current in seen:
+                break  # loop guard
+            seen.add(current)
+            ordered.append(current)
+            current = page_lines[current]["next"]
+
+        result[page] = ordered
+
+    return result
+
+
+def _repair_revision(conn, revision_id):
+    """Repair linked list pointers for one revision.
+
+    Returns a summary dict with counts of changes applied.
+    """
+    page_ordered = _page_walk(conn, revision_id)
+
+    # Build global order from sorted pages
+    global_order = []
+    for page in sorted(page_ordered.keys()):
+        global_order.extend(page_ordered[page])
+
+    # Compute expected pointers for every line in the repaired chain
+    expected = {}
+    for i, line_id in enumerate(global_order):
+        expected[line_id] = (
+            global_order[i + 1] if i + 1 < len(global_order) else None,  # next
+            global_order[i - 1] if i > 0 else None,  # prev
+        )
+
+    # Fetch current state from DB
+    current_rows = conn.execute(
+        sa.text(
+            "SELECT line_id, next_line_id, previous_line_id "
+            "FROM script_line_revision_association WHERE revision_id = :rev_id"
+        ),
+        {"rev_id": revision_id},
+    ).fetchall()
+    current_by_id = {row[0]: (row[1], row[2]) for row in current_rows}
+
+    # Lines that need pointer correction
+    updates = []  # (new_next, new_prev, revision_id, line_id)
+    for line_id, (exp_next, exp_prev) in expected.items():
+        curr_next, curr_prev = current_by_id.get(line_id, (None, None))
+        if curr_next != exp_next or curr_prev != exp_prev:
+            updates.append((exp_next, exp_prev, revision_id, line_id))
+
+    # True orphans: in the revision but not reached by any page-local walk
+    reachable_set = set(global_order)
+    orphan_ids = set(current_by_id.keys()) - reachable_set
+
+    if orphan_ids:
+        print(
+            f"  Revision {revision_id}: deleting {len(orphan_ids)} orphan(s): "
+            f"{sorted(orphan_ids)}"
+        )
+        # Delete cue associations for orphaned lines first (FK ordering)
+        for orphan_id in orphan_ids:
+            conn.execute(
+                sa.text(
+                    "DELETE FROM script_cue_association "
+                    "WHERE revision_id = :rev_id AND line_id = :line_id"
+                ),
+                {"rev_id": revision_id, "line_id": orphan_id},
+            )
+        # Delete the orphaned associations themselves
+        for orphan_id in orphan_ids:
+            conn.execute(
+                sa.text(
+                    "DELETE FROM script_line_revision_association "
+                    "WHERE revision_id = :rev_id AND line_id = :line_id"
+                ),
+                {"rev_id": revision_id, "line_id": orphan_id},
+            )
+
+    if updates:
+        print(
+            f"  Revision {revision_id}: fixing {len(updates)} pointer(s) "
+            f"(out of {len(current_by_id)} associations)"
+        )
+        for new_next, new_prev, rev_id, line_id in updates:
+            conn.execute(
+                sa.text(
+                    "UPDATE script_line_revision_association "
+                    "SET next_line_id = :next_id, previous_line_id = :prev_id "
+                    "WHERE revision_id = :rev_id AND line_id = :line_id"
+                ),
+                {
+                    "next_id": new_next,
+                    "prev_id": new_prev,
+                    "rev_id": rev_id,
+                    "line_id": line_id,
+                },
+            )
+
+    return {
+        "revision_id": revision_id,
+        "total": len(current_by_id),
+        "pointer_updates": len(updates),
+        "orphans_deleted": len(orphan_ids),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Migration
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    print("Repairing ScriptLineRevisionAssociation linked lists…")
+
+    revision_ids = [
+        row[0]
+        for row in conn.execute(
+            sa.text("SELECT id FROM script_revisions ORDER BY id")
+        ).fetchall()
+    ]
+
+    total_updates = 0
+    total_orphans = 0
+    for rev_id in revision_ids:
+        result = _repair_revision(conn, rev_id)
+        total_updates += result["pointer_updates"]
+        total_orphans += result["orphans_deleted"]
+
+    print(
+        f"Repair complete: {total_updates} pointer fix(es), "
+        f"{total_orphans} orphan(s) deleted across {len(revision_ids)} revision(s)."
+    )
+
+
+def downgrade() -> None:
+    pass  # data repair cannot be reversed

--- a/server/alembic_config/versions/d3e9f0c1a2b4_add_script_revision_fk_constraints.py
+++ b/server/alembic_config/versions/d3e9f0c1a2b4_add_script_revision_fk_constraints.py
@@ -1,0 +1,69 @@
+"""add_script_revision_fk_constraints
+
+Revision ID: d3e9f0c1a2b4
+Revises: c2f8d4a6e0b3
+Create Date: 2026-02-25 00:00:00.000000
+
+Adds composite self-referential FK constraints to prevent cross-revision
+linked list pointer corruption:
+
+  (revision_id, next_line_id)     → (revision_id, line_id)  DEFERRABLE INITIALLY DEFERRED
+  (revision_id, previous_line_id) → (revision_id, line_id)  DEFERRABLE INITIALLY DEFERRED
+
+Must run AFTER c2f8d4a6e0b3 (data repair), because Alembic's SQLite batch
+mode executes `INSERT INTO _tmp SELECT * FROM original` in autocommit mode.
+In autocommit mode, SQLite treats DEFERRABLE INITIALLY DEFERRED as IMMEDIATE
+(there is no surrounding transaction to defer to), so the FK check fires
+right after the INSERT.  If the data still contained broken pointers, that
+INSERT would fail with an IntegrityError.
+
+With the repair committed first, every (revision_id, next_line_id) and
+(revision_id, previous_line_id) value already exists as a valid
+(revision_id, line_id) pair, so the batch INSERT succeeds immediately.
+
+DEFERRABLE INITIALLY DEFERRED is still the correct semantics for
+application-level usage: during revision creation, associations are inserted
+one at a time, and SQLAlchemy uses explicit BEGIN/COMMIT transactions, so
+deferred checking fires at COMMIT (when all rows are present).
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d3e9f0c1a2b4"
+down_revision: Union[str, None] = "c2f8d4a6e0b3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    print("Adding composite FK constraints to script_line_revision_association…")
+
+    with op.batch_alter_table("script_line_revision_association") as batch_op:
+        batch_op.create_foreign_key(
+            "fk_slra_next_same_revision",
+            "script_line_revision_association",
+            ["revision_id", "next_line_id"],
+            ["revision_id", "line_id"],
+            deferrable=True,
+            initially="DEFERRED",
+        )
+        batch_op.create_foreign_key(
+            "fk_slra_prev_same_revision",
+            "script_line_revision_association",
+            ["revision_id", "previous_line_id"],
+            ["revision_id", "line_id"],
+            deferrable=True,
+            initially="DEFERRED",
+        )
+
+    print("FK constraints added.")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("script_line_revision_association") as batch_op:
+        batch_op.drop_constraint("fk_slra_next_same_revision", type_="foreignkey")
+        batch_op.drop_constraint("fk_slra_prev_same_revision", type_="foreignkey")

--- a/server/models/script.py
+++ b/server/models/script.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     Boolean,
     DateTime,
     ForeignKey,
+    ForeignKeyConstraint,
     Integer,
     String,
     TypeDecorator,
@@ -149,6 +150,32 @@ class ScriptLine(db.Model):
 
 class ScriptLineRevisionAssociation(db.Model, DeleteMixin):
     __tablename__ = "script_line_revision_association"
+    __table_args__ = (
+        # Self-referential composite FK constraints enforce that next_line_id and
+        # previous_line_id always point to lines within the same revision.
+        # DEFERRABLE INITIALLY DEFERRED: checked at COMMIT, not at INSERT, so that
+        # lines can be inserted in any order during revision creation.
+        ForeignKeyConstraint(
+            ["revision_id", "next_line_id"],
+            [
+                "script_line_revision_association.revision_id",
+                "script_line_revision_association.line_id",
+            ],
+            name="fk_slra_next_same_revision",
+            deferrable=True,
+            initially="DEFERRED",
+        ),
+        ForeignKeyConstraint(
+            ["revision_id", "previous_line_id"],
+            [
+                "script_line_revision_association.revision_id",
+                "script_line_revision_association.line_id",
+            ],
+            name="fk_slra_prev_same_revision",
+            deferrable=True,
+            initially="DEFERRED",
+        ),
+    )
 
     revision_id: Mapped[int] = mapped_column(
         ForeignKey("script_revisions.id"), primary_key=True, index=True

--- a/server/test/controllers/api/show/script/test_revision_fk_constraints.py
+++ b/server/test/controllers/api/show/script/test_revision_fk_constraints.py
@@ -1,0 +1,199 @@
+"""Tests for the composite FK constraints on ScriptLineRevisionAssociation.
+
+The constraints (added by migration c2f8d4a6e0b3) enforce that next_line_id
+and previous_line_id always reference a line within the same revision:
+
+  (revision_id, next_line_id)     → (revision_id, line_id)  DEFERRABLE INITIALLY DEFERRED
+  (revision_id, previous_line_id) → (revision_id, line_id)  DEFERRABLE INITIALLY DEFERRED
+
+These tests use skip_migrations=True (in-memory SQLite), so constraints are
+present because __table_args__ in ScriptLineRevisionAssociation includes them.
+FK enforcement is enabled via the PRAGMA foreign_keys=ON event listener in
+utils/database.py.
+
+DEFERRED constraints: the IntegrityError fires at session.commit() (end of
+the `with` block), not at flush time.
+"""
+
+from sqlalchemy.exc import IntegrityError
+
+from models.script import (
+    Script,
+    ScriptLine,
+    ScriptLineRevisionAssociation,
+    ScriptLineType,
+    ScriptRevision,
+)
+from models.show import Show, ShowScriptType
+from test.conftest import DigiScriptTestCase
+
+
+class TestRevisionLinkedListFKConstraints(DigiScriptTestCase):
+    """Verify the composite self-referential FK constraints on
+    script_line_revision_association are enforced by SQLite."""
+
+    def _create_show_script_revision(self, session, revision_num=1):
+        """Helper: create show → script → revision, return (script_id, revision_id)."""
+        show = Show(name=f"Test Show {revision_num}", script_mode=ShowScriptType.FULL)
+        session.add(show)
+        session.flush()
+
+        script = Script(show_id=show.id)
+        session.add(script)
+        session.flush()
+
+        revision = ScriptRevision(
+            script_id=script.id,
+            revision=revision_num,
+            description=f"Rev {revision_num}",
+        )
+        session.add(revision)
+        session.flush()
+
+        script.current_revision = revision.id
+        return script.id, revision.id
+
+    def _make_line(self, session, page=1):
+        """Helper: create a bare ScriptLine (no act/scene required)."""
+        line = ScriptLine(
+            act_id=None,
+            scene_id=None,
+            page=page,
+            line_type=ScriptLineType.DIALOGUE,
+        )
+        session.add(line)
+        session.flush()
+        return line.id
+
+    def test_null_pointers_always_valid(self):
+        """A single-line revision with NULL next/prev commits without error."""
+        with self._app.get_db().sessionmaker() as session:
+            _, revision_id = self._create_show_script_revision(session)
+            line_id = self._make_line(session)
+
+            assoc = ScriptLineRevisionAssociation(
+                revision_id=revision_id,
+                line_id=line_id,
+                next_line_id=None,
+                previous_line_id=None,
+            )
+            session.add(assoc)
+            # No exception expected — NULL FK values are always valid
+
+    def test_next_line_id_must_be_in_same_revision(self):
+        """next_line_id pointing to a line in a different revision raises IntegrityError."""
+        # Set up: two revisions, each with one line
+        with self._app.get_db().sessionmaker() as session:
+            _, revision_a_id = self._create_show_script_revision(session, 1)
+            line_a_id = self._make_line(session, page=1)
+            assoc_a = ScriptLineRevisionAssociation(
+                revision_id=revision_a_id,
+                line_id=line_a_id,
+                next_line_id=None,
+                previous_line_id=None,
+            )
+            session.add(assoc_a)
+
+            _, revision_b_id = self._create_show_script_revision(session, 2)
+            line_b_id = self._make_line(session, page=1)
+            assoc_b = ScriptLineRevisionAssociation(
+                revision_id=revision_b_id,
+                line_id=line_b_id,
+                next_line_id=None,
+                previous_line_id=None,
+            )
+            session.add(assoc_b)
+            # Both associations committed cleanly so far
+
+        # Now try to make revision A's line point to revision B's line
+        with self.assertRaises(IntegrityError):
+            with self._app.get_db().sessionmaker() as session:
+                assoc = session.get(
+                    ScriptLineRevisionAssociation,
+                    {"revision_id": revision_a_id, "line_id": line_a_id},
+                )
+                # line_b_id exists in script_lines (satisfies the simple FK)
+                # but (revision_a_id, line_b_id) does NOT exist in the association
+                # table → composite FK violation fires at commit
+                assoc.next_line_id = line_b_id
+
+    def test_previous_line_id_must_be_in_same_revision(self):
+        """previous_line_id pointing to a line in a different revision raises IntegrityError."""
+        with self._app.get_db().sessionmaker() as session:
+            _, revision_a_id = self._create_show_script_revision(session, 1)
+            line_a_id = self._make_line(session, page=1)
+            session.add(
+                ScriptLineRevisionAssociation(
+                    revision_id=revision_a_id,
+                    line_id=line_a_id,
+                    next_line_id=None,
+                    previous_line_id=None,
+                )
+            )
+
+            _, revision_b_id = self._create_show_script_revision(session, 2)
+            line_b_id = self._make_line(session, page=1)
+            session.add(
+                ScriptLineRevisionAssociation(
+                    revision_id=revision_b_id,
+                    line_id=line_b_id,
+                    next_line_id=None,
+                    previous_line_id=None,
+                )
+            )
+
+        with self.assertRaises(IntegrityError):
+            with self._app.get_db().sessionmaker() as session:
+                assoc = session.get(
+                    ScriptLineRevisionAssociation,
+                    {"revision_id": revision_a_id, "line_id": line_a_id},
+                )
+                # (revision_a_id, line_b_id) doesn't exist → composite FK violation
+                assoc.previous_line_id = line_b_id
+
+    def test_valid_chain_in_same_revision_accepted(self):
+        """A well-formed 3-line chain within one revision commits cleanly.
+
+        Because the constraints are DEFERRED, we can insert associations in any
+        order (all with NULL pointers first) and then update the pointers — the
+        FK check only runs at COMMIT time, when all rows are present.
+        """
+        with self._app.get_db().sessionmaker() as session:
+            _, revision_id = self._create_show_script_revision(session)
+
+            line1_id = self._make_line(session, page=1)
+            line2_id = self._make_line(session, page=1)
+            line3_id = self._make_line(session, page=1)
+
+            # Insert with NULL pointers first (deferred FK allows this)
+            for lid in (line1_id, line2_id, line3_id):
+                session.add(
+                    ScriptLineRevisionAssociation(
+                        revision_id=revision_id,
+                        line_id=lid,
+                        next_line_id=None,
+                        previous_line_id=None,
+                    )
+                )
+            session.flush()
+
+            # Now wire up the chain
+            a1 = session.get(
+                ScriptLineRevisionAssociation,
+                {"revision_id": revision_id, "line_id": line1_id},
+            )
+            a2 = session.get(
+                ScriptLineRevisionAssociation,
+                {"revision_id": revision_id, "line_id": line2_id},
+            )
+            a3 = session.get(
+                ScriptLineRevisionAssociation,
+                {"revision_id": revision_id, "line_id": line3_id},
+            )
+
+            a1.next_line_id = line2_id
+            a2.previous_line_id = line1_id
+            a2.next_line_id = line3_id
+            a3.previous_line_id = line2_id
+            # All (revision_id, next/prev_line_id) pairs exist in the table
+            # → commit succeeds


### PR DESCRIPTION
## Summary

Backports two data-consistency fixes from `feature/collaborative-editing` as a standalone PR. No collaborative editing functionality is included.

- **Repair migration** (`c2f8d4a6e0b3`): walks every revision's linked list, rebuilds pointer mismatches, and deletes true orphans (lines unreachable by any page walk). This is a pre-existing bug — the corruption can occur independently of collaborative editing.
- **FK constraint migration** (`d3e9f0c1a2b4`): adds composite self-referential FK constraints on `(revision_id, next_line_id)` and `(revision_id, previous_line_id)`, both `DEFERRABLE INITIALLY DEFERRED`, to prevent cross-revision pointer corruption at the schema level going forward.
- **Model update** (`server/models/script.py`): adds matching `__table_args__` to `ScriptLineRevisionAssociation` so `alembic check` passes in CI.

**Why repair before constraint?** Alembic's SQLite batch mode runs the table copy in autocommit mode. In autocommit, SQLite enforces `DEFERRABLE INITIALLY DEFERRED` constraints immediately (no surrounding transaction), so the batch `INSERT INTO _tmp SELECT * FROM original` would fail on any broken pointer. Committing the repair first guarantees clean data before the constraint is applied.

## Follow-up for `feature/collaborative-editing`

After this merges to `dev`, the collab branch needs:
1. Delete `c2f8d4a6e0b3_repair_script_revision_linked_lists.py` (now in dev)
2. Delete `d3e9f0c1a2b4_add_script_revision_fk_constraints.py` (now in dev)
3. Update merge migration `14f82e306537_.py` — change `down_revision` from `("43fcd5292e0f", "c1db8c1f4e37")` to `("43fcd5292e0f", "d3e9f0c1a2b4")`

## Test plan

- [x] `ruff check` — no lint errors
- [x] `ruff format --check` — no format issues
- [x] `alembic upgrade head` — both migrations apply cleanly
- [x] `alembic check` — no schema drift detected
- [x] `pytest` — 562/562 tests pass
- [ ] CI: `check-database-migrations`, `pylint` (ruff) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)