### PR TITLE
Add stage direction style import from other shows

### DIFF
--- a/client/src/store/modules/script.js
+++ b/client/src/store/modules/script.js
@@ -326,6 +326,17 @@ export default {
         Vue.$toast.error('Unable to edit stage direction style');
       }
     },
+    async GET_IMPORTABLE_STAGE_DIRECTION_STYLES() {
+      const response = await fetch(
+        `${makeURL('/api/v1/show/script/stage_direction_styles/import')}`,
+        { method: 'GET' }
+      );
+      if (!response.ok) {
+        log.error('Unable to fetch importable stage direction styles');
+        throw new Error('Failed to fetch importable styles');
+      }
+      return response.json();
+    },
     async GET_COMPILED_SCRIPTS(context) {
       const response = await fetch(`${makeURL('/api/v1/show/script/compiled_scripts')}`, {
         method: 'GET',

--- a/client/src/vue_components/show/config/script/StageDirectionStyles.vue
+++ b/client/src/vue_components/show/config/script/StageDirectionStyles.vue
@@ -11,6 +11,71 @@
       <b-button v-if="IS_SCRIPT_EDITOR" v-b-modal.new-config-modal variant="outline-success">
         New Style
       </b-button>
+      <b-button
+        v-if="IS_SCRIPT_EDITOR"
+        variant="outline-info"
+        class="ml-2"
+        @click="openImportModal"
+      >
+        Import Style
+      </b-button>
+      <b-modal
+        id="import-style-modal"
+        ref="import-style-modal"
+        title="Import Stage Direction Style"
+        size="xl"
+        ok-only
+        ok-title="Close"
+        @hidden="resetImportState"
+      >
+        <div v-if="isLoadingImport" class="text-center py-3">
+          <b-spinner />
+        </div>
+        <div v-else-if="importStyleGroups.length === 0" class="text-muted text-center py-3">
+          No styles available to import from other shows.
+        </div>
+        <div v-else>
+          <b-card v-for="show in importStyleGroups" :key="show.id" no-body class="mb-2">
+            <b-card-header class="section-card-header" @click="toggleImportShow(show.id)">
+              <div class="d-flex justify-content-between align-items-center">
+                <span>{{ show.name }}</span>
+                <b-icon-chevron-down v-if="styleGroupExpanded[show.id]" font-scale="0.8" />
+                <b-icon-chevron-up v-else font-scale="0.8" />
+              </div>
+            </b-card-header>
+            <b-collapse :visible="styleGroupExpanded[show.id]">
+              <b-card-body class="p-0">
+                <b-table :items="show.styles" :fields="importColumns" small show-empty class="mb-0">
+                  <template #cell(example)="row">
+                    <i class="example-stage-direction" :style="exampleCss(row.item)">
+                      <template v-if="row.item.text_format === 'upper'">
+                        {{ exampleText | uppercase }}
+                      </template>
+                      <template v-else-if="row.item.text_format === 'lower'">
+                        {{ exampleText | lowercase }}
+                      </template>
+                      <template v-else>
+                        {{ exampleText }}
+                      </template>
+                    </i>
+                  </template>
+                  <template #cell(btn)="row">
+                    <b-button
+                      variant="outline-success"
+                      size="sm"
+                      :disabled="!!isImporting[row.item.id]"
+                      @click="importStyle(row.item)"
+                    >
+                      <b-spinner v-if="isImporting[row.item.id]" small />
+                      <span v-else>Import</span>
+                    </b-button>
+                  </template>
+                </b-table>
+              </b-card-body>
+            </b-collapse>
+          </b-card>
+        </div>
+      </b-modal>
       <b-modal
         id="new-config-modal"
         ref="new-config-modal"
@@ -292,6 +357,11 @@ export default {
         { key: 'example', label: 'Example Stage Direction' },
         { key: 'btn', label: '' },
       ],
+      importColumns: [
+        'description',
+        { key: 'example', label: 'Example Stage Direction' },
+        { key: 'btn', label: '' },
+      ],
       rowsPerPage: 15,
       currentPage: 1,
       newStyleFormState: {
@@ -322,6 +392,10 @@ export default {
       isSubmittingNew: false,
       isSubmittingEdit: false,
       isDeleting: false,
+      importStyleGroups: [],
+      styleGroupExpanded: {},
+      isLoadingImport: false,
+      isImporting: {},
     };
   },
   computed: {
@@ -587,11 +661,60 @@ export default {
       }
       return style;
     },
+    async openImportModal() {
+      this.$bvModal.show('import-style-modal');
+      this.isLoadingImport = true;
+      try {
+        const data = await this.GET_IMPORTABLE_STAGE_DIRECTION_STYLES();
+        this.importStyleGroups = data.style_groups;
+        const expanded = {};
+        data.style_groups.forEach((group) => {
+          expanded[group.id] = true;
+        });
+        this.styleGroupExpanded = expanded;
+      } catch (error) {
+        log.error('Error fetching importable stage direction styles:', error);
+        this.$toast.error('Failed to load styles for import');
+      } finally {
+        this.isLoadingImport = false;
+      }
+    },
+    resetImportState() {
+      this.importStyleGroups = [];
+      this.styleGroupExpanded = {};
+      this.isLoadingImport = false;
+      this.isImporting = {};
+    },
+    toggleImportShow(showId) {
+      this.$set(this.styleGroupExpanded, showId, !this.styleGroupExpanded[showId]);
+    },
+    async importStyle(style) {
+      this.$set(this.isImporting, style.id, true);
+      try {
+        await this.ADD_STAGE_DIRECTION_STYLE({
+          description: style.description,
+          bold: style.bold,
+          italic: style.italic,
+          underline: style.underline,
+          textFormat: style.text_format,
+          textColour: style.text_colour,
+          enableBackgroundColour: style.enable_background_colour,
+          backgroundColour: style.background_colour,
+        });
+        this.$toast.success(`Imported "${style.description}"`);
+      } catch (error) {
+        log.error('Error importing stage direction style:', error);
+        this.$toast.error(`Failed to import "${style.description}"`);
+      } finally {
+        this.$set(this.isImporting, style.id, false);
+      }
+    },
     ...mapActions([
       'GET_STAGE_DIRECTION_STYLES',
       'ADD_STAGE_DIRECTION_STYLE',
       'DELETE_STAGE_DIRECTION_STYLE',
       'UPDATE_STAGE_DIRECTION_STYLE',
+      'GET_IMPORTABLE_STAGE_DIRECTION_STYLES',
     ]),
   },
 };

--- a/docs/pages/script_config.md
+++ b/docs/pages/script_config.md
@@ -64,6 +64,30 @@ Click **New Revision** to create a new revision. You'll need to provide a descri
 
 When you create a new revision, its base state is copied from the currently loaded revision. Any changes you make to the script after that point will only affect the active revision - other revisions remain unchanged, preserving the complete history of your script.
 
+### Stage Direction Styles
+
+The **Stage Direction Styles** tab lets you define the visual appearance of stage direction lines throughout your script. Each style controls the text formatting applied when that style is assigned to a stage direction line.
+
+#### Creating a New Style
+
+Click **New Style** to open the style editor. You can configure:
+
+- **Description** — a name for the style (e.g. "Narrator", "Whisper")
+- **Default Styles** — toggle Bold, Italic, and Underline
+- **Default Text Format** — Default, Uppercase, or Lowercase
+- **Text Colour** — a colour picker for the text colour
+- **Background Colour** — optionally enable and choose a background highlight colour
+
+A live preview of the style is shown at the top of the editor so you can see how it will appear in the script before saving.
+
+#### Importing Styles from Another Show
+
+Click **Import Style** to open the import modal. This shows all stage direction styles from every other show in your DigiScript instance, grouped by show name. Each style is displayed with its live preview so you can see exactly what it will look like.
+
+Click **Import** next to any style to copy it into the current show. The import creates an independent copy — changes to the imported style will not affect the original show, and vice versa. The modal stays open so you can import multiple styles in a single session.
+
+If no other shows have stage direction styles defined, a message is shown indicating there are no styles available to import.
+
 ### Script Content
 
 The **Script** tab is where you edit the actual script content. When you first navigate to this tab, you'll see an empty script interface:

--- a/server/controllers/api/show/script/stage_direction_styles.py
+++ b/server/controllers/api/show/script/stage_direction_styles.py
@@ -16,7 +16,7 @@ from rbac.role import Role
 from schemas.schemas import StageDirectionStyleSchema
 from utils.web.base_controller import BaseAPIController
 from utils.web.route import ApiRoute, ApiVersion
-from utils.web.web_decorators import no_live_session, requires_show
+from utils.web.web_decorators import api_authenticated, no_live_session, requires_show
 
 
 VALID_TEXT_FORMATS = ("default", "upper", "lower")
@@ -229,3 +229,36 @@ class StageDirectionStylesController(BaseAPIController):
             else:
                 self.set_status(404)
                 await self.finish({"message": ERROR_SHOW_NOT_FOUND})
+
+
+@ApiRoute("/show/script/stage_direction_styles/import", ApiVersion.V1)
+class StageDirectionStylesImportController(BaseAPIController):
+    @api_authenticated
+    @requires_show
+    def get(self):
+        """
+        Return all stage direction styles from all other shows, grouped by show.
+
+        :returns: JSON with a ``shows`` key containing a list of show objects,
+            each with ``id``, ``name``, and ``styles`` fields.
+        """
+        current_show_id = self.get_current_show()["id"]
+        schema = StageDirectionStyleSchema()
+
+        with self.make_session() as session:
+            rows = session.execute(
+                select(Show, StageDirectionStyle)
+                .join(Script, Script.show_id == Show.id)
+                .join(StageDirectionStyle, StageDirectionStyle.script_id == Script.id)
+                .where(Show.id != current_show_id)
+                .order_by(Show.id)
+            ).all()
+
+            shows_map: dict = {}
+            for show, style in rows:
+                if show.id not in shows_map:
+                    shows_map[show.id] = {"id": show.id, "name": show.name, "styles": []}
+                shows_map[show.id]["styles"].append(schema.dump(style))
+
+        self.set_status(200)
+        self.finish({"style_groups": list(shows_map.values())})

--- a/server/controllers/api/show/script/stage_direction_styles.py
+++ b/server/controllers/api/show/script/stage_direction_styles.py
@@ -257,7 +257,11 @@ class StageDirectionStylesImportController(BaseAPIController):
             shows_map: dict = {}
             for show, style in rows:
                 if show.id not in shows_map:
-                    shows_map[show.id] = {"id": show.id, "name": show.name, "styles": []}
+                    shows_map[show.id] = {
+                        "id": show.id,
+                        "name": show.name,
+                        "styles": [],
+                    }
                 shows_map[show.id]["styles"].append(schema.dump(style))
 
         self.set_status(200)

--- a/server/test/controllers/api/show/script/test_stage_direction_styles.py
+++ b/server/test/controllers/api/show/script/test_stage_direction_styles.py
@@ -92,3 +92,159 @@ class TestStageDirectionStylesController(DigiScriptTestCase):
         self.assertEqual(200, response.code)
         response_body = tornado.escape.json_decode(response.body)
         self.assertEqual([], response_body["styles"])
+
+
+class TestStageDirectionStylesImport(DigiScriptTestCase):
+    """Test suite for GET /api/v1/show/script/stage_direction_styles/import."""
+
+    IMPORT_URL = "/api/v1/show/script/stage_direction_styles/import"
+
+    def setUp(self):
+        super().setUp()
+        with self._app.get_db().sessionmaker() as session:
+            current_show = Show(name="Current Show", script_mode=ShowScriptType.FULL)
+            session.add(current_show)
+            session.flush()
+            self.current_show_id = current_show.id
+
+            current_script = Script(show_id=current_show.id)
+            session.add(current_script)
+            session.flush()
+            current_revision = ScriptRevision(
+                script_id=current_script.id, revision=1, description="Initial"
+            )
+            session.add(current_revision)
+            session.flush()
+            current_script.current_revision = current_revision.id
+
+            current_style = StageDirectionStyle(
+                script_id=current_script.id,
+                description="Current Show Style",
+                bold=False,
+                italic=False,
+                underline=False,
+                text_format="default",
+                text_colour="#111111",
+                enable_background_colour=False,
+                background_colour=None,
+            )
+            session.add(current_style)
+
+            other_show = Show(name="Other Show", script_mode=ShowScriptType.FULL)
+            session.add(other_show)
+            session.flush()
+            self.other_show_id = other_show.id
+
+            other_script = Script(show_id=other_show.id)
+            session.add(other_script)
+            session.flush()
+            other_revision = ScriptRevision(
+                script_id=other_script.id, revision=1, description="Initial"
+            )
+            session.add(other_revision)
+            session.flush()
+            other_script.current_revision = other_revision.id
+
+            other_style = StageDirectionStyle(
+                script_id=other_script.id,
+                description="Other Show Style",
+                bold=True,
+                italic=False,
+                underline=False,
+                text_format="upper",
+                text_colour="#222222",
+                enable_background_colour=False,
+                background_colour=None,
+            )
+            session.add(other_style)
+
+            empty_show = Show(name="Empty Show", script_mode=ShowScriptType.FULL)
+            session.add(empty_show)
+            session.flush()
+            self.empty_show_id = empty_show.id
+
+            empty_script = Script(show_id=empty_show.id)
+            session.add(empty_script)
+            session.flush()
+            empty_revision = ScriptRevision(
+                script_id=empty_script.id, revision=1, description="Initial"
+            )
+            session.add(empty_revision)
+            session.flush()
+            empty_script.current_revision = empty_revision.id
+
+            session.commit()
+
+        self._app.digi_settings.settings["current_show"].set_value(self.current_show_id)
+
+    def _login_admin(self):
+        self.fetch(
+            "/api/v1/auth/create",
+            method="POST",
+            body=tornado.escape.json_encode(
+                {"username": "admin", "password": "adminpass", "is_admin": True}
+            ),
+        )
+        resp = self.fetch(
+            "/api/v1/auth/login",
+            method="POST",
+            body=tornado.escape.json_encode(
+                {"username": "admin", "password": "adminpass"}
+            ),
+        )
+        return tornado.escape.json_decode(resp.body)["access_token"]
+
+    def test_get_import_requires_auth(self):
+        """GET without auth token returns 401."""
+        response = self.fetch(self.IMPORT_URL)
+        self.assertEqual(401, response.code)
+
+    def test_get_import_requires_show(self):
+        """GET with auth but no current show returns 400."""
+        self._app.digi_settings.settings["current_show"].set_value(None)
+        token = self._login_admin()
+        response = self.fetch(
+            self.IMPORT_URL,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(400, response.code)
+
+    def test_get_import_excludes_current_show(self):
+        """Current show's styles must not appear in the import response."""
+        token = self._login_admin()
+        response = self.fetch(
+            self.IMPORT_URL,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(200, response.code)
+        body = tornado.escape.json_decode(response.body)
+        show_ids = [s["id"] for s in body["style_groups"]]
+        self.assertNotIn(self.current_show_id, show_ids)
+
+    def test_get_import_includes_other_shows(self):
+        """Other shows with styles are returned with correct name and style data."""
+        token = self._login_admin()
+        response = self.fetch(
+            self.IMPORT_URL,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(200, response.code)
+        body = tornado.escape.json_decode(response.body)
+        other = next((s for s in body["style_groups"] if s["id"] == self.other_show_id), None)
+        self.assertIsNotNone(other)
+        self.assertEqual("Other Show", other["name"])
+        self.assertEqual(1, len(other["styles"]))
+        self.assertEqual("Other Show Style", other["styles"][0]["description"])
+        self.assertEqual("upper", other["styles"][0]["text_format"])
+
+    def test_get_import_skips_shows_with_no_styles(self):
+        """Shows that have a script but no styles are omitted from the response."""
+        token = self._login_admin()
+        response = self.fetch(
+            self.IMPORT_URL,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(200, response.code)
+        body = tornado.escape.json_decode(response.body)
+        show_ids = [s["id"] for s in body["style_groups"]]
+        self.assertNotIn(self.empty_show_id, show_ids)

--- a/server/test/controllers/api/show/script/test_stage_direction_styles.py
+++ b/server/test/controllers/api/show/script/test_stage_direction_styles.py
@@ -230,7 +230,9 @@ class TestStageDirectionStylesImport(DigiScriptTestCase):
         )
         self.assertEqual(200, response.code)
         body = tornado.escape.json_decode(response.body)
-        other = next((s for s in body["style_groups"] if s["id"] == self.other_show_id), None)
+        other = next(
+            (s for s in body["style_groups"] if s["id"] == self.other_show_id), None
+        )
         self.assertIsNotNone(other)
         self.assertEqual("Other Show", other["name"])
         self.assertEqual(1, len(other["styles"]))


### PR DESCRIPTION
## Summary

- Adds an **Import Style** button on the Stage Direction Styles tab (Script Config) that opens a modal listing all stage direction styles from other shows, grouped by show with live previews
- Each show group is a collapsible card (consistent with `ConfigSettings` UX pattern), expanded by default
- Importing creates an unlinked copy in the current show — no ongoing link to the source
- New `GET /api/v1/show/script/stage_direction_styles/import` endpoint; requires auth, excludes current show via a single JOIN query returning `style_groups`
- 5 new backend tests; frontend lint and all 571 backend tests pass

Closes #987

## Test plan

- [ ] Start the server and load a show that has stage direction styles defined
- [ ] Navigate to Script Config → Stage Direction Styles tab
- [ ] Verify **Import Style** button is visible to script editors and hidden to non-editors
- [ ] Click Import Style — modal opens, shows collapsible cards per show with live style previews
- [ ] Collapse and expand a show section — chevron toggles correctly
- [ ] Click **Import** on a style — it appears in the current show's style list; toast confirmation shown
- [ ] Verify imported style is an independent copy (editing/deleting it does not affect the source show)
- [ ] Test with no other shows having styles — empty state message is displayed
- [ ] Run `cd server && pytest test/controllers/api/show/script/test_stage_direction_styles.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)