### PR TITLE
Add cue type import from other shows

### DIFF
--- a/client/src/store/modules/show.js
+++ b/client/src/store/modules/show.js
@@ -455,6 +455,16 @@ export default {
         Vue.$toast.error('Unable to edit cue type');
       }
     },
+    async GET_IMPORTABLE_CUE_TYPES() {
+      const response = await fetch(`${makeURL('/api/v1/show/cues/types/import')}`, {
+        method: 'GET',
+      });
+      if (!response.ok) {
+        log.error('Unable to fetch importable cue types');
+        throw new Error('Failed to fetch importable cue types');
+      }
+      return response.json();
+    },
     async GET_SHOW_SESSION_DATA(context) {
       const response = await fetch(`${makeURL('/api/v1/show/sessions')}`);
       if (response.ok) {

--- a/client/src/views/show/config/ConfigCues.vue
+++ b/client/src/views/show/config/ConfigCues.vue
@@ -16,6 +16,14 @@
                 <b-button v-if="IS_SHOW_EDITOR" v-b-modal.new-cue-type variant="outline-success">
                   New Cue Type
                 </b-button>
+                <b-button
+                  v-if="IS_SHOW_EDITOR"
+                  variant="outline-info"
+                  class="ml-2"
+                  @click="openImportModal"
+                >
+                  Import Cue Type
+                </b-button>
               </template>
               <template #cell(colour)="data">
                 <p :style="{ color: data.item.colour }">
@@ -166,6 +174,48 @@
         </b-form-group>
       </b-form>
     </b-modal>
+    <b-modal
+      id="import-cue-type-modal"
+      ref="import-cue-type-modal"
+      title="Import Cue Type"
+      size="xl"
+      hide-footer
+      @hidden="resetImportState"
+    >
+      <div v-if="isLoadingImport" class="text-center">
+        <b-spinner />
+      </div>
+      <div v-else-if="importCueTypeGroups.length === 0">
+        <p class="text-muted">No cue types available to import from other shows.</p>
+      </div>
+      <div v-else>
+        <b-card v-for="show in importCueTypeGroups" :key="show.id" no-body class="mb-2">
+          <b-card-header style="cursor: pointer" @click="toggleImportShow(show.id)">
+            <span>{{ show.name }}</span>
+          </b-card-header>
+          <b-collapse :visible="cueTypeGroupExpanded[show.id]">
+            <b-table :items="show.cue_types" :fields="importCueTypeFields" small>
+              <template #cell(colour)="data">
+                <p :style="{ color: data.item.colour }">
+                  <b-icon-square-fill />
+                </p>
+              </template>
+              <template #cell(action)="data">
+                <b-button
+                  variant="outline-success"
+                  size="sm"
+                  :disabled="!!isImporting[data.item.id]"
+                  @click="importCueType(data.item)"
+                >
+                  <b-spinner v-if="isImporting[data.item.id]" small />
+                  <span v-else>Import</span>
+                </b-button>
+              </template>
+            </b-table>
+          </b-collapse>
+        </b-card>
+      </div>
+    </b-modal>
   </b-container>
 </template>
 
@@ -199,6 +249,16 @@ export default {
       submittingNewCueType: false,
       submittingEditCueType: false,
       deletingCueType: false,
+      importCueTypeGroups: [],
+      cueTypeGroupExpanded: {},
+      isLoadingImport: false,
+      isImporting: {},
+      importCueTypeFields: [
+        { key: 'prefix', label: 'Prefix' },
+        { key: 'description', label: 'Description' },
+        { key: 'colour', label: 'Colour' },
+        { key: 'action', label: '' },
+      ],
     };
   },
   validations: {
@@ -234,7 +294,13 @@ export default {
     await this.GET_CUE_TYPES();
   },
   methods: {
-    ...mapActions(['GET_CUE_TYPES', 'ADD_CUE_TYPE', 'DELETE_CUE_TYPE', 'UPDATE_CUE_TYPE']),
+    ...mapActions([
+      'GET_CUE_TYPES',
+      'ADD_CUE_TYPE',
+      'DELETE_CUE_TYPE',
+      'UPDATE_CUE_TYPE',
+      'GET_IMPORTABLE_CUE_TYPES',
+    ]),
     resetNewCueTypeForm() {
       this.newCueTypeForm = {
         prefix: '',
@@ -333,6 +399,42 @@ export default {
     validateEditCueTypeState(name) {
       const { $dirty, $error } = this.$v.editCueTypeFormState[name];
       return $dirty ? !$error : null;
+    },
+    async openImportModal() {
+      this.$bvModal.show('import-cue-type-modal');
+      this.isLoadingImport = true;
+      try {
+        const data = await this.GET_IMPORTABLE_CUE_TYPES();
+        this.importCueTypeGroups = data.cue_type_groups;
+        data.cue_type_groups.forEach((show) => {
+          this.$set(this.cueTypeGroupExpanded, show.id, true);
+        });
+      } catch (e) {
+        log.error('Error loading importable cue types:', e);
+      } finally {
+        this.isLoadingImport = false;
+      }
+    },
+    toggleImportShow(showId) {
+      this.$set(this.cueTypeGroupExpanded, showId, !this.cueTypeGroupExpanded[showId]);
+    },
+    async importCueType(cueType) {
+      this.$set(this.isImporting, cueType.id, true);
+      try {
+        await this.ADD_CUE_TYPE({
+          prefix: cueType.prefix,
+          description: cueType.description,
+          colour: cueType.colour,
+        });
+      } finally {
+        this.$set(this.isImporting, cueType.id, false);
+      }
+    },
+    resetImportState() {
+      this.importCueTypeGroups = [];
+      this.cueTypeGroupExpanded = {};
+      this.isLoadingImport = false;
+      this.isImporting = {};
     },
   },
 };

--- a/client/src/views/show/config/ConfigCues.vue
+++ b/client/src/views/show/config/ConfigCues.vue
@@ -191,7 +191,11 @@
       <div v-else>
         <b-card v-for="show in importCueTypeGroups" :key="show.id" no-body class="mb-2">
           <b-card-header style="cursor: pointer" @click="toggleImportShow(show.id)">
-            <span>{{ show.name }}</span>
+            <div class="d-flex justify-content-between align-items-center">
+              <span>{{ show.name }}</span>
+              <b-icon-chevron-down v-if="cueTypeGroupExpanded[show.id]" font-scale="0.8" />
+              <b-icon-chevron-up v-else font-scale="0.8" />
+            </div>
           </b-card-header>
           <b-collapse :visible="cueTypeGroupExpanded[show.id]">
             <b-table :items="show.cue_types" :fields="importCueTypeFields" small>

--- a/docs/pages/cue_config.md
+++ b/docs/pages/cue_config.md
@@ -10,7 +10,7 @@ The **Cue Types** tab allows you to Add, Edit, and Delete different cue types. C
 
 #### Creating Cue Types
 
-Click **Add** to create a new cue type. For each cue type, you'll need to specify:
+Click **New Cue Type** to create a new cue type. For each cue type, you'll need to specify:
 - **Prefix**: A short identifier (e.g., "LX" for lighting, "SND" for sound)
 - **Description**: A full description of the cue type
 - **Color**: A color code to visually distinguish this cue type in the interface
@@ -20,6 +20,10 @@ After adding cue types, they will appear in the cue types overview:
 ![](../images/config_show/cue_types.png)
 
 The color you choose will be used throughout DigiScript to make different cue types instantly recognizable during configuration and live shows.
+
+#### Importing Cue Types from Another Show
+
+If you have already configured cue types for another show, you can import them into the current show using the **Import Cue Type** button. This opens a panel listing all cue types from your other shows, grouped by show name. Click **Import** next to any cue type to add an independent copy to the current show — changes made after import do not affect the original show.
 
 ### Adding Cues to the Script
 

--- a/server/controllers/api/show/cues.py
+++ b/server/controllers/api/show/cues.py
@@ -183,6 +183,41 @@ class CueTypesController(BaseAPIController):
                 await self.finish({"message": ERROR_SHOW_NOT_FOUND})
 
 
+@ApiRoute("show/cues/types/import", ApiVersion.V1)
+class CueTypesImportController(BaseAPIController):
+    @requires_show
+    def get(self):
+        """
+        Return all cue types from all other shows, grouped by show.
+
+        :returns: JSON with a ``cue_type_groups`` key containing a list of show
+            objects, each with ``id``, ``name``, and ``cue_types`` fields.
+        """
+        current_show_id = self.get_current_show()["id"]
+        schema = CueTypeSchema()
+
+        with self.make_session() as session:
+            rows = session.execute(
+                select(Show, CueType)
+                .join(CueType, CueType.show_id == Show.id)
+                .where(Show.id != current_show_id)
+                .order_by(Show.id)
+            ).all()
+
+            shows_map: dict = {}
+            for show, cue_type in rows:
+                if show.id not in shows_map:
+                    shows_map[show.id] = {
+                        "id": show.id,
+                        "name": show.name,
+                        "cue_types": [],
+                    }
+                shows_map[show.id]["cue_types"].append(schema.dump(cue_type))
+
+        self.set_status(200)
+        self.finish({"cue_type_groups": list(shows_map.values())})
+
+
 @ApiRoute("show/cues", ApiVersion.V1)
 class CueController(BaseAPIController):
     @requires_show

--- a/server/test/controllers/api/show/test_cues.py
+++ b/server/test/controllers/api/show/test_cues.py
@@ -832,3 +832,107 @@ class TestCueSearchController(DigiScriptTestCase):
         # Verify page number is valid (1-3 in our test data)
         self.assertGreaterEqual(location["page"], 1)
         self.assertLessEqual(location["page"], 3)
+
+
+class TestCueTypeImportController(DigiScriptTestCase):
+    """Test suite for GET /api/v1/show/cues/types/import endpoint."""
+
+    def setUp(self):
+        super().setUp()
+        with self._app.get_db().sessionmaker() as session:
+            # Current show — its cue types must be excluded from import results
+            current_show = Show(name="Current Show", script_mode=ShowScriptType.FULL)
+            session.add(current_show)
+            session.flush()
+            self.current_show_id = current_show.id
+
+            current_cue_type = CueType(
+                show_id=current_show.id,
+                prefix="LX",
+                description="Lighting",
+                colour="#ff0000",
+            )
+            session.add(current_cue_type)
+            session.flush()
+            self.current_cue_type_id = current_cue_type.id
+
+            # Other show — its cue types should appear in import results
+            other_show = Show(name="Other Show", script_mode=ShowScriptType.FULL)
+            session.add(other_show)
+            session.flush()
+            self.other_show_id = other_show.id
+
+            other_cue_type = CueType(
+                show_id=other_show.id,
+                prefix="SND",
+                description="Sound",
+                colour="#00ff00",
+            )
+            session.add(other_cue_type)
+            session.flush()
+            self.other_cue_type_id = other_cue_type.id
+
+            # Empty show — no cue types, must not appear in import results
+            empty_show = Show(name="Empty Show", script_mode=ShowScriptType.FULL)
+            session.add(empty_show)
+            session.flush()
+            self.empty_show_id = empty_show.id
+
+            session.commit()
+
+        self._app.digi_settings.settings["current_show"].set_value(self.current_show_id)
+
+    def test_get_import_requires_show(self):
+        """Test that the endpoint returns 400 when no current show is set."""
+        self._app.digi_settings.settings["current_show"].set_value(None)
+        response = self.fetch("/api/v1/show/cues/types/import")
+        self.assertEqual(400, response.code)
+
+    def test_get_import_excludes_current_show(self):
+        """Test that the current show's cue types are not included in the response."""
+        response = self.fetch("/api/v1/show/cues/types/import")
+        self.assertEqual(200, response.code)
+        body = tornado.escape.json_decode(response.body)
+        group_ids = [g["id"] for g in body["cue_type_groups"]]
+        self.assertNotIn(self.current_show_id, group_ids)
+
+    def test_get_import_includes_other_shows(self):
+        """Test that other shows with cue types are included with correct data."""
+        response = self.fetch("/api/v1/show/cues/types/import")
+        self.assertEqual(200, response.code)
+        body = tornado.escape.json_decode(response.body)
+
+        other_group = next(
+            (g for g in body["cue_type_groups"] if g["id"] == self.other_show_id), None
+        )
+        self.assertIsNotNone(other_group)
+        self.assertEqual("Other Show", other_group["name"])
+        self.assertEqual(1, len(other_group["cue_types"]))
+
+        cue_type = other_group["cue_types"][0]
+        self.assertEqual("SND", cue_type["prefix"])
+        self.assertEqual("Sound", cue_type["description"])
+        self.assertEqual("#00ff00", cue_type["colour"])
+
+    def test_get_import_skips_shows_with_no_cue_types(self):
+        """Test that shows with no cue types are not included in the response."""
+        response = self.fetch("/api/v1/show/cues/types/import")
+        self.assertEqual(200, response.code)
+        body = tornado.escape.json_decode(response.body)
+        group_ids = [g["id"] for g in body["cue_type_groups"]]
+        self.assertNotIn(self.empty_show_id, group_ids)
+
+    def test_get_import_returns_correct_structure(self):
+        """Test that the response contains the expected top-level structure."""
+        response = self.fetch("/api/v1/show/cues/types/import")
+        self.assertEqual(200, response.code)
+        body = tornado.escape.json_decode(response.body)
+
+        self.assertIn("cue_type_groups", body)
+        self.assertIsInstance(body["cue_type_groups"], list)
+
+        for group in body["cue_type_groups"]:
+            self.assertIn("id", group)
+            self.assertIn("name", group)
+            self.assertIn("cue_types", group)
+            self.assertIsInstance(group["cue_types"], list)


### PR DESCRIPTION
## Summary

- Adds a **Import Cue Type** button to the Cue Types tab, mirroring the stage direction style import feature added in PR #989
- Backend `GET /api/v1/show/cues/types/import` returns cue types from all other shows grouped by show (empty shows excluded via INNER JOIN)
- Import modal shows collapsible show groups with per-row import buttons and loading spinners
- Imported cue types are independent copies — changes do not affect the source show
- 5 new backend tests in `TestCueTypeImportController`; all 576 backend and 99 frontend tests pass

## Test plan

- [ ] Backend tests: `cd server && pytest test/controllers/api/show/test_cues.py::TestCueTypeImportController -v`
- [ ] Full backend suite: `cd server && pytest`
- [ ] Frontend lint: `cd client && npm run ci-lint`
- [ ] Frontend tests: `cd client && npm run test:run`
- [ ] Manual: open two shows, add cue types to one, switch to the other and verify Import Cue Type button works; confirm current show's types are not listed; confirm shows with no cue types are not shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)