### PR TITLE
Fix stage direction style DELETE (reads ID from query param, not body)

### DIFF
--- a/server/controllers/api/show/script/stage_direction_styles.py
+++ b/server/controllers/api/show/script/stage_direction_styles.py
@@ -5,6 +5,7 @@ from controllers.api.constants import (
     ERROR_BACKGROUND_COLOUR_MISSING,
     ERROR_DESCRIPTION_MISSING,
     ERROR_ID_MISSING,
+    ERROR_INVALID_ID,
     ERROR_SHOW_NOT_FOUND,
     ERROR_STAGE_DIRECTION_STYLE_NOT_FOUND,
     ERROR_TEXT_COLOUR_MISSING,
@@ -200,12 +201,17 @@ class StageDirectionStylesController(BaseAPIController):
                     select(Script).where(Script.show_id == show.id)
                 ).first()
                 self.requires_role(script, Role.WRITE)
-                data = escape.json_decode(self.request.body)
 
-                style_id = data.get("id", None)
-                if not style_id:
+                style_id_str = self.get_argument("id", None)
+                if not style_id_str:
                     self.set_status(400)
                     await self.finish({"message": ERROR_ID_MISSING})
+                    return
+                try:
+                    style_id = int(style_id_str)
+                except ValueError:
+                    self.set_status(400)
+                    await self.finish({"message": ERROR_INVALID_ID})
                     return
 
                 entry: StageDirectionStyle = session.get(StageDirectionStyle, style_id)

--- a/server/test/controllers/api/show/script/test_stage_direction_styles.py
+++ b/server/test/controllers/api/show/script/test_stage_direction_styles.py
@@ -64,6 +64,66 @@ class TestStageDirectionStylesController(DigiScriptTestCase):
         self.assertEqual(1, len(response_body["styles"]))
         self.assertEqual("Test Style", response_body["styles"][0]["description"])
 
+    def _login_admin(self):
+        self.fetch(
+            "/api/v1/auth/create",
+            method="POST",
+            body=tornado.escape.json_encode(
+                {"username": "admin", "password": "adminpass", "is_admin": True}
+            ),
+        )
+        resp = self.fetch(
+            "/api/v1/auth/login",
+            method="POST",
+            body=tornado.escape.json_encode(
+                {"username": "admin", "password": "adminpass"}
+            ),
+        )
+        return tornado.escape.json_decode(resp.body)["access_token"]
+
+    def test_delete_stage_direction_style(self):
+        """DELETE with valid id removes the style and returns 200."""
+        token = self._login_admin()
+        response = self.fetch(
+            f"/api/v1/show/script/stage_direction_styles?id={self.style_id}",
+            method="DELETE",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(200, response.code)
+        with self._app.get_db().sessionmaker() as session:
+            entry = session.get(StageDirectionStyle, self.style_id)
+            self.assertIsNone(entry)
+
+    def test_delete_stage_direction_style_missing_id(self):
+        """DELETE without id param returns 400."""
+        token = self._login_admin()
+        response = self.fetch(
+            "/api/v1/show/script/stage_direction_styles",
+            method="DELETE",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(400, response.code)
+
+    def test_delete_stage_direction_style_invalid_id(self):
+        """DELETE with non-integer id returns 400."""
+        token = self._login_admin()
+        response = self.fetch(
+            "/api/v1/show/script/stage_direction_styles?id=abc",
+            method="DELETE",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(400, response.code)
+
+    def test_delete_stage_direction_style_not_found(self):
+        """DELETE with unknown id returns 404."""
+        token = self._login_admin()
+        response = self.fetch(
+            "/api/v1/show/script/stage_direction_styles?id=99999",
+            method="DELETE",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(404, response.code)
+
     def test_get_stage_direction_styles_empty(self):
         """Test GET returns empty list when no styles exist."""
         # Create a show with a script but no styles


### PR DESCRIPTION
## Summary

- The `delete()` handler in `StageDirectionStylesController` was calling `escape.json_decode(self.request.body)` to read the style ID, but DELETE requests carry no body
- The frontend correctly sends the ID as a query parameter (`?id=N`), matching every other DELETE endpoint in the codebase (characters, cast, cues, etc.)
- Fix replaces the body decode with `self.get_argument("id", None)` + `int()` validation, and adds `ERROR_INVALID_ID` to imports

## Test plan

- [x] `test_delete_stage_direction_style` — happy path: 200, style removed from DB
- [x] `test_delete_stage_direction_style_missing_id` — no `id` param → 400
- [x] `test_delete_stage_direction_style_invalid_id` — `id=abc` → 400
- [x] `test_delete_stage_direction_style_not_found` — unknown ID → 404
- [x] Full test suite: 580 passed
- [x] `ruff check`: no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)