### PR TITLE
Add session tag type import from other shows

### DIFF
--- a/client/src/store/modules/show.js
+++ b/client/src/store/modules/show.js
@@ -652,6 +652,16 @@ export default {
         Vue.$toast.error('Unable to delete session tag');
       }
     },
+    async GET_IMPORTABLE_SESSION_TAGS() {
+      const response = await fetch(`${makeURL('/api/v1/show/session/tags/import')}`, {
+        method: 'GET',
+      });
+      if (!response.ok) {
+        log.error('Unable to fetch importable session tags');
+        throw new Error('Failed to fetch importable session tags');
+      }
+      return response.json();
+    },
     async UPDATE_SESSION_TAGS(context, { sessionId, tagIds }) {
       const response = await fetch(`${makeURL('/api/v1/show/sessions/assign-tags')}`, {
         method: 'PATCH',

--- a/client/src/vue_components/show/config/sessions/SessionTagList.vue
+++ b/client/src/vue_components/show/config/sessions/SessionTagList.vue
@@ -12,6 +12,14 @@
         <b-button v-if="IS_SHOW_EDITOR" v-b-modal.new-tag variant="outline-success">
           New Tag
         </b-button>
+        <b-button
+          v-if="IS_SHOW_EDITOR"
+          variant="outline-info"
+          class="ml-2"
+          @click="openImportModal"
+        >
+          Import Tag
+        </b-button>
       </template>
       <template #cell(tag)="data">
         <span
@@ -141,6 +149,63 @@
         </b-form-group>
       </b-form>
     </b-modal>
+    <b-modal
+      id="import-tag-modal"
+      ref="import-tag-modal"
+      title="Import Session Tag"
+      size="xl"
+      hide-footer
+      @hidden="resetImportState"
+    >
+      <div v-if="isLoadingImport" class="text-center">
+        <b-spinner />
+      </div>
+      <div v-else-if="importTagGroups.length === 0">
+        <p class="text-muted">No session tags available to import from other shows.</p>
+      </div>
+      <div v-else>
+        <b-card v-for="show in importTagGroups" :key="show.id" no-body class="mb-2">
+          <b-card-header style="cursor: pointer" @click="toggleImportShow(show.id)">
+            <div class="d-flex justify-content-between align-items-center">
+              <span>{{ show.name }}</span>
+              <b-icon-chevron-down v-if="tagGroupExpanded[show.id]" font-scale="0.8" />
+              <b-icon-chevron-up v-else font-scale="0.8" />
+            </div>
+          </b-card-header>
+          <b-collapse :visible="tagGroupExpanded[show.id]">
+            <b-table :items="show.tags" :fields="importTagFields" small>
+              <template #cell(tag)="data">
+                <span
+                  class="tag-pill"
+                  :style="{
+                    backgroundColor: data.item.colour,
+                    color: contrastColor({ bgColor: data.item.colour }),
+                  }"
+                >
+                  {{ data.item.tag }}
+                </span>
+              </template>
+              <template #cell(action)="data">
+                <span
+                  v-b-tooltip.hover
+                  :title="tagAlreadyExists(data.item) ? 'Already exists in this show' : ''"
+                >
+                  <b-button
+                    variant="outline-success"
+                    size="sm"
+                    :disabled="!!isImporting[data.item.id] || tagAlreadyExists(data.item)"
+                    @click="importTag(data.item)"
+                  >
+                    <b-spinner v-if="isImporting[data.item.id]" small />
+                    <span v-else>Import</span>
+                  </b-button>
+                </span>
+              </template>
+            </b-table>
+          </b-collapse>
+        </b-card>
+      </div>
+    </b-modal>
   </span>
 </template>
 
@@ -196,6 +261,14 @@ export default {
       isSubmittingNewTag: false,
       isSubmittingEditTag: false,
       isSubmittingDeleteTag: false,
+      importTagGroups: [],
+      tagGroupExpanded: {},
+      isLoadingImport: false,
+      isImporting: {},
+      importTagFields: [
+        { key: 'tag', label: 'Tag' },
+        { key: 'action', label: '' },
+      ],
     };
   },
   validations: {
@@ -222,9 +295,17 @@ export default {
   },
   computed: {
     ...mapGetters(['SESSION_TAGS', 'SHOW_SESSIONS_LIST', 'IS_SHOW_EDITOR']),
+    existingTagNames() {
+      return new Set((this.SESSION_TAGS || []).map((t) => t.tag.toLowerCase()));
+    },
   },
   methods: {
-    ...mapActions(['ADD_SESSION_TAG', 'UPDATE_SESSION_TAG', 'DELETE_SESSION_TAG']),
+    ...mapActions([
+      'ADD_SESSION_TAG',
+      'UPDATE_SESSION_TAG',
+      'DELETE_SESSION_TAG',
+      'GET_IMPORTABLE_SESSION_TAGS',
+    ]),
     contrastColor,
     getSessionCountForTag(tagId) {
       if (!this.SHOW_SESSIONS_LIST || !Array.isArray(this.SHOW_SESSIONS_LIST)) {
@@ -315,6 +396,41 @@ export default {
     validateEditTag(name) {
       const { $dirty, $error } = this.$v.editTagForm[name];
       return $dirty ? !$error : null;
+    },
+    async openImportModal() {
+      this.$bvModal.show('import-tag-modal');
+      this.isLoadingImport = true;
+      try {
+        const data = await this.GET_IMPORTABLE_SESSION_TAGS();
+        this.importTagGroups = data.tag_groups;
+        data.tag_groups.forEach((show) => {
+          this.$set(this.tagGroupExpanded, show.id, true);
+        });
+      } catch (e) {
+        log.error('Error loading importable session tags:', e);
+      } finally {
+        this.isLoadingImport = false;
+      }
+    },
+    toggleImportShow(showId) {
+      this.$set(this.tagGroupExpanded, showId, !this.tagGroupExpanded[showId]);
+    },
+    tagAlreadyExists(tag) {
+      return this.existingTagNames.has(tag.tag.toLowerCase());
+    },
+    async importTag(tag) {
+      this.$set(this.isImporting, tag.id, true);
+      try {
+        await this.ADD_SESSION_TAG({ tag: tag.tag, colour: tag.colour });
+      } finally {
+        this.$set(this.isImporting, tag.id, false);
+      }
+    },
+    resetImportState() {
+      this.importTagGroups = [];
+      this.tagGroupExpanded = {};
+      this.isLoadingImport = false;
+      this.isImporting = {};
     },
     async deleteTag(data) {
       if (this.isSubmittingDeleteTag) {

--- a/docs/pages/show_config.md
+++ b/docs/pages/show_config.md
@@ -15,7 +15,7 @@ The Show Config page is organized into several sections, each accessible from th
 - **Script**: Create and edit the show script with revisions
 - **Cues**: Configure cue types and assign cues to script lines (see [Cue Configuration](./cue_config.md))
 - [Microphones](./show_config/microphones.md): Set up microphones and allocate them to characters
-- **Sessions**: View the history of live show sessions
+- **Sessions**: View the history of live show sessions and manage session tag types
 
 ### Configuration Workflow
 
@@ -47,5 +47,17 @@ A streamlined single-column layout. This mode is ideal for:
 - Simple dialogue-heavy shows
 
 **Note**: The script mode is set during show creation and affects the entire show. It cannot be changed after the fact.
+
+### Sessions
+
+The **Sessions** section shows a history of all live show sessions that have been run. The **Tags** tab lets you create and manage session tag types — coloured labels that can be applied to individual sessions to categorise them (e.g. "Tech", "Dress", "Opening Night").
+
+#### Session Tags
+
+Each tag has a **name** and a **colour**. Tag names must be unique within a show (case-insensitive). Tags can be applied to sessions from the Sessions tab.
+
+#### Importing Session Tags from Another Show
+
+If you have already configured session tags for a different show, you can import them into the current show using the **Import Tag** button on the Tags tab. This opens a panel listing all session tags from your other shows, grouped by show name. Click **Import** next to any tag to add an independent copy to the current show. Tags that already exist in the current show (matched case-insensitively) are shown as disabled and cannot be imported again.
 
 Once your show is fully configured, you're ready to [run a live show](./live_show.md)!

--- a/server/controllers/api/show/session/tags.py
+++ b/server/controllers/api/show/session/tags.py
@@ -205,3 +205,38 @@ class SessionTagsController(BaseAPIController):
             else:
                 self.set_status(404)
                 await self.finish({"message": ERROR_SHOW_NOT_FOUND})
+
+
+@ApiRoute("show/session/tags/import", ApiVersion.V1)
+class SessionTagImportController(BaseAPIController):
+    @requires_show
+    def get(self):
+        """
+        Return all session tags from all other shows, grouped by show.
+
+        :returns: JSON with a ``tag_groups`` key containing a list of show objects,
+            each with ``id``, ``name``, and ``tags`` fields.
+        """
+        current_show_id = self.get_current_show()["id"]
+        schema = ShowSessionTagSchema()
+
+        with self.make_session() as session:
+            rows = session.execute(
+                select(Show, SessionTag)
+                .join(SessionTag, SessionTag.show_id == Show.id)
+                .where(Show.id != current_show_id)
+                .order_by(Show.id)
+            ).all()
+
+            shows_map: dict = {}
+            for show, tag in rows:
+                if show.id not in shows_map:
+                    shows_map[show.id] = {
+                        "id": show.id,
+                        "name": show.name,
+                        "tags": [],
+                    }
+                shows_map[show.id]["tags"].append(schema.dump(tag))
+
+        self.set_status(200)
+        self.finish({"tag_groups": list(shows_map.values())})

--- a/server/test/controllers/api/show/session/test_tags.py
+++ b/server/test/controllers/api/show/session/test_tags.py
@@ -466,9 +466,7 @@ class TestSessionTagImportController(DigiScriptTestCase):
             session.flush()
             self.other_show_id = other_show.id
 
-            other_tag = SessionTag(
-                show_id=other_show.id, tag="Dress", colour="#00ff00"
-            )
+            other_tag = SessionTag(show_id=other_show.id, tag="Dress", colour="#00ff00")
             session.add(other_tag)
             session.flush()
             self.other_tag_id = other_tag.id

--- a/server/test/controllers/api/show/session/test_tags.py
+++ b/server/test/controllers/api/show/session/test_tags.py
@@ -1,5 +1,6 @@
 """Tests for SessionTag CRUD API controller."""
 
+import tornado.escape
 from sqlalchemy import insert, select
 from tornado import escape
 
@@ -438,3 +439,100 @@ class TestSessionTagsController(DigiScriptTestCase):
                 select(ShowSession).where(ShowSession.id == session_id)
             ).first()
             self.assertIsNotNone(show_session)
+
+
+class TestSessionTagImportController(DigiScriptTestCase):
+    """Test suite for GET /api/v1/show/session/tags/import endpoint."""
+
+    def setUp(self):
+        super().setUp()
+        with self._app.get_db().sessionmaker() as session:
+            # Current show — its tags must be excluded from import results
+            current_show = Show(name="Current Show", script_mode=ShowScriptType.FULL)
+            session.add(current_show)
+            session.flush()
+            self.current_show_id = current_show.id
+
+            current_tag = SessionTag(
+                show_id=current_show.id, tag="Tech", colour="#ff0000"
+            )
+            session.add(current_tag)
+            session.flush()
+            self.current_tag_id = current_tag.id
+
+            # Other show — its tags should appear in import results
+            other_show = Show(name="Other Show", script_mode=ShowScriptType.FULL)
+            session.add(other_show)
+            session.flush()
+            self.other_show_id = other_show.id
+
+            other_tag = SessionTag(
+                show_id=other_show.id, tag="Dress", colour="#00ff00"
+            )
+            session.add(other_tag)
+            session.flush()
+            self.other_tag_id = other_tag.id
+
+            # Empty show — no tags, must not appear in import results
+            empty_show = Show(name="Empty Show", script_mode=ShowScriptType.FULL)
+            session.add(empty_show)
+            session.flush()
+            self.empty_show_id = empty_show.id
+
+            session.commit()
+
+        self._app.digi_settings.settings["current_show"].set_value(self.current_show_id)
+
+    def test_get_import_requires_show(self):
+        """Test that the endpoint returns 400 when no current show is set."""
+        self._app.digi_settings.settings["current_show"].set_value(None)
+        response = self.fetch("/api/v1/show/session/tags/import")
+        self.assertEqual(400, response.code)
+
+    def test_get_import_excludes_current_show(self):
+        """Test that the current show's tags are not included in the response."""
+        response = self.fetch("/api/v1/show/session/tags/import")
+        self.assertEqual(200, response.code)
+        body = tornado.escape.json_decode(response.body)
+        group_ids = [g["id"] for g in body["tag_groups"]]
+        self.assertNotIn(self.current_show_id, group_ids)
+
+    def test_get_import_includes_other_shows(self):
+        """Test that other shows with tags are included with correct data."""
+        response = self.fetch("/api/v1/show/session/tags/import")
+        self.assertEqual(200, response.code)
+        body = tornado.escape.json_decode(response.body)
+
+        other_group = next(
+            (g for g in body["tag_groups"] if g["id"] == self.other_show_id), None
+        )
+        self.assertIsNotNone(other_group)
+        self.assertEqual("Other Show", other_group["name"])
+        self.assertEqual(1, len(other_group["tags"]))
+
+        tag = other_group["tags"][0]
+        self.assertEqual("Dress", tag["tag"])
+        self.assertEqual("#00ff00", tag["colour"])
+
+    def test_get_import_skips_shows_with_no_tags(self):
+        """Test that shows with no tags are not included in the response."""
+        response = self.fetch("/api/v1/show/session/tags/import")
+        self.assertEqual(200, response.code)
+        body = tornado.escape.json_decode(response.body)
+        group_ids = [g["id"] for g in body["tag_groups"]]
+        self.assertNotIn(self.empty_show_id, group_ids)
+
+    def test_get_import_returns_correct_structure(self):
+        """Test that the response contains the expected top-level structure."""
+        response = self.fetch("/api/v1/show/session/tags/import")
+        self.assertEqual(200, response.code)
+        body = tornado.escape.json_decode(response.body)
+
+        self.assertIn("tag_groups", body)
+        self.assertIsInstance(body["tag_groups"], list)
+
+        for group in body["tag_groups"]:
+            self.assertIn("id", group)
+            self.assertIn("name", group)
+            self.assertIn("tags", group)
+            self.assertIsInstance(group["tags"], list)


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/show/session/tags/import` endpoint that returns all session tags from other shows, grouped by show, excluding the currently loaded show
- Adds an **Import Tag** button on the Session Tags tab (editor-only) that opens a modal listing importable tags grouped by show
- Duplicate detection is real-time and client-side: the import button is disabled for tags whose name already exists in the current show (case-insensitive), driven by the WebSocket-updated `SESSION_TAGS` Vuex state — no round-trip needed
- Follows the identical pattern used by cue type import (PR #991) and stage direction style import (PR #989)

## Test plan

- [ ] Run `pytest test/controllers/api/show/session/test_tags.py -v` — all 24 tests (19 existing + 5 new) pass
- [ ] Run `ruff check` — no errors
- [ ] Run `npm run ci-lint` and `npm run test:run` — all clean
- [ ] Create a show with 2–3 session tags, load a second (empty) show, open Sessions → Tags, click **Import Tag**
- [ ] Verify first show appears with correct tag names and colours
- [ ] Import a tag, verify it appears in the tag list and its import button becomes disabled immediately (WebSocket refresh drives `existingTagNames`)

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)