### PR TITLE
Fix save modal showing nonsensical 'Saving page X of Y' when X > Y

### DIFF
--- a/client/src/vue_components/show/config/script/ScriptEditor.vue
+++ b/client/src/vue_components/show/config/script/ScriptEditor.vue
@@ -712,18 +712,15 @@ export default {
       if (!this.IS_CUT_MODE) {
         if (this.scriptChanges) {
           this.savingInProgress = true;
-          this.totalSavePages = Object.keys(this.TMP_SCRIPT).length;
+          this.totalSavePages = this.currentMaxPage;
           this.curSavePage = 0;
           this.$bvModal.show('save-script');
 
-          const orderedPages = Object.keys(this.TMP_SCRIPT)
-            .map((x) => parseInt(x, 10))
-            .sort((a, b) => a - b);
-
-          for (const pageNo of orderedPages) {
+          for (let pageNo = 1; pageNo <= this.currentMaxPage; pageNo++) {
             this.curSavePage = pageNo;
-            // Check whether the page actually has any lines on it, and if not then skip
             const tmpScriptPage = this.TMP_SCRIPT[pageNo.toString()];
+            if (!tmpScriptPage) continue;
+            // Check whether the page actually has any lines on it, and if not then skip
             if (tmpScriptPage.length !== 0) {
               // Check the actual script to see if the page exists or not
               const actualScriptPage = this.GET_SCRIPT_PAGE(pageNo);

--- a/client/src/vue_components/show/config/script/ScriptEditor.vue
+++ b/client/src/vue_components/show/config/script/ScriptEditor.vue
@@ -712,11 +712,13 @@ export default {
       if (!this.IS_CUT_MODE) {
         if (this.scriptChanges) {
           this.savingInProgress = true;
-          this.totalSavePages = this.currentMaxPage;
+          const tmpPageKeys = Object.keys(this.TMP_SCRIPT).map((x) => Number.parseInt(x, 10));
+          const maxPage = Math.max(this.currentMaxPage, ...tmpPageKeys, 0);
+          this.totalSavePages = maxPage;
           this.curSavePage = 0;
           this.$bvModal.show('save-script');
 
-          for (let pageNo = 1; pageNo <= this.currentMaxPage; pageNo++) {
+          for (let pageNo = 1; pageNo <= maxPage; pageNo++) {
             this.curSavePage = pageNo;
             const tmpScriptPage = this.TMP_SCRIPT[pageNo.toString()];
             if (!tmpScriptPage) continue;


### PR DESCRIPTION
## Summary

- **Bug**: The "Saving Script" modal displayed the raw script page number as X and the count of loaded pages as Y, producing impossible values like "Saving page 13 of 1"
- **Root cause**: `totalSavePages` was set to `Object.keys(TMP_SCRIPT).length` (count of loaded pages) while `curSavePage` was set to the actual page number — two different units in the same "X of Y" display
- **Fix**: Loop from 1 to `Math.max(currentMaxPage, ...TMP_SCRIPT keys)` so both values share the same scale. Taking the max of both sources handles existing pages (via `currentMaxPage` from the backend) and newly added pages that haven't been saved yet (which live in `TMP_SCRIPT` above `currentMaxPage`). Pages not loaded into `TMP_SCRIPT` are skipped silently, hiding the implementation detail that only changed pages are actually saved

## Test plan

- [ ] Open a show with a script that has content beyond page 1
- [ ] Navigate to a later page (e.g. page 13), make an edit, and click Save
- [ ] Confirm the modal now shows "Saving page 1 of N" → "Saving page N of N" where N = total script pages — never X > Y
- [ ] Add a brand new page beyond the current max, make an edit, and click Save — confirm the new page is included in the count and is saved correctly
- [ ] Confirm the progress bar fills smoothly left to right with no value exceeding the max
- [ ] Verify autosave toast is unaffected (shows actual page number, no "of Y" — unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)