### PR TITLE
Add bulk act/scene edit mode to script editor

### DIFF
--- a/client/src/vue_components/show/config/script/BulkActSceneModal.vue
+++ b/client/src/vue_components/show/config/script/BulkActSceneModal.vue
@@ -1,0 +1,134 @@
+<template>
+  <b-modal
+    id="bulk-act-scene-modal"
+    title="Bulk Edit Act/Scene"
+    size="md"
+    ok-title="Apply"
+    :ok-disabled="!canApply"
+    @ok="handleOk"
+    @hidden="reset"
+  >
+    <p class="text-muted small mb-3">
+      Applies the selected act and scene to all lines from the chosen start line to end line
+      (inclusive).
+    </p>
+    <b-form-group label="Act" label-for="bulk-act-input">
+      <b-form-select
+        id="bulk-act-input"
+        v-model="selectedActId"
+        :options="actOptions"
+        @change="selectedSceneId = null"
+      />
+    </b-form-group>
+    <b-form-group label="Scene" label-for="bulk-scene-input">
+      <b-form-select
+        id="bulk-scene-input"
+        v-model="selectedSceneId"
+        :options="sceneOptions"
+        :disabled="selectedActId == null"
+      />
+    </b-form-group>
+  </b-modal>
+</template>
+
+<script>
+export default {
+  name: 'BulkActSceneModal',
+  events: ['apply'],
+  props: {
+    previousLineOfStart: {
+      type: Object,
+      default: null,
+    },
+    nextLineOfEnd: {
+      type: Object,
+      default: null,
+    },
+    acts: {
+      required: true,
+      type: Array,
+    },
+    scenes: {
+      required: true,
+      type: Array,
+    },
+  },
+  data() {
+    return {
+      selectedActId: null,
+      selectedSceneId: null,
+    };
+  },
+  computed: {
+    validActs() {
+      // Same algorithm as nextActs in ScriptLineEditor — constrained by the line before
+      // the start selection (lower bound) and the line after the end selection (upper bound).
+      let startAct = this.acts.find((act) => act.previous_act == null);
+      if (this.previousLineOfStart != null && this.previousLineOfStart.act_id != null) {
+        startAct = this.acts.find((act) => act.id === this.previousLineOfStart.act_id);
+      }
+      const validActs = [];
+      let nextAct = startAct;
+      while (nextAct != null) {
+        validActs.push(nextAct);
+        if (this.nextLineOfEnd != null && this.nextLineOfEnd.act_id === nextAct.id) {
+          break;
+        }
+        nextAct = this.acts.find((act) => act.id === nextAct.next_act) || null;
+      }
+      return validActs;
+    },
+    validScenes() {
+      if (this.selectedActId == null) {
+        return [];
+      }
+      const actScenes = this.scenes.filter((scene) => scene.act === this.selectedActId);
+      let startScene = actScenes.find((scene) => scene.previous_scene == null);
+      if (
+        this.previousLineOfStart != null &&
+        this.previousLineOfStart.act_id === this.selectedActId &&
+        this.previousLineOfStart.scene_id != null
+      ) {
+        startScene = actScenes.find((scene) => scene.id === this.previousLineOfStart.scene_id);
+      }
+      const validScenes = [];
+      let nextScene = startScene;
+      while (nextScene != null) {
+        validScenes.push(nextScene);
+        if (this.nextLineOfEnd != null && this.nextLineOfEnd.scene_id === nextScene.id) {
+          break;
+        }
+        nextScene = actScenes.find((scene) => scene.id === nextScene.next_scene) || null;
+      }
+      return validScenes;
+    },
+    actOptions() {
+      return [
+        { value: null, text: 'Select an act', disabled: true },
+        ...this.validActs.map((act) => ({ value: act.id, text: act.name })),
+      ];
+    },
+    sceneOptions() {
+      return [
+        { value: null, text: 'Select a scene', disabled: true },
+        ...this.validScenes.map((scene) => ({ value: scene.id, text: scene.name })),
+      ];
+    },
+    canApply() {
+      return this.selectedActId != null && this.selectedSceneId != null;
+    },
+  },
+  methods: {
+    handleOk(bvModalEvt) {
+      bvModalEvt.preventDefault();
+      if (this.canApply) {
+        this.$emit('apply', { actId: this.selectedActId, sceneId: this.selectedSceneId });
+      }
+    },
+    reset() {
+      this.selectedActId = null;
+      this.selectedSceneId = null;
+    },
+  },
+};
+</script>

--- a/client/src/vue_components/show/config/script/ScriptEditor.vue
+++ b/client/src/vue_components/show/config/script/ScriptEditor.vue
@@ -50,6 +50,13 @@
             >
               Save
             </b-button>
+            <b-button
+              v-if="canEdit && !IS_CUT_MODE"
+              :variant="bulkEditMode ? 'info' : 'outline-info'"
+              @click="bulkEditMode ? exitBulkEditMode() : enterBulkEditMode()"
+            >
+              {{ bulkEditMode ? 'Exit Bulk Edit' : 'Bulk Edit' }}
+            </b-button>
           </b-button-group>
         </b-col>
       </b-row>
@@ -98,6 +105,9 @@
               :line-part-cuts="linePartCuts"
               :stage-direction-styles="STAGE_DIRECTION_STYLES"
               :stage-direction-style-overrides="STAGE_DIRECTION_STYLE_OVERRIDES"
+              :bulk-edit-mode="bulkEditMode"
+              :is-bulk-start="isBulkStart(index)"
+              :is-bulk-end="isBulkEnd(index)"
               @editLine="beginEditingLine(currentEditPage, index)"
               @cutLinePart="cutLinePart"
               @insertDialogue="insertDialogueAt(currentEditPage, index)"
@@ -105,6 +115,8 @@
               @insertCueLine="insertCueLineAt(currentEditPage, index)"
               @insertSpacing="insertSpacingAt(currentEditPage, index)"
               @deleteLine="deleteLine(currentEditPage, index)"
+              @set-bulk-start="onSetBulkStart(index)"
+              @set-bulk-end="onSetBulkEnd(index)"
             />
           </template>
         </template>
@@ -155,6 +167,13 @@
         />
       </div>
     </b-modal>
+    <bulk-act-scene-modal
+      :previous-line-of-start="previousLineOfStart"
+      :next-line-of-end="nextLineOfEnd"
+      :acts="ACT_LIST"
+      :scenes="SCENE_LIST"
+      @apply="onBulkApply"
+    />
     <b-modal
       id="go-to-page-script-editor"
       ref="go-to-page-script-editor"
@@ -201,6 +220,7 @@ import { diff } from 'deep-object-diff';
 import log from 'loglevel';
 import { sample } from 'lodash';
 
+import BulkActSceneModal from '@/vue_components/show/config/script/BulkActSceneModal.vue';
 import ScriptLineEditor from '@/vue_components/show/config/script/ScriptLineEditor.vue';
 import ScriptLineViewer from '@/vue_components/show/config/script/ScriptLineViewer.vue';
 import { makeURL, randInt } from '@/js/utils';
@@ -209,7 +229,7 @@ import { LINE_TYPES } from '@/constants/lineTypes';
 
 export default {
   name: 'ScriptConfig',
-  components: { ScriptLineViewer, ScriptLineEditor },
+  components: { BulkActSceneModal, ScriptLineViewer, ScriptLineEditor },
   data() {
     return {
       currentEditPage: 1,
@@ -238,6 +258,11 @@ export default {
       autoSaveInterval: null,
       isAutoSaving: false,
       navbarHeight: 0,
+      bulkEditMode: false,
+      bulkEditStart: null,
+      bulkEditEnd: null,
+      previousLineOfStart: null,
+      nextLineOfEnd: null,
     };
   },
   validations: {
@@ -316,6 +341,12 @@ export default {
   watch: {
     currentEditPage(val) {
       localStorage.setItem('scriptEditPage', val);
+    },
+    async bulkEditEnd(val) {
+      if (val != null) {
+        await this.loadBoundaryLines();
+        this.$bvModal.show('bulk-act-scene-modal');
+      }
     },
     USER_SETTINGS() {
       this.setupAutoSave();
@@ -412,6 +443,7 @@ export default {
         }
       }
       this.editPages = [];
+      this.exitBulkEditMode();
       this.RESET_TO_SAVED(this.currentEditPage);
       this.resetCutsToSaved();
       this.$socket.sendObj({
@@ -917,6 +949,107 @@ export default {
       } else {
         this.navbarHeight = 56;
       }
+    },
+    enterBulkEditMode() {
+      this.bulkEditMode = true;
+      this.bulkEditStart = null;
+      this.bulkEditEnd = null;
+    },
+    exitBulkEditMode() {
+      this.bulkEditMode = false;
+      this.bulkEditStart = null;
+      this.bulkEditEnd = null;
+      this.previousLineOfStart = null;
+      this.nextLineOfEnd = null;
+    },
+    onSetBulkStart(index) {
+      this.bulkEditStart = {
+        page: this.currentEditPage,
+        lineIndex: index,
+      };
+      this.bulkEditEnd = null;
+    },
+    onSetBulkEnd(index) {
+      const { page: startPage, lineIndex: startIndex } = this.bulkEditStart || {};
+      if (startPage === this.currentEditPage && index <= startIndex) {
+        this.$toast.error('End line must come after start line');
+        return;
+      }
+      if (startPage != null && this.currentEditPage < startPage) {
+        this.$toast.error('End line must come after start line');
+        return;
+      }
+      this.bulkEditEnd = { page: this.currentEditPage, lineIndex: index };
+    },
+    isBulkStart(index) {
+      return (
+        this.bulkEditStart != null &&
+        this.bulkEditStart.page === this.currentEditPage &&
+        this.bulkEditStart.lineIndex === index
+      );
+    },
+    isBulkEnd(index) {
+      return (
+        this.bulkEditEnd != null &&
+        this.bulkEditEnd.page === this.currentEditPage &&
+        this.bulkEditEnd.lineIndex === index
+      );
+    },
+    async loadBoundaryLines() {
+      const { page: startPage, lineIndex: startIndex } = this.bulkEditStart;
+      const { page: endPage, lineIndex: endIndex } = this.bulkEditEnd;
+
+      if (startIndex === 0 && startPage > 1) {
+        await this.LOAD_SCRIPT_PAGE(startPage - 1);
+      }
+      const endPageLines = this.TMP_SCRIPT[endPage.toString()];
+      if (endPageLines && endIndex === endPageLines.length - 1) {
+        await this.LOAD_SCRIPT_PAGE(endPage + 1);
+      }
+
+      const startPageLines = this.TMP_SCRIPT[startPage.toString()];
+      if (startIndex > 0 && startPageLines) {
+        this.previousLineOfStart = startPageLines[startIndex - 1] || null;
+      } else if (startPage > 1) {
+        const prevPage = this.TMP_SCRIPT[(startPage - 1).toString()];
+        this.previousLineOfStart = prevPage ? prevPage[prevPage.length - 1] : null;
+      } else {
+        this.previousLineOfStart = null;
+      }
+
+      const endLines = this.TMP_SCRIPT[endPage.toString()];
+      if (endLines && endIndex < endLines.length - 1) {
+        this.nextLineOfEnd = endLines[endIndex + 1] || null;
+      } else {
+        const nextPage = this.TMP_SCRIPT[(endPage + 1).toString()];
+        this.nextLineOfEnd = nextPage ? nextPage[0] : null;
+      }
+    },
+    async onBulkApply({ actId, sceneId }) {
+      const { page: startPage, lineIndex: startIndex } = this.bulkEditStart;
+      const { page: endPage, lineIndex: endIndex } = this.bulkEditEnd;
+
+      for (let p = startPage; p <= endPage; p++) {
+        await this.LOAD_SCRIPT_PAGE(p);
+      }
+
+      for (let p = startPage; p <= endPage; p++) {
+        const pageLines = this.TMP_SCRIPT[p.toString()];
+        if (!pageLines) continue;
+        const fromIndex = p === startPage ? startIndex : 0;
+        const toIndex = p === endPage ? endIndex : pageLines.length - 1;
+        for (let i = fromIndex; i <= toIndex; i++) {
+          if (this.DELETED_LINES(p).includes(i)) continue;
+          this.SET_LINE({
+            pageNo: p,
+            lineIndex: i,
+            lineObj: { ...pageLines[i], act_id: actId, scene_id: sceneId },
+          });
+        }
+      }
+
+      this.$bvModal.hide('bulk-act-scene-modal');
+      this.exitBulkEditMode();
     },
     ...mapMutations([
       'REMOVE_PAGE',

--- a/client/src/vue_components/show/config/script/ScriptLineViewer.vue
+++ b/client/src/vue_components/show/config/script/ScriptLineViewer.vue
@@ -119,8 +119,24 @@
       </b-col>
     </template>
     <b-col cols="1" align-self="end">
+      <b-button-group v-if="bulkEditMode && canEdit && !IS_CUT_MODE">
+        <b-button
+          size="sm"
+          :variant="isBulkStart ? 'success' : 'outline-secondary'"
+          @click.stop="$emit('set-bulk-start')"
+        >
+          Start
+        </b-button>
+        <b-button
+          size="sm"
+          :variant="isBulkEnd ? 'success' : 'outline-secondary'"
+          @click.stop="$emit('set-bulk-end')"
+        >
+          End
+        </b-button>
+      </b-button-group>
       <b-dropdown
-        v-show="canEdit && !IS_CUT_MODE"
+        v-else-if="canEdit && !IS_CUT_MODE"
         split
         text="Edit"
         right
@@ -165,6 +181,8 @@ export default {
     'insertCueLine',
     'insertSpacing',
     'deleteLine',
+    'set-bulk-start',
+    'set-bulk-end',
   ],
   props: {
     line: {
@@ -214,6 +232,18 @@ export default {
     stageDirectionStyleOverrides: {
       required: true,
       type: Array,
+    },
+    bulkEditMode: {
+      type: Boolean,
+      default: false,
+    },
+    isBulkStart: {
+      type: Boolean,
+      default: false,
+    },
+    isBulkEnd: {
+      type: Boolean,
+      default: false,
     },
   },
   data() {


### PR DESCRIPTION
## Summary

Closes #998

- Adds a **Bulk Edit** toggle button to the script editor toolbar (visible when the user is the current editor and not in cut mode)
- In bulk edit mode, each script line's Edit dropdown is replaced with **Start** and **End** selection buttons
- Once a start and end line are chosen (across any number of pages), a modal opens with act/scene selects constrained to the valid range — the same ordering logic (`nextActs`/`nextScenes`) used by the single-line editor
- On confirm, all lines in the selected range are updated in `TMP_SCRIPT` via the existing `SET_LINE` mutation; the normal Save button and per-page PATCH endpoint handle persistence
- No backend changes required

## Test plan

- [ ] Enter edit mode on a show with multiple acts/scenes and a multi-page script
- [ ] Click **Bulk Edit** — verify toolbar button highlights and Edit dropdowns on lines are replaced with Start/End buttons
- [ ] Click **Start** on a line, navigate to another page, click **End** on a later line — verify the modal opens
- [ ] Verify the act/scene dropdowns in the modal are correctly constrained (options respect the previous line before start and next line after end)
- [ ] Select a valid act/scene and click Apply — verify all lines in the range update and the Save button becomes active
- [ ] Click Save — verify changes persist after reload
- [ ] Verify **Exit Bulk Edit** cancels the mode without making changes
- [ ] Verify selecting End before Start (same page) shows a toast error
- [ ] Verify Stop Editing also exits bulk edit mode and discards changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)