### PR TITLE
Fix Reset/Submit buttons always enabled in system settings

### DIFF
--- a/client/src/vue_components/config/ConfigSettings.vue
+++ b/client/src/vue_components/config/ConfigSettings.vue
@@ -100,7 +100,9 @@
                 style="float: right; padding-top: 1rem; padding-bottom: 0.5rem"
               >
                 <b-button type="reset" variant="danger" :disabled="!hasChanges"> Reset </b-button>
-                <b-button type="submit" variant="primary" :disabled="!hasChanges"> Submit </b-button>
+                <b-button type="submit" variant="primary" :disabled="!hasChanges">
+                  Submit
+                </b-button>
               </b-button-group>
             </div>
           </b-form>
@@ -155,7 +157,7 @@ export default {
     },
     hasChanges() {
       return Object.keys(this.editSettings).some(
-        (key) => this.editSettings[key] !== this.RAW_SETTINGS[key]?.value,
+        (key) => this.editSettings[key] !== this.RAW_SETTINGS[key]?.value
       );
     },
     dirtySettingsByCategory() {

--- a/client/src/vue_components/config/ConfigSettings.vue
+++ b/client/src/vue_components/config/ConfigSettings.vue
@@ -99,8 +99,8 @@
                 size="md"
                 style="float: right; padding-top: 1rem; padding-bottom: 0.5rem"
               >
-                <b-button type="reset" variant="danger"> Reset </b-button>
-                <b-button type="submit" variant="primary"> Submit </b-button>
+                <b-button type="reset" variant="danger" :disabled="!hasChanges"> Reset </b-button>
+                <b-button type="submit" variant="primary" :disabled="!hasChanges"> Submit </b-button>
               </b-button-group>
             </div>
           </b-form>
@@ -152,6 +152,11 @@ export default {
         });
       });
       return settingsByCategory;
+    },
+    hasChanges() {
+      return Object.keys(this.editSettings).some(
+        (key) => this.editSettings[key] !== this.RAW_SETTINGS[key]?.value,
+      );
     },
     dirtySettingsByCategory() {
       const dirtySettingsByCategory = {};


### PR DESCRIPTION
## Summary
- Closes #1003
- Adds a `hasChanges` computed property to `ConfigSettings.vue` that compares current `editSettings` values against the stored `RAW_SETTINGS` values
- Binds `:disabled="!hasChanges"` to both the Reset and Submit buttons so they are only enabled when there are actual unsaved changes
- Reverting a setting to its original value correctly disables both buttons again

## Test plan
- [ ] Load the settings page — both buttons are disabled
- [ ] Change a setting — both buttons become enabled
- [ ] Change the setting back to its original value — both buttons disable again
- [ ] Change multiple settings, revert some but not all — buttons remain enabled
- [ ] Click Reset — form reverts, both buttons disable
- [ ] Click Submit after making a change — settings save successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)