### PR TITLE
TypeScript migration Stage 3: type all Vuex store modules

### DIFF
--- a/client/src/js/http-interceptor.ts
+++ b/client/src/js/http-interceptor.ts
@@ -1,12 +1,11 @@
 import store from '@/store/store';
 import Vue from 'vue';
 import log from 'loglevel';
+import { makeURL } from '@/js/utils';
 
-// vue-toast-notification v0.6.x predates @types — cast the constructor for static toast calls
-const VueWithToast = Vue as typeof Vue & {
+const VueToast = Vue as typeof Vue & {
   $toast: { warning: (m: string) => void; error: (m: string) => void };
 };
-import { makeURL } from '@/js/utils';
 
 export default function setupHttpInterceptor(): void {
   // Store the original fetch function
@@ -56,7 +55,7 @@ export default function setupHttpInterceptor(): void {
 
           if (isRefreshRequest || isRefreshingToken) {
             log.warn('Token refresh failed with 401 or already refreshing, logging out');
-            VueWithToast.$toast.warning('Your session has expired. Please log in again.');
+            VueToast.$toast.warning('Your session has expired. Please log in again.');
             await store.dispatch('USER_LOGOUT');
             return response;
           }
@@ -83,7 +82,7 @@ export default function setupHttpInterceptor(): void {
               }
               // If refresh fails, handle unauthorized state
               log.warn('Token refresh failed, logging out');
-              VueWithToast.$toast.warning('Your session has expired. Please log in again.');
+              VueToast.$toast.warning('Your session has expired. Please log in again.');
               await store.dispatch('USER_LOGOUT');
 
               // Return the original 401 response
@@ -91,7 +90,7 @@ export default function setupHttpInterceptor(): void {
             } catch (refreshError) {
               isRefreshingToken = false;
               log.error('Error during token refresh:', refreshError);
-              VueWithToast.$toast.error('Authentication error - please log in again');
+              VueToast.$toast.error('Authentication error - please log in again');
               await store.dispatch('USER_LOGOUT');
               return response;
             }

--- a/client/src/store/modules/help.ts
+++ b/client/src/store/modules/help.ts
@@ -1,36 +1,55 @@
 import log from 'loglevel';
 import Fuse from 'fuse.js';
+import type { Module } from 'vuex';
+import type { RootState } from '@/types/store';
 
-export default {
+interface HelpManifestEntry {
+  title: string;
+  slug: string;
+  path: string;
+  category: string;
+}
+
+interface HelpState {
+  manifest: HelpManifestEntry[];
+  documents: Record<string, string>;
+  currentDocument: string | null;
+  loading: boolean;
+  error: string | null;
+  searchIndex: Fuse<HelpManifestEntry> | null;
+  searchResults: HelpManifestEntry[];
+}
+
+const module: Module<HelpState, RootState> = {
   state: {
-    manifest: [], // Array of { title, slug, path, category }
-    documents: {}, // Cache: { slug: markdownContent }
-    currentDocument: null, // Currently viewed doc slug
+    manifest: [],
+    documents: {},
+    currentDocument: null,
     loading: false,
     error: null,
-    searchIndex: null, // Fuse.js instance
+    searchIndex: null,
     searchResults: [],
   },
   mutations: {
-    SET_MANIFEST(state, manifest) {
+    SET_MANIFEST(state: HelpState, manifest: HelpManifestEntry[]) {
       state.manifest = manifest;
     },
-    SET_DOCUMENT(state, { slug, content }) {
+    SET_DOCUMENT(state: HelpState, { slug, content }: { slug: string; content: string }) {
       state.documents[slug] = content;
     },
-    SET_LOADING(state, loading) {
+    SET_LOADING(state: HelpState, loading: boolean) {
       state.loading = loading;
     },
-    SET_ERROR(state, error) {
+    SET_ERROR(state: HelpState, error: string | null) {
       state.error = error;
     },
-    SET_CURRENT_DOCUMENT(state, slug) {
+    SET_CURRENT_DOCUMENT(state: HelpState, slug: string) {
       state.currentDocument = slug;
     },
-    SET_SEARCH_INDEX(state, fuseInstance) {
+    SET_SEARCH_INDEX(state: HelpState, fuseInstance: Fuse<HelpManifestEntry>) {
       state.searchIndex = fuseInstance;
     },
-    SET_SEARCH_RESULTS(state, results) {
+    SET_SEARCH_RESULTS(state: HelpState, results: HelpManifestEntry[]) {
       state.searchResults = results;
     },
   },
@@ -45,7 +64,6 @@ export default {
         const manifest = await response.json();
         context.commit('SET_MANIFEST', manifest);
 
-        // Initialize Fuse.js search
         const fuse = new Fuse(manifest, {
           keys: ['title', 'path'],
           threshold: 0.3,
@@ -60,8 +78,7 @@ export default {
       }
     },
 
-    async LOAD_DOCUMENT(context, slug) {
-      // Check cache first
+    async LOAD_DOCUMENT(context, slug: string) {
       if (context.state.documents[slug]) {
         context.commit('SET_CURRENT_DOCUMENT', slug);
         context.commit('SET_ERROR', null);
@@ -95,7 +112,7 @@ export default {
       }
     },
 
-    SEARCH_DOCUMENTS(context, query) {
+    SEARCH_DOCUMENTS(context, query: string) {
       if (!context.state.searchIndex) {
         log.warn('Search index not initialized');
         return;
@@ -118,11 +135,13 @@ export default {
     },
   },
   getters: {
-    DOCUMENTATION_MANIFEST: (state) => state.manifest,
-    CURRENT_DOCUMENT_CONTENT: (state) =>
+    DOCUMENTATION_MANIFEST: (state: HelpState) => state.manifest,
+    CURRENT_DOCUMENT_CONTENT: (state: HelpState) =>
       state.currentDocument ? state.documents[state.currentDocument] : null,
-    IS_LOADING: (state) => state.loading,
-    ERROR: (state) => state.error,
-    SEARCH_RESULTS: (state) => state.searchResults,
+    IS_LOADING: (state: HelpState) => state.loading,
+    ERROR: (state: HelpState) => state.error,
+    SEARCH_RESULTS: (state: HelpState) => state.searchResults,
   },
 };
+
+export default module;

--- a/client/src/store/modules/script.ts
+++ b/client/src/store/modules/script.ts
@@ -1,9 +1,33 @@
 import Vue from 'vue';
 import log from 'loglevel';
+import type { Module } from 'vuex';
 
 import { makeURL } from '@/js/utils';
+import type { RootState } from '@/types/store';
+import type {
+  ScriptLine,
+  ScriptRevision,
+  StageDirectionStyle,
+  ScriptCut,
+  CompiledScript,
+} from '@/types/api/script';
+import type { Cue } from '@/types/api/cues';
 
-export default {
+interface ScriptState {
+  currentRevision: number | null;
+  revisions: ScriptRevision[];
+  script: Record<string, ScriptLine[]>;
+  cues: Record<string, Cue[]>;
+  cuts: ScriptCut[];
+  stageDirectionStyles: StageDirectionStyle[];
+  compiledScripts: CompiledScript[];
+}
+
+const VueToast = Vue as typeof Vue & {
+  $toast: { success: (m: string) => void; error: (m: string) => void };
+};
+
+const module: Module<ScriptState, RootState> = {
   state: {
     currentRevision: null,
     revisions: [],
@@ -14,25 +38,28 @@ export default {
     compiledScripts: [],
   },
   mutations: {
-    SET_REVISIONS(state, revisions) {
+    SET_REVISIONS(state: ScriptState, revisions: ScriptRevision[]) {
       state.revisions = revisions;
     },
-    SET_CURRENT_REVISION(state, currentRevision) {
+    SET_CURRENT_REVISION(state: ScriptState, currentRevision: number | null) {
       state.currentRevision = currentRevision;
     },
-    SET_SCRIPT_PAGE(state, { pageNumber, page }) {
+    SET_SCRIPT_PAGE(
+      state: ScriptState,
+      { pageNumber, page }: { pageNumber: string; page: ScriptLine[] }
+    ) {
       Vue.set(state.script, pageNumber, page);
     },
-    SET_CUES(state, cues) {
+    SET_CUES(state: ScriptState, cues: Record<string, Cue[]>) {
       state.cues = cues;
     },
-    SET_CUTS(state, cuts) {
+    SET_CUTS(state: ScriptState, cuts: ScriptCut[]) {
       state.cuts = cuts;
     },
-    SET_STAGE_DIRECTION_STYLES(state, styles) {
+    SET_STAGE_DIRECTION_STYLES(state: ScriptState, styles: StageDirectionStyle[]) {
       state.stageDirectionStyles = styles;
     },
-    SET_COMPILED_SCRIPTS(state, compiledScripts) {
+    SET_COMPILED_SCRIPTS(state: ScriptState, compiledScripts: CompiledScript[]) {
       state.compiledScripts = compiledScripts;
     },
   },
@@ -47,70 +74,65 @@ export default {
         log.error('Unable to get script revisions');
       }
     },
-    async ADD_SCRIPT_REVISION(context, scriptRevision) {
-      const payload = {
+    async ADD_SCRIPT_REVISION(
+      context,
+      scriptRevision: {
+        description: string;
+        parent_revision_id?: number | null;
+        set_as_current?: boolean | null;
+      }
+    ) {
+      const payload: Record<string, unknown> = {
         description: scriptRevision.description,
       };
 
-      // Add optional parent_revision_id if provided
       if (scriptRevision.parent_revision_id != null) {
         payload.parent_revision_id = scriptRevision.parent_revision_id;
       }
 
-      // Add optional set_as_current if provided (defaults to true on backend)
       if (scriptRevision.set_as_current != null) {
         payload.set_as_current = scriptRevision.set_as_current;
       }
 
       const response = await fetch(`${makeURL('/api/v1/show/script/revisions')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
       if (response.ok) {
         context.dispatch('GET_SCRIPT_REVISIONS');
-        Vue.$toast.success('Added new script revision!');
+        VueToast.$toast.success('Added new script revision!');
       } else {
         log.error('Unable to add new script revision');
-        Vue.$toast.error('Unable to add new script revision');
+        VueToast.$toast.error('Unable to add new script revision');
       }
     },
-    async DELETE_SCRIPT_REVISION(context, revisionID) {
-      const searchParams = new URLSearchParams({
-        rev_id: revisionID,
-      });
+    async DELETE_SCRIPT_REVISION(context, revisionID: number) {
+      const searchParams = new URLSearchParams({ rev_id: String(revisionID) });
       const response = await fetch(`${makeURL('/api/v1/show/script/revisions')}?${searchParams}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         context.dispatch('GET_SCRIPT_REVISIONS');
-        Vue.$toast.success('Deleted script revision!');
+        VueToast.$toast.success('Deleted script revision!');
       } else {
         log.error('Unable to delete script revision');
-        Vue.$toast.error('Unable to delete script revision');
+        VueToast.$toast.error('Unable to delete script revision');
       }
     },
-    async LOAD_SCRIPT_REVISION(context, revisionID) {
+    async LOAD_SCRIPT_REVISION(context, revisionID: number) {
       const response = await fetch(`${makeURL('/api/v1/show/script/revisions/current')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          new_rev_id: revisionID,
-        }),
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ new_rev_id: revisionID }),
       });
       if (response.ok) {
         context.dispatch('GET_SCRIPT_REVISIONS');
-        Vue.$toast.success('Loaded script revision!');
+        VueToast.$toast.success('Loaded script revision!');
       } else {
         log.error('Unable to load script revision');
-        Vue.$toast.error('Unable to load script revision');
+        VueToast.$toast.error('Unable to load script revision');
       }
     },
     async SCRIPT_REVISION_CHANGED(context) {
@@ -123,22 +145,15 @@ export default {
       await context.dispatch('LOAD_CUES');
       await context.dispatch('GET_CUTS');
     },
-    async LOAD_SCRIPT_PAGE(context, page) {
-      const searchParams = new URLSearchParams({
-        page,
-      });
+    async LOAD_SCRIPT_PAGE(context, page: string | number) {
+      const searchParams = new URLSearchParams({ page: String(page) });
       const response = await fetch(`${makeURL('/api/v1/show/script')}?${searchParams}`, {
         method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         const respJson = await response.json();
-        context.commit('SET_SCRIPT_PAGE', {
-          pageNumber: respJson.page,
-          page: respJson.lines,
-        });
+        context.commit('SET_SCRIPT_PAGE', { pageNumber: respJson.page, page: respJson.lines });
       } else {
         log.error('Unable to load script page');
       }
@@ -146,9 +161,7 @@ export default {
     async LOAD_CUES(context) {
       const response = await fetch(`${makeURL('/api/v1/show/cues')}`, {
         method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         const respJson = await response.json();
@@ -157,72 +170,66 @@ export default {
         log.error('Unable to load cues');
       }
     },
-    async ADD_NEW_CUE(context, cue) {
+    async ADD_NEW_CUE(context, cue: Partial<Cue>) {
       const response = await fetch(`${makeURL('/api/v1/show/cues')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(cue),
       });
       if (response.ok) {
         context.dispatch('LOAD_CUES');
-        Vue.$toast.success('Added new cue!');
+        VueToast.$toast.success('Added new cue!');
       } else {
         log.error('Unable to add new cue');
-        Vue.$toast.error('Unable to add new cue');
+        VueToast.$toast.error('Unable to add new cue');
       }
     },
-    async EDIT_CUE(context, cue) {
+    async EDIT_CUE(context, cue: Partial<Cue>) {
       const response = await fetch(`${makeURL('/api/v1/show/cues')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(cue),
       });
       if (response.ok) {
         context.dispatch('LOAD_CUES');
-        Vue.$toast.success('Edited cue!');
+        VueToast.$toast.success('Edited cue!');
       } else {
         log.error('Unable to edit cue');
-        Vue.$toast.error('Unable to edit cue');
+        VueToast.$toast.error('Unable to edit cue');
       }
     },
-    async DELETE_CUE(context, cue) {
+    async DELETE_CUE(context, cue: { cueId: number; lineId: number }) {
       const searchParams = new URLSearchParams({
-        cueId: cue.cueId,
-        lineId: cue.lineId,
+        cueId: String(cue.cueId),
+        lineId: String(cue.lineId),
       });
       const response = await fetch(`${makeURL('/api/v1/show/cues')}?${searchParams}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         context.dispatch('LOAD_CUES');
-        Vue.$toast.success('Deleted cue!');
+        VueToast.$toast.success('Deleted cue!');
       } else {
         log.error('Unable to delete cue');
-        Vue.$toast.error('Unable to delete cue');
+        VueToast.$toast.error('Unable to delete cue');
       }
     },
-    async SEARCH_CUES(context, { identifier, cueTypeId }) {
+    async SEARCH_CUES(
+      _context,
+      { identifier, cueTypeId }: { identifier: string; cueTypeId: number }
+    ) {
       const params = new URLSearchParams();
       params.append('identifier', identifier);
-      params.append('cue_type_id', cueTypeId);
+      params.append('cue_type_id', String(cueTypeId));
 
       const response = await fetch(`${makeURL('/api/v1/show/cues/search')}?${params}`, {
         method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
 
       if (response.ok) {
-        const result = await response.json();
-        return result;
+        return response.json();
       }
       log.error('Unable to search for cue');
       throw new Error('Cue search failed');
@@ -230,9 +237,7 @@ export default {
     async GET_CUTS(context) {
       const response = await fetch(`${makeURL('/api/v1/show/script/cuts')}`, {
         method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         const respJson = await response.json();
@@ -241,30 +246,24 @@ export default {
         log.error('Unable to load script cuts');
       }
     },
-    async SAVE_SCRIPT_CUTS(context, cuts) {
+    async SAVE_SCRIPT_CUTS(context, cuts: ScriptCut[]) {
       const response = await fetch(`${makeURL('/api/v1/show/script/cuts')}`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          cuts,
-        }),
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cuts }),
       });
       if (response.ok) {
         await context.dispatch('GET_CUTS');
-        Vue.$toast.success('Saved script cuts!');
+        VueToast.$toast.success('Saved script cuts!');
       } else {
         log.error('Unable to save script cuts');
-        Vue.$toast.error('Unable to save script cuts');
+        VueToast.$toast.error('Unable to save script cuts');
       }
     },
     async GET_STAGE_DIRECTION_STYLES(context) {
       const response = await fetch(`${makeURL('/api/v1/show/script/stage_direction_styles')}`, {
         method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         const respJson = await response.json();
@@ -273,57 +272,46 @@ export default {
         log.error('Unable to load stage direction styles');
       }
     },
-    async ADD_STAGE_DIRECTION_STYLE(context, style) {
+    async ADD_STAGE_DIRECTION_STYLE(context, style: Partial<StageDirectionStyle>) {
       const response = await fetch(`${makeURL('/api/v1/show/script/stage_direction_styles')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(style),
       });
       if (response.ok) {
         context.dispatch('GET_STAGE_DIRECTION_STYLES');
-        Vue.$toast.success('Added new stage direction style!');
+        VueToast.$toast.success('Added new stage direction style!');
       } else {
         log.error('Unable to add new stage direction style');
-        Vue.$toast.error('Unable to add new stage direction style');
+        VueToast.$toast.error('Unable to add new stage direction style');
       }
     },
-    async DELETE_STAGE_DIRECTION_STYLE(context, styleId) {
-      const searchParams = new URLSearchParams({
-        id: styleId,
-      });
+    async DELETE_STAGE_DIRECTION_STYLE(context, styleId: number) {
+      const searchParams = new URLSearchParams({ id: String(styleId) });
       const response = await fetch(
         `${makeURL('/api/v1/show/script/stage_direction_styles')}?${searchParams}`,
-        {
-          method: 'DELETE',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        }
+        { method: 'DELETE', headers: { 'Content-Type': 'application/json' } }
       );
       if (response.ok) {
         context.dispatch('GET_STAGE_DIRECTION_STYLES');
-        Vue.$toast.success('Deleted stage direction style!');
+        VueToast.$toast.success('Deleted stage direction style!');
       } else {
         log.error('Unable to delete stage direction style');
-        Vue.$toast.error('Unable to delete stage direction style');
+        VueToast.$toast.error('Unable to delete stage direction style');
       }
     },
-    async UPDATE_STAGE_DIRECTION_STYLE(context, style) {
+    async UPDATE_STAGE_DIRECTION_STYLE(context, style: Partial<StageDirectionStyle>) {
       const response = await fetch(`${makeURL('/api/v1/show/script/stage_direction_styles')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(style),
       });
       if (response.ok) {
         context.dispatch('GET_STAGE_DIRECTION_STYLES');
-        Vue.$toast.success('Updated stage direction style!');
+        VueToast.$toast.success('Updated stage direction style!');
       } else {
         log.error('Unable to edit stage direction style');
-        Vue.$toast.error('Unable to edit stage direction style');
+        VueToast.$toast.error('Unable to edit stage direction style');
       }
     },
     async GET_IMPORTABLE_STAGE_DIRECTION_STYLES() {
@@ -340,9 +328,7 @@ export default {
     async GET_COMPILED_SCRIPTS(context) {
       const response = await fetch(`${makeURL('/api/v1/show/script/compiled_scripts')}`, {
         method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         const respJson = await response.json();
@@ -353,30 +339,32 @@ export default {
     },
   },
   getters: {
-    SCRIPT_REVISIONS(state) {
+    SCRIPT_REVISIONS(state: ScriptState) {
       return state.revisions;
     },
-    CURRENT_REVISION(state) {
+    CURRENT_REVISION(state: ScriptState) {
       return state.currentRevision;
     },
-    GET_SCRIPT_PAGE: (state) => (page) => {
+    GET_SCRIPT_PAGE: (state: ScriptState) => (page: string | number) => {
       const pageStr = page.toString();
       if (Object.keys(state.script).includes(pageStr)) {
         return state.script[pageStr];
       }
       return [];
     },
-    SCRIPT_CUES(state) {
+    SCRIPT_CUES(state: ScriptState) {
       return state.cues;
     },
-    SCRIPT_CUTS(state) {
+    SCRIPT_CUTS(state: ScriptState) {
       return state.cuts;
     },
-    STAGE_DIRECTION_STYLES(state) {
+    STAGE_DIRECTION_STYLES(state: ScriptState) {
       return state.stageDirectionStyles;
     },
-    COMPILED_SCRIPTS(state) {
+    COMPILED_SCRIPTS(state: ScriptState) {
       return state.compiledScripts;
     },
   },
 };
+
+export default module;

--- a/client/src/store/modules/scriptConfig.ts
+++ b/client/src/store/modules/scriptConfig.ts
@@ -1,8 +1,24 @@
 import Vue from 'vue';
 import { detailedDiff } from 'deep-object-diff';
 import log from 'loglevel';
+import type { Module } from 'vuex';
 
 import { makeURL } from '@/js/utils';
+import type { RootState } from '@/types/store';
+import type { ScriptLine, PageStatus } from '@/types/api/script';
+
+interface EditStatus {
+  canRequestEdit: boolean;
+  currentEditor: string | null;
+}
+
+interface ScriptConfigState {
+  tmpScript: Record<string, ScriptLine[]>;
+  deletedLines: Record<string, number[]>;
+  editStatus: EditStatus;
+  cutMode: boolean;
+  insertedLines: Record<string, number[]>;
+}
 
 /**
  * Computes the page status object (added/updated/deleted/inserted) to send to the PATCH endpoint.
@@ -10,18 +26,17 @@ import { makeURL } from '@/js/utils';
  * deepDiff.added fires on a line index whenever *any* nested property is new — including a new
  * element in line_parts. Only lines with id == null are truly new; lines with an existing id that
  * have nested additions must be treated as updates instead.
- *
- * :param actualScriptPage: The current saved page from the store (will be cloned internally).
- * :param tmpScriptPage: The edited in-progress page.
- * :param deletedLines: Array of line indices marked for deletion.
- * :param insertedLines: Array of line indices that were inserted mid-page.
- * :returns: { added, updated, deleted, inserted }
  */
-export function computePageStatus(actualScriptPage, tmpScriptPage, deletedLines, insertedLines) {
-  const augmented = JSON.parse(JSON.stringify(actualScriptPage));
+export function computePageStatus(
+  actualScriptPage: ScriptLine[],
+  tmpScriptPage: ScriptLine[],
+  deletedLines: number[],
+  insertedLines: number[]
+): PageStatus {
+  const augmented: ScriptLine[] = JSON.parse(JSON.stringify(actualScriptPage));
   JSON.parse(JSON.stringify(insertedLines))
-    .sort((a, b) => a - b)
-    .forEach((lineIndex) => {
+    .sort((a: number, b: number) => a - b)
+    .forEach((lineIndex: number) => {
       augmented.splice(lineIndex, 0, JSON.parse(JSON.stringify(tmpScriptPage[lineIndex])));
     });
 
@@ -38,7 +53,9 @@ export function computePageStatus(actualScriptPage, tmpScriptPage, deletedLines,
   };
 }
 
-export default {
+const VueToast = Vue as typeof Vue & { $toast: { error: (m: string) => void } };
+
+const module: Module<ScriptConfigState, RootState> = {
   state: {
     tmpScript: {},
     deletedLines: {},
@@ -50,21 +67,30 @@ export default {
     insertedLines: {},
   },
   mutations: {
-    SET_EDIT_STATUS(state, editStatus) {
+    SET_EDIT_STATUS(state: ScriptConfigState, editStatus: EditStatus) {
       state.editStatus = editStatus;
     },
-    ADD_PAGE(state, { pageNo, pageContents }) {
+    ADD_PAGE(
+      state: ScriptConfigState,
+      { pageNo, pageContents }: { pageNo: number; pageContents: ScriptLine[] }
+    ) {
       Vue.set(state.tmpScript, pageNo, pageContents);
     },
-    REMOVE_PAGE(state, pageNo) {
+    REMOVE_PAGE(state: ScriptConfigState, pageNo: number) {
       Vue.delete(state.tmpScript, pageNo);
     },
-    ADD_BLANK_LINE(state, { pageNo, lineObj }) {
-      const line = JSON.parse(JSON.stringify(lineObj));
+    ADD_BLANK_LINE(
+      state: ScriptConfigState,
+      { pageNo, lineObj }: { pageNo: number; lineObj: ScriptLine }
+    ) {
+      const line: ScriptLine = JSON.parse(JSON.stringify(lineObj));
       line.page = pageNo;
       state.tmpScript[pageNo].push(line);
     },
-    INSERT_BLANK_LINE(state, { pageNo, lineIndex, lineObj }) {
+    INSERT_BLANK_LINE(
+      state: ScriptConfigState,
+      { pageNo, lineIndex, lineObj }: { pageNo: number; lineIndex: number; lineObj: ScriptLine }
+    ) {
       const pageNoStr = pageNo.toString();
 
       if (
@@ -72,13 +98,13 @@ export default {
         state.deletedLines[pageNoStr].includes(lineIndex)
       ) {
         const lineId = state.tmpScript[pageNoStr][lineIndex].id;
-        const line = JSON.parse(JSON.stringify(lineObj));
+        const line: ScriptLine = JSON.parse(JSON.stringify(lineObj));
         line.page = pageNo;
         line.id = lineId;
         state.tmpScript[pageNo].splice(lineIndex, 1, line);
         state.deletedLines[pageNoStr].splice(state.deletedLines[pageNoStr].indexOf(lineIndex), 1);
       } else {
-        const line = JSON.parse(JSON.stringify(lineObj));
+        const line: ScriptLine = JSON.parse(JSON.stringify(lineObj));
         line.page = pageNo;
         state.tmpScript[pageNo].splice(lineIndex, 0, line);
         if (!Object.keys(state.insertedLines).includes(pageNoStr)) {
@@ -87,10 +113,16 @@ export default {
         state.insertedLines[pageNoStr].push(lineIndex);
       }
     },
-    SET_LINE(state, { pageNo, lineIndex, lineObj }) {
+    SET_LINE(
+      state: ScriptConfigState,
+      { pageNo, lineIndex, lineObj }: { pageNo: number; lineIndex: number; lineObj: ScriptLine }
+    ) {
       Vue.set(state.tmpScript[pageNo], lineIndex, lineObj);
     },
-    DELETE_LINE(state, { pageNo, lineIndex }) {
+    DELETE_LINE(
+      state: ScriptConfigState,
+      { pageNo, lineIndex }: { pageNo: number; lineIndex: number }
+    ) {
       const pageNoStr = pageNo.toString();
       if (state.tmpScript[pageNoStr][lineIndex].id !== null) {
         if (!Object.keys(state.deletedLines).includes(pageNoStr)) {
@@ -107,28 +139,28 @@ export default {
         state.insertedLines[pageNoStr].splice(lineIndex, 1);
       }
     },
-    RESET_DELETED(state, pageNo) {
+    RESET_DELETED(state: ScriptConfigState, pageNo: number) {
       const pageNoStr = pageNo.toString();
       if (Object.keys(state.deletedLines).includes(pageNoStr)) {
         Vue.set(state.deletedLines, pageNoStr, []);
       }
     },
-    RESET_INSERTED(state, pageNo) {
+    RESET_INSERTED(state: ScriptConfigState, pageNo: number) {
       const pageNoStr = pageNo.toString();
       if (Object.keys(state.insertedLines).includes(pageNoStr)) {
         Vue.set(state.insertedLines, pageNoStr, []);
       }
     },
-    EMPTY_SCRIPT(state) {
+    EMPTY_SCRIPT(state: ScriptConfigState) {
       state.tmpScript = {};
     },
-    SET_CUT_MODE(state, cutMode) {
+    SET_CUT_MODE(state: ScriptConfigState, cutMode: boolean) {
       state.cutMode = cutMode;
     },
   },
   actions: {
     REQUEST_EDIT_FAILURE(context) {
-      Vue.$toast.error('Unable to edit script');
+      VueToast.$toast.error('Unable to edit script');
       context.dispatch('GET_SCRIPT_CONFIG_STATUS');
       context.commit('SET_CUT_MODE', false);
     },
@@ -141,7 +173,7 @@ export default {
         log.error('Unable to get script config status');
       }
     },
-    ADD_BLANK_PAGE(context, pageNo) {
+    ADD_BLANK_PAGE(context, pageNo: number) {
       const pageNoStr = pageNo.toString();
       const pageContents = JSON.parse(JSON.stringify(context.getters.GET_SCRIPT_PAGE(pageNoStr)));
       context.commit('ADD_PAGE', {
@@ -149,13 +181,13 @@ export default {
         pageContents,
       });
     },
-    RESET_TO_SAVED(context, pageNo) {
+    RESET_TO_SAVED(context, pageNo: number) {
       context.commit('EMPTY_SCRIPT');
       context.dispatch('ADD_BLANK_PAGE', pageNo);
     },
-    async SAVE_NEW_PAGE(context, pageNo) {
+    async SAVE_NEW_PAGE(context, pageNo: number) {
       const searchParams = new URLSearchParams({
-        page: pageNo,
+        page: String(pageNo),
       });
       const response = await fetch(`${makeURL('/api/v1/show/script')}?${searchParams}`, {
         method: 'POST',
@@ -170,8 +202,8 @@ export default {
       }
       return true;
     },
-    async SAVE_CHANGED_PAGE(context, pageNo) {
-      const tmpScriptPage = context.getters.TMP_SCRIPT[pageNo.toString()];
+    async SAVE_CHANGED_PAGE(context, pageNo: number) {
+      const tmpScriptPage: ScriptLine[] = context.getters.TMP_SCRIPT[pageNo.toString()];
       const pageStatus = computePageStatus(
         context.getters.GET_SCRIPT_PAGE(pageNo),
         tmpScriptPage,
@@ -179,7 +211,7 @@ export default {
         context.getters.INSERTED_LINES(pageNo)
       );
       const searchParams = new URLSearchParams({
-        page: pageNo,
+        page: String(pageNo),
       });
       const response = await fetch(`${makeURL('/api/v1/show/script')}?${searchParams}`, {
         method: 'PATCH',
@@ -199,29 +231,29 @@ export default {
     },
   },
   getters: {
-    TMP_SCRIPT(state) {
+    TMP_SCRIPT(state: ScriptConfigState) {
       return state.tmpScript;
     },
-    DELETED_LINES: (state) => (page) => {
+    DELETED_LINES: (state: ScriptConfigState) => (page: number | string) => {
       const pageStr = page.toString();
       if (Object.keys(state.deletedLines).includes(pageStr)) {
         return state.deletedLines[pageStr];
       }
       return [];
     },
-    ALL_DELETED_LINES(state) {
+    ALL_DELETED_LINES(state: ScriptConfigState) {
       return state.deletedLines;
     },
-    CAN_REQUEST_EDIT(state) {
+    CAN_REQUEST_EDIT(state: ScriptConfigState) {
       return state.editStatus.canRequestEdit;
     },
-    CURRENT_EDITOR(state) {
+    CURRENT_EDITOR(state: ScriptConfigState) {
       return state.editStatus.currentEditor;
     },
-    IS_CUT_MODE(state) {
+    IS_CUT_MODE(state: ScriptConfigState) {
       return state.cutMode;
     },
-    INSERTED_LINES: (state) => (page) => {
+    INSERTED_LINES: (state: ScriptConfigState) => (page: number | string) => {
       const pageStr = page.toString();
       if (Object.keys(state.insertedLines).includes(pageStr)) {
         return state.insertedLines[pageStr];
@@ -230,3 +262,5 @@ export default {
     },
   },
 };
+
+export default module;

--- a/client/src/store/modules/show.ts
+++ b/client/src/store/modules/show.ts
@@ -1,10 +1,53 @@
 import Vue from 'vue';
 import log from 'loglevel';
+import type { Module } from 'vuex';
 
 import { makeURL } from '@/js/utils';
-import { buildSceneGraph, detectMicConflicts } from '@/js/micConflictUtils';
+import { detectMicConflicts } from '@/js/micConflictUtils';
+import type { RootState } from '@/types/store';
+import type { Cast, Character, CharacterGroup, Act, Scene } from '@/types/api/show';
+import type { CueType } from '@/types/api/cues';
+import type { ShowSession, Interval, SessionTag } from '@/types/api/session';
+import type { Microphone, MicrophoneAllocation } from '@/types/api/microphones';
 
-export default {
+interface ToastInstance {
+  dismiss: () => void;
+}
+
+interface ScriptMode {
+  key: string;
+  value: number;
+}
+
+interface ShowState {
+  castList: Cast[];
+  characterList: Character[];
+  characterGroupList: CharacterGroup[];
+  actList: Act[];
+  sceneList: Scene[];
+  cueTypes: CueType[];
+  sessions: ShowSession[];
+  currentSession: ShowSession | null;
+  currentInterval: Interval | null;
+  sessionFollowData: Record<string, unknown>;
+  microphones: Microphone[];
+  micAllocations: MicrophoneAllocation[];
+  noLeaderToast: ToastInstance | null;
+  scriptModes: ScriptMode[];
+  sessionTags: SessionTag[];
+  stageManagerMode: boolean;
+}
+
+const VueToast = Vue as typeof Vue & {
+  $toast: {
+    success: (m: string) => void;
+    error: (m: string, opts?: { duration: number }) => void;
+    info: (m: string, opts?: { duration: number }) => void;
+    warning: (m: string, opts?: { duration: number }) => ToastInstance;
+  };
+};
+
+const module: Module<ShowState, RootState> = {
   state: {
     castList: [],
     characterList: [],
@@ -24,59 +67,59 @@ export default {
     stageManagerMode: false,
   },
   mutations: {
-    SET_CAST_LIST(state, castList) {
+    SET_CAST_LIST(state: ShowState, castList: Cast[]) {
       state.castList = castList;
     },
-    SET_CHARACTER_LIST(state, characterList) {
+    SET_CHARACTER_LIST(state: ShowState, characterList: Character[]) {
       state.characterList = characterList;
     },
-    SET_CHARACTER_GROUP_LIST(state, characterGroupList) {
+    SET_CHARACTER_GROUP_LIST(state: ShowState, characterGroupList: CharacterGroup[]) {
       state.characterGroupList = characterGroupList;
     },
-    SET_ACT_LIST(state, actList) {
+    SET_ACT_LIST(state: ShowState, actList: Act[]) {
       state.actList = actList;
     },
-    SET_SCENE_LIST(state, sceneList) {
+    SET_SCENE_LIST(state: ShowState, sceneList: Scene[]) {
       state.sceneList = sceneList;
     },
-    SET_CUE_TYPES(state, cueTypes) {
+    SET_CUE_TYPES(state: ShowState, cueTypes: CueType[]) {
       state.cueTypes = cueTypes;
     },
-    CLEAR_CURRENT_SHOW(state) {
+    CLEAR_CURRENT_SHOW(state: ShowState) {
       state.castList = [];
       state.characterList = [];
       state.actList = [];
       state.sceneList = [];
       state.sessionTags = [];
     },
-    SET_SESSIONS_LIST(state, sessions) {
+    SET_SESSIONS_LIST(state: ShowState, sessions: ShowSession[]) {
       state.sessions = sessions;
     },
-    SET_CURRENT_SESSION(state, session) {
+    SET_CURRENT_SESSION(state: ShowState, session: ShowSession | null) {
       state.currentSession = session;
     },
-    SET_CURRENT_INTERVAL(state, interval) {
+    SET_CURRENT_INTERVAL(state: ShowState, interval: Interval | null) {
       state.currentInterval = interval;
     },
-    SET_SESSION_FOLLOW_DATA(state, data) {
+    SET_SESSION_FOLLOW_DATA(state: ShowState, data: Record<string, unknown>) {
       state.sessionFollowData = data;
     },
-    SET_MIC_LIST(state, micList) {
+    SET_MIC_LIST(state: ShowState, micList: Microphone[]) {
       state.microphones = micList;
     },
-    SET_MIC_ALLOCATIONS_LIST(state, micAllocations) {
+    SET_MIC_ALLOCATIONS_LIST(state: ShowState, micAllocations: MicrophoneAllocation[]) {
       state.micAllocations = micAllocations;
     },
-    SET_TOAST_INSTANCE(state, toast) {
+    SET_TOAST_INSTANCE(state: ShowState, toast: ToastInstance | null) {
       state.noLeaderToast = toast;
     },
-    UPDATE_SCRIPT_MODES(state, modes) {
+    UPDATE_SCRIPT_MODES(state: ShowState, modes: ScriptMode[]) {
       state.scriptModes = modes;
     },
-    SET_SESSION_TAGS(state, tags) {
+    SET_SESSION_TAGS(state: ShowState, tags: SessionTag[]) {
       state.sessionTags = tags;
     },
-    SET_STAGE_MANAGER_MODE(state, enabled) {
+    SET_STAGE_MANAGER_MODE(state: ShowState, enabled: boolean) {
       state.stageManagerMode = enabled;
     },
   },
@@ -90,54 +133,46 @@ export default {
         log.error('Unable to get cast list');
       }
     },
-    async ADD_CAST_MEMBER(context, castMember) {
+    async ADD_CAST_MEMBER(context, castMember: Partial<Cast>) {
       const response = await fetch(`${makeURL('/api/v1/show/cast')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(castMember),
       });
       if (response.ok) {
         context.dispatch('GET_CAST_LIST');
-        Vue.$toast.success('Added new cast member!');
+        VueToast.$toast.success('Added new cast member!');
       } else {
         log.error('Unable to add new cast member');
-        Vue.$toast.error('Unable to add new cast member');
+        VueToast.$toast.error('Unable to add new cast member');
       }
     },
-    async DELETE_CAST_MEMBER(context, castID) {
-      const searchParams = new URLSearchParams({
-        id: castID,
-      });
+    async DELETE_CAST_MEMBER(context, castID: number) {
+      const searchParams = new URLSearchParams({ id: String(castID) });
       const response = await fetch(`${makeURL('/api/v1/show/cast')}?${searchParams}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         context.dispatch('GET_CAST_LIST');
-        Vue.$toast.success('Deleted cast member!');
+        VueToast.$toast.success('Deleted cast member!');
       } else {
         log.error('Unable to delete cast member');
-        Vue.$toast.error('Unable to delete cast member');
+        VueToast.$toast.error('Unable to delete cast member');
       }
     },
-    async UPDATE_CAST_MEMBER(context, castMember) {
+    async UPDATE_CAST_MEMBER(context, castMember: Partial<Cast>) {
       const response = await fetch(`${makeURL('/api/v1/show/cast')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(castMember),
       });
       if (response.ok) {
         context.dispatch('GET_CAST_LIST');
-        Vue.$toast.success('Updated cast member!');
+        VueToast.$toast.success('Updated cast member!');
       } else {
         log.error('Unable to edit cast member');
-        Vue.$toast.error('Unable to edit cast member');
+        VueToast.$toast.error('Unable to edit cast member');
       }
     },
     async GET_CHARACTER_LIST(context) {
@@ -149,54 +184,46 @@ export default {
         log.error('Unable to get characters list');
       }
     },
-    async ADD_CHARACTER(context, character) {
+    async ADD_CHARACTER(context, character: Partial<Character>) {
       const response = await fetch(`${makeURL('/api/v1/show/character')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(character),
       });
       if (response.ok) {
         context.dispatch('GET_CHARACTER_LIST');
-        Vue.$toast.success('Added new character!');
+        VueToast.$toast.success('Added new character!');
       } else {
         log.error('Unable to add new character');
-        Vue.$toast.error('Unable to add new character');
+        VueToast.$toast.error('Unable to add new character');
       }
     },
-    async DELETE_CHARACTER(context, characterID) {
-      const searchParams = new URLSearchParams({
-        id: characterID,
-      });
+    async DELETE_CHARACTER(context, characterID: number) {
+      const searchParams = new URLSearchParams({ id: String(characterID) });
       const response = await fetch(`${makeURL('/api/v1/show/character')}?${searchParams}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         context.dispatch('GET_CHARACTER_LIST');
-        Vue.$toast.success('Deleted character!');
+        VueToast.$toast.success('Deleted character!');
       } else {
         log.error('Unable to delete character');
-        Vue.$toast.error('Unable to delete character');
+        VueToast.$toast.error('Unable to delete character');
       }
     },
-    async UPDATE_CHARACTER(context, character) {
+    async UPDATE_CHARACTER(context, character: Partial<Character>) {
       const response = await fetch(`${makeURL('/api/v1/show/character')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(character),
       });
       if (response.ok) {
         context.dispatch('GET_CHARACTER_LIST');
-        Vue.$toast.success('Updated character!');
+        VueToast.$toast.success('Updated character!');
       } else {
         log.error('Unable to edit character');
-        Vue.$toast.error('Unable to edit character');
+        VueToast.$toast.error('Unable to edit character');
       }
     },
     async GET_CHARACTER_GROUP_LIST(context) {
@@ -209,54 +236,46 @@ export default {
         log.error('Unable to get characters list');
       }
     },
-    async ADD_CHARACTER_GROUP(context, act) {
+    async ADD_CHARACTER_GROUP(context, act: Partial<CharacterGroup>) {
       const response = await fetch(`${makeURL('/api/v1/show/character/group')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(act),
       });
       if (response.ok) {
         context.dispatch('GET_CHARACTER_GROUP_LIST');
-        Vue.$toast.success('Added new character group!');
+        VueToast.$toast.success('Added new character group!');
       } else {
         log.error('Unable to add new character group');
-        Vue.$toast.error('Unable to add new character group');
+        VueToast.$toast.error('Unable to add new character group');
       }
     },
-    async DELETE_CHARACTER_GROUP(context, characterGroupID) {
-      const searchParams = new URLSearchParams({
-        id: characterGroupID,
-      });
+    async DELETE_CHARACTER_GROUP(context, characterGroupID: number) {
+      const searchParams = new URLSearchParams({ id: String(characterGroupID) });
       const response = await fetch(`${makeURL('/api/v1/show/character/group')}?${searchParams}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         context.dispatch('GET_CHARACTER_GROUP_LIST');
-        Vue.$toast.success('Deleted character group!');
+        VueToast.$toast.success('Deleted character group!');
       } else {
         log.error('Unable to delete character group');
-        Vue.$toast.error('Unable to delete character group');
+        VueToast.$toast.error('Unable to delete character group');
       }
     },
-    async UPDATE_CHARACTER_GROUP(context, characterGroup) {
+    async UPDATE_CHARACTER_GROUP(context, characterGroup: Partial<CharacterGroup>) {
       const response = await fetch(`${makeURL('/api/v1/show/character/group')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(characterGroup),
       });
       if (response.ok) {
         context.dispatch('GET_CHARACTER_GROUP_LIST');
-        Vue.$toast.success('Updated character group!');
+        VueToast.$toast.success('Updated character group!');
       } else {
         log.error('Unable to edit character group');
-        Vue.$toast.error('Unable to edit character group');
+        VueToast.$toast.error('Unable to edit character group');
       }
     },
     async GET_ACT_LIST(context) {
@@ -268,70 +287,60 @@ export default {
         log.error('Unable to get acts list');
       }
     },
-    async ADD_ACT(context, act) {
+    async ADD_ACT(context, act: Partial<Act>) {
       const response = await fetch(`${makeURL('/api/v1/show/act')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(act),
       });
       if (response.ok) {
         context.dispatch('GET_ACT_LIST');
-        Vue.$toast.success('Added new act!');
+        VueToast.$toast.success('Added new act!');
       } else {
         log.error('Unable to add new act');
-        Vue.$toast.error('Unable to add new act');
+        VueToast.$toast.error('Unable to add new act');
       }
     },
-    async DELETE_ACT(context, actID) {
-      const searchParams = new URLSearchParams({
-        id: actID,
-      });
+    async DELETE_ACT(context, actID: number) {
+      const searchParams = new URLSearchParams({ id: String(actID) });
       const response = await fetch(`${makeURL('/api/v1/show/act')}?${searchParams}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         context.dispatch('GET_ACT_LIST');
-        Vue.$toast.success('Deleted act!');
+        VueToast.$toast.success('Deleted act!');
       } else {
         log.error('Unable to delete act');
-        Vue.$toast.error('Unable to delete act');
+        VueToast.$toast.error('Unable to delete act');
       }
     },
-    async UPDATE_ACT(context, act) {
+    async UPDATE_ACT(context, act: Partial<Act>) {
       const response = await fetch(`${makeURL('/api/v1/show/act')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(act),
       });
       if (response.ok) {
         context.dispatch('GET_ACT_LIST');
-        Vue.$toast.success('Updated act!');
+        VueToast.$toast.success('Updated act!');
       } else {
         log.error('Unable to edit act');
-        Vue.$toast.error('Unable to edit act');
+        VueToast.$toast.error('Unable to edit act');
       }
     },
-    async SET_ACT_FIRST_SCENE(context, act) {
+    async SET_ACT_FIRST_SCENE(context, act: Partial<Act>) {
       const response = await fetch(`${makeURL('/api/v1/show/act/first_scene')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(act),
       });
       if (response.ok) {
         context.dispatch('GET_ACT_LIST');
-        Vue.$toast.success('Updated act!');
+        VueToast.$toast.success('Updated act!');
       } else {
         log.error('Unable to edit act');
-        Vue.$toast.error('Unable to edit act');
+        VueToast.$toast.error('Unable to edit act');
       }
     },
     async GET_SCENE_LIST(context) {
@@ -343,57 +352,49 @@ export default {
         log.error('Unable to get scenes list');
       }
     },
-    async ADD_SCENE(context, scene) {
+    async ADD_SCENE(context, scene: Partial<Scene>) {
       const response = await fetch(`${makeURL('/api/v1/show/scene')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(scene),
       });
       if (response.ok) {
         context.dispatch('GET_SCENE_LIST');
         context.dispatch('GET_ACT_LIST');
-        Vue.$toast.success('Added new scene!');
+        VueToast.$toast.success('Added new scene!');
       } else {
         log.error('Unable to add new scene');
-        Vue.$toast.error('Unable to add new scene');
+        VueToast.$toast.error('Unable to add new scene');
       }
     },
-    async DELETE_SCENE(context, sceneID) {
-      const searchParams = new URLSearchParams({
-        id: sceneID,
-      });
+    async DELETE_SCENE(context, sceneID: number) {
+      const searchParams = new URLSearchParams({ id: String(sceneID) });
       const response = await fetch(`${makeURL('/api/v1/show/scene')}?${searchParams}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         context.dispatch('GET_SCENE_LIST');
         context.dispatch('GET_ACT_LIST');
-        Vue.$toast.success('Deleted scene!');
+        VueToast.$toast.success('Deleted scene!');
       } else {
         log.error('Unable to delete scene');
-        Vue.$toast.error('Unable to delete scene');
+        VueToast.$toast.error('Unable to delete scene');
       }
     },
-    async UPDATE_SCENE(context, scene) {
+    async UPDATE_SCENE(context, scene: Partial<Scene>) {
       const response = await fetch(`${makeURL('/api/v1/show/scene')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(scene),
       });
       if (response.ok) {
         context.dispatch('GET_SCENE_LIST');
         context.dispatch('GET_ACT_LIST');
-        Vue.$toast.success('Updated scene!');
+        VueToast.$toast.success('Updated scene!');
       } else {
         log.error('Unable to edit scene');
-        Vue.$toast.error('Unable to edit scene');
+        VueToast.$toast.error('Unable to edit scene');
       }
     },
     async GET_CUE_TYPES(context) {
@@ -405,54 +406,46 @@ export default {
         log.error('Unable to get cue types');
       }
     },
-    async ADD_CUE_TYPE(context, cueType) {
+    async ADD_CUE_TYPE(context, cueType: Partial<CueType>) {
       const response = await fetch(`${makeURL('/api/v1/show/cues/types')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(cueType),
       });
       if (response.ok) {
         context.dispatch('GET_CUE_TYPES');
-        Vue.$toast.success('Added new cue type!');
+        VueToast.$toast.success('Added new cue type!');
       } else {
         log.error('Unable to add new cue type');
-        Vue.$toast.error('Unable to add new cue type');
+        VueToast.$toast.error('Unable to add new cue type');
       }
     },
-    async DELETE_CUE_TYPE(context, cueTypeID) {
-      const searchParams = new URLSearchParams({
-        id: cueTypeID,
-      });
+    async DELETE_CUE_TYPE(context, cueTypeID: number) {
+      const searchParams = new URLSearchParams({ id: String(cueTypeID) });
       const response = await fetch(`${makeURL('/api/v1/show/cues/types')}?${searchParams}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         context.dispatch('GET_CUE_TYPES');
-        Vue.$toast.success('Deleted cue type!');
+        VueToast.$toast.success('Deleted cue type!');
       } else {
         log.error('Unable to delete cue type');
-        Vue.$toast.error('Unable to delete cue type');
+        VueToast.$toast.error('Unable to delete cue type');
       }
     },
-    async UPDATE_CUE_TYPE(context, cueType) {
+    async UPDATE_CUE_TYPE(context, cueType: Partial<CueType>) {
       const response = await fetch(`${makeURL('/api/v1/show/cues/types')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(cueType),
       });
       if (response.ok) {
         context.dispatch('GET_CUE_TYPES');
-        Vue.$toast.success('Updated cue type!');
+        VueToast.$toast.success('Updated cue type!');
       } else {
         log.error('Unable to edit cue type');
-        Vue.$toast.error('Unable to edit cue type');
+        VueToast.$toast.error('Unable to edit cue type');
       }
     },
     async GET_IMPORTABLE_CUE_TYPES() {
@@ -483,24 +476,23 @@ export default {
         log.error('Unable to get show sessions');
       }
     },
-    async ELECTED_LEADER(context, payload) {
-      Vue.$toast.info('You are now leader of the script - other clients will follow your view', {
-        duration: 0,
-      });
+    async ELECTED_LEADER(_context, _payload: unknown) {
+      VueToast.$toast.info(
+        'You are now leader of the script - other clients will follow your view',
+        { duration: 0 }
+      );
     },
-    async NO_LEADER(context, payload) {
+    async NO_LEADER(context, _payload: unknown) {
       await context.dispatch('GET_SHOW_SESSION_DATA');
       if (context.getters.NO_LEADER_TOAST == null) {
-        const instance = Vue.$toast.warning(
+        const instance = VueToast.$toast.warning(
           'There is no script leader. Please scroll your own script!',
-          {
-            duration: 0,
-          }
+          { duration: 0 }
         );
         context.commit('SET_TOAST_INSTANCE', instance);
       }
     },
-    SCRIPT_SCROLL(context, payload) {
+    SCRIPT_SCROLL(context, payload: { DATA: Record<string, unknown> }) {
       context.commit('SET_SESSION_FOLLOW_DATA', payload.DATA);
     },
     async GET_MICROPHONE_LIST(context) {
@@ -512,54 +504,46 @@ export default {
         log.error('Unable to get microphone list');
       }
     },
-    async ADD_MICROPHONE(context, microphone) {
+    async ADD_MICROPHONE(context, microphone: Partial<Microphone>) {
       const response = await fetch(`${makeURL('/api/v1/show/microphones')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(microphone),
       });
       if (response.ok) {
         context.dispatch('GET_MICROPHONE_LIST');
-        Vue.$toast.success('Added new microphone!');
+        VueToast.$toast.success('Added new microphone!');
       } else {
         log.error('Unable to add new microphone');
-        Vue.$toast.error('Unable to add new microphone');
+        VueToast.$toast.error('Unable to add new microphone');
       }
     },
-    async DELETE_MICROPHONE(context, microphoneId) {
-      const searchParams = new URLSearchParams({
-        id: microphoneId,
-      });
+    async DELETE_MICROPHONE(context, microphoneId: number) {
+      const searchParams = new URLSearchParams({ id: String(microphoneId) });
       const response = await fetch(`${makeURL('/api/v1/show/microphones')}?${searchParams}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         context.dispatch('GET_MICROPHONE_LIST');
-        Vue.$toast.success('Deleted microphone!');
+        VueToast.$toast.success('Deleted microphone!');
       } else {
         log.error('Unable to delete microphone');
-        Vue.$toast.error('Unable to delete microphone');
+        VueToast.$toast.error('Unable to delete microphone');
       }
     },
-    async UPDATE_MICROPHONE(context, microphone) {
+    async UPDATE_MICROPHONE(context, microphone: Partial<Microphone>) {
       const response = await fetch(`${makeURL('/api/v1/show/microphones')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(microphone),
       });
       if (response.ok) {
         context.dispatch('GET_MICROPHONE_LIST');
-        Vue.$toast.success('Updated microphone!');
+        VueToast.$toast.success('Updated microphone!');
       } else {
         log.error('Unable to edit microphone');
-        Vue.$toast.error('Unable to edit microphone');
+        VueToast.$toast.error('Unable to edit microphone');
       }
     },
     async GET_MIC_ALLOCATIONS(context) {
@@ -571,20 +555,18 @@ export default {
         log.error('Unable to get microphone allocations');
       }
     },
-    async UPDATE_MIC_ALLOCATIONS(context, allocations) {
+    async UPDATE_MIC_ALLOCATIONS(context, allocations: unknown) {
       const response = await fetch(`${makeURL('/api/v1/show/microphones/allocations')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(allocations),
       });
       if (response.ok) {
         context.dispatch('GET_MIC_ALLOCATIONS');
-        Vue.$toast.success('Updated microphone allocations!');
+        VueToast.$toast.success('Updated microphone allocations!');
       } else {
         log.error('Unable to edit microphone allocations');
-        Vue.$toast.error('Unable to edit microphone allocations');
+        VueToast.$toast.error('Unable to edit microphone allocations');
       }
     },
     async GET_SCRIPT_MODES(context) {
@@ -605,51 +587,45 @@ export default {
         log.error('Unable to get session tags');
       }
     },
-    async ADD_SESSION_TAG(context, tag) {
+    async ADD_SESSION_TAG(context, tag: Partial<SessionTag>) {
       const response = await fetch(`${makeURL('/api/v1/show/session/tags')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(tag),
       });
       if (response.ok) {
         context.dispatch('GET_SESSION_TAGS');
-        Vue.$toast.success('Added new session tag!');
+        VueToast.$toast.success('Added new session tag!');
       } else {
         log.error('Unable to add session tag');
-        Vue.$toast.error('Unable to add session tag');
+        VueToast.$toast.error('Unable to add session tag');
       }
     },
-    async UPDATE_SESSION_TAG(context, tag) {
+    async UPDATE_SESSION_TAG(context, tag: Partial<SessionTag>) {
       const response = await fetch(`${makeURL('/api/v1/show/session/tags')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(tag),
       });
       if (response.ok) {
         context.dispatch('GET_SESSION_TAGS');
-        Vue.$toast.success('Updated session tag!');
+        VueToast.$toast.success('Updated session tag!');
       } else {
         log.error('Unable to edit session tag');
-        Vue.$toast.error('Unable to edit session tag');
+        VueToast.$toast.error('Unable to edit session tag');
       }
     },
-    async DELETE_SESSION_TAG(context, tagId) {
+    async DELETE_SESSION_TAG(context, tagId: number) {
       const response = await fetch(`${makeURL('/api/v1/show/session/tags')}?id=${tagId}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         context.dispatch('GET_SESSION_TAGS');
-        Vue.$toast.success('Deleted session tag!');
+        VueToast.$toast.success('Deleted session tag!');
       } else {
         log.error('Unable to delete session tag');
-        Vue.$toast.error('Unable to delete session tag');
+        VueToast.$toast.error('Unable to delete session tag');
       }
     },
     async GET_IMPORTABLE_SESSION_TAGS() {
@@ -662,144 +638,130 @@ export default {
       }
       return response.json();
     },
-    async UPDATE_SESSION_TAGS(context, { sessionId, tagIds }) {
+    async UPDATE_SESSION_TAGS(
+      context,
+      { sessionId, tagIds }: { sessionId: number; tagIds: number[] }
+    ) {
       const response = await fetch(`${makeURL('/api/v1/show/sessions/assign-tags')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          session_id: sessionId,
-          tag_ids: tagIds,
-        }),
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ session_id: sessionId, tag_ids: tagIds }),
       });
       if (response.ok) {
         await context.dispatch('GET_SHOW_SESSION_DATA');
-        Vue.$toast.success('Updated session tags!');
+        VueToast.$toast.success('Updated session tags!');
       } else {
         const errorData = await response.json().catch(() => ({}));
         log.error('Unable to update session tags:', errorData);
-        Vue.$toast.error(errorData.message || 'Unable to update session tags');
+        VueToast.$toast.error(errorData.message || 'Unable to update session tags');
         throw new Error('Failed to update session tags');
       }
     },
   },
   getters: {
-    CAST_LIST(state) {
+    CAST_LIST(state: ShowState) {
       return state.castList;
     },
-    CAST_DICT(state) {
+    CAST_DICT(state: ShowState) {
       return Object.fromEntries(state.castList.map((cast) => [cast.id, cast]));
     },
-    CAST_BY_ID: (state, getters) => (castId) => {
-      if (castId == null) {
-        return null;
-      }
+    CAST_BY_ID: (_state: ShowState, getters) => (castId: number | null) => {
+      if (castId == null) return null;
       const castStr = castId.toString();
       if (Object.keys(getters.CAST_DICT).includes(castStr)) {
         return getters.CAST_DICT[castStr];
       }
       return null;
     },
-    CHARACTER_LIST(state) {
+    CHARACTER_LIST(state: ShowState) {
       return state.characterList;
     },
-    CHARACTER_DICT(state) {
+    CHARACTER_DICT(state: ShowState) {
       return Object.fromEntries(state.characterList.map((character) => [character.id, character]));
     },
-    CHARACTER_BY_ID: (state, getters) => (characterId) => {
-      if (characterId == null) {
-        return null;
-      }
+    CHARACTER_BY_ID: (_state: ShowState, getters) => (characterId: number | null) => {
+      if (characterId == null) return null;
       const characterStr = characterId.toString();
       if (Object.keys(getters.CHARACTER_DICT).includes(characterStr)) {
         return getters.CHARACTER_DICT[characterStr];
       }
       return null;
     },
-    CHARACTER_GROUP_LIST(state) {
+    CHARACTER_GROUP_LIST(state: ShowState) {
       return state.characterGroupList;
     },
-    ACT_LIST(state) {
+    ACT_LIST(state: ShowState) {
       return state.actList;
     },
-    ACT_DICT(state) {
+    ACT_DICT(state: ShowState) {
       return Object.fromEntries(state.actList.map((act) => [act.id, act]));
     },
-    ACT_BY_ID: (state, getters) => (actId) => {
-      if (actId == null) {
-        return null;
-      }
+    ACT_BY_ID: (_state: ShowState, getters) => (actId: number | null) => {
+      if (actId == null) return null;
       const actStr = actId.toString();
       if (Object.keys(getters.ACT_DICT).includes(actStr)) {
         return getters.ACT_DICT[actStr];
       }
       return null;
     },
-    SCENE_LIST(state) {
+    SCENE_LIST(state: ShowState) {
       return state.sceneList;
     },
-    SCENE_DICT(state) {
+    SCENE_DICT(state: ShowState) {
       return Object.fromEntries(state.sceneList.map((scene) => [scene.id, scene]));
     },
-    SCENE_BY_ID: (state, getters) => (sceneId) => {
-      if (sceneId == null) {
-        return null;
-      }
+    SCENE_BY_ID: (_state: ShowState, getters) => (sceneId: number | null) => {
+      if (sceneId == null) return null;
       const sceneStr = sceneId.toString();
       if (Object.keys(getters.SCENE_DICT).includes(sceneStr)) {
         return getters.SCENE_DICT[sceneStr];
       }
       return null;
     },
-    CUE_TYPES(state) {
+    CUE_TYPES(state: ShowState) {
       return state.cueTypes;
     },
-    CUE_TYPES_DICT(state) {
+    CUE_TYPES_DICT(state: ShowState) {
       return Object.fromEntries(state.cueTypes.map((cueType) => [cueType.id, cueType]));
     },
-    CUE_TYPE_BY_ID: (state, getters) => (cueTypeId) => {
-      if (cueTypeId == null) {
-        return null;
-      }
+    CUE_TYPE_BY_ID: (_state: ShowState, getters) => (cueTypeId: number | null) => {
+      if (cueTypeId == null) return null;
       const cueTypeStr = cueTypeId.toString();
       if (Object.keys(getters.CUE_TYPES_DICT).includes(cueTypeStr)) {
         return getters.CUE_TYPES_DICT[cueTypeStr];
       }
       return null;
     },
-    SHOW_SESSIONS_LIST(state) {
+    SHOW_SESSIONS_LIST(state: ShowState) {
       return state.sessions;
     },
-    CURRENT_SHOW_SESSION(state) {
+    CURRENT_SHOW_SESSION(state: ShowState) {
       return state.currentSession;
     },
-    CURRENT_SHOW_INTERVAL(state) {
+    CURRENT_SHOW_INTERVAL(state: ShowState) {
       return state.currentInterval;
     },
-    SESSION_FOLLOW_DATA(state) {
+    SESSION_FOLLOW_DATA(state: ShowState) {
       return state.sessionFollowData;
     },
-    MICROPHONES(state) {
+    MICROPHONES(state: ShowState) {
       return state.microphones;
     },
-    MICROPHONE_DICT(state) {
+    MICROPHONE_DICT(state: ShowState) {
       return Object.fromEntries(state.microphones.map((mic) => [mic.id, mic]));
     },
-    MICROPHONE_BY_ID: (state, getters) => (micId) => {
-      if (micId == null) {
-        return null;
-      }
+    MICROPHONE_BY_ID: (_state: ShowState, getters) => (micId: number | null) => {
+      if (micId == null) return null;
       const micStr = micId.toString();
       if (Object.keys(getters.MICROPHONE_DICT).includes(micStr)) {
         return getters.MICROPHONE_DICT[micStr];
       }
       return null;
     },
-    MIC_ALLOCATIONS(state) {
+    MIC_ALLOCATIONS(state: ShowState) {
       return state.micAllocations;
     },
-    ORDERED_SCENES(state, getters) {
+    ORDERED_SCENES(_state: ShowState, getters) {
       if (
         !getters.CURRENT_SHOW?.first_act_id ||
         !getters.SCENE_LIST?.length ||
@@ -808,7 +770,7 @@ export default {
         return [];
       }
 
-      const scenes = [];
+      const scenes: Scene[] = [];
       let currentAct = getters.ACT_BY_ID(getters.CURRENT_SHOW.first_act_id);
 
       while (currentAct != null) {
@@ -822,14 +784,13 @@ export default {
 
       return scenes;
     },
-    MIC_CONFLICTS(state, getters) {
-      // Transform MIC_ALLOCATIONS from array format to object format
-      const allocationsObj = {};
+    MIC_CONFLICTS(_state: ShowState, getters) {
+      const allocationsObj: Record<string, Record<number, number>> = {};
       Object.keys(getters.MIC_ALLOCATIONS).forEach((micId) => {
         const allocs = getters.MIC_ALLOCATIONS[micId];
-        const sceneData = {};
+        const sceneData: Record<number, number> = {};
         if (Array.isArray(allocs)) {
-          allocs.forEach((alloc) => {
+          allocs.forEach((alloc: { scene_id: number; character_id: number }) => {
             sceneData[alloc.scene_id] = alloc.character_id;
           });
         }
@@ -845,49 +806,45 @@ export default {
         getters.CAST_LIST
       );
     },
-    CONFLICTS_BY_SCENE(state, getters) {
+    CONFLICTS_BY_SCENE(_state: ShowState, getters) {
       return getters.MIC_CONFLICTS.conflictsByScene || {};
     },
-    CONFLICTS_BY_MIC(state, getters) {
+    CONFLICTS_BY_MIC(_state: ShowState, getters) {
       return getters.MIC_CONFLICTS.conflictsByMic || {};
     },
-    MIC_TIMELINE_DATA(state, getters) {
-      const scenes = getters.ORDERED_SCENES;
-      const allocations = getters.MIC_ALLOCATIONS;
-      const conflicts = getters.MIC_CONFLICTS.conflicts || [];
-
+    MIC_TIMELINE_DATA(_state: ShowState, getters) {
       return {
-        scenes,
-        allocations,
-        conflicts,
+        scenes: getters.ORDERED_SCENES,
+        allocations: getters.MIC_ALLOCATIONS,
+        conflicts: getters.MIC_CONFLICTS.conflicts || [],
         microphones: getters.MICROPHONES,
         characters: getters.CHARACTER_LIST,
       };
     },
-    NO_LEADER_TOAST(state) {
+    NO_LEADER_TOAST(state: ShowState) {
       return state.noLeaderToast;
     },
-    SCRIPT_MODES(state) {
+    SCRIPT_MODES(state: ShowState) {
       return state.scriptModes;
     },
-    SESSION_TAGS(state) {
+    SESSION_TAGS(state: ShowState) {
       return state.sessionTags;
     },
-    SESSION_TAGS_DICT(state) {
+    SESSION_TAGS_DICT(state: ShowState) {
       return Object.fromEntries(state.sessionTags.map((tag) => [tag.id, tag]));
     },
-    SESSION_TAG_BY_ID: (state, getters) => (tagId) => {
-      if (tagId == null) {
-        return null;
-      }
+    SESSION_TAG_BY_ID: (_state: ShowState, getters) => (tagId: number | null) => {
+      if (tagId == null) return null;
       const tagStr = tagId.toString();
       if (Object.keys(getters.SESSION_TAGS_DICT).includes(tagStr)) {
         return getters.SESSION_TAGS_DICT[tagStr];
       }
       return null;
     },
-    STAGE_MANAGER_MODE(state) {
+    STAGE_MANAGER_MODE(state: ShowState) {
       return state.stageManagerMode;
     },
   },
 };
+
+export default module;

--- a/client/src/store/modules/stage.ts
+++ b/client/src/store/modules/stage.ts
@@ -1,9 +1,36 @@
 import Vue from 'vue';
 import log from 'loglevel';
+import type { Module } from 'vuex';
 
 import { makeURL } from '@/js/utils';
+import type { RootState } from '@/types/store';
+import type {
+  Crew,
+  CrewAssignment,
+  SceneryType,
+  Scenery,
+  SceneryAllocation,
+  PropType,
+  Props,
+  PropsAllocation,
+} from '@/types/api/stage';
 
-export default {
+interface StageState {
+  crewList: Crew[];
+  crewAssignments: CrewAssignment[];
+  sceneryTypes: SceneryType[];
+  sceneryList: Scenery[];
+  sceneryAllocations: SceneryAllocation[];
+  propTypes: PropType[];
+  propsList: Props[];
+  propsAllocations: PropsAllocation[];
+}
+
+const VueToast = Vue as typeof Vue & {
+  $toast: { success: (m: string) => void; error: (m: string) => void };
+};
+
+const module: Module<StageState, RootState> = {
   state: {
     crewList: [],
     crewAssignments: [],
@@ -15,28 +42,28 @@ export default {
     propsAllocations: [],
   },
   mutations: {
-    SET_CREW_LIST(state, crewList) {
+    SET_CREW_LIST(state: StageState, crewList: Crew[]) {
       state.crewList = crewList;
     },
-    SET_CREW_ASSIGNMENTS(state, assignments) {
+    SET_CREW_ASSIGNMENTS(state: StageState, assignments: CrewAssignment[]) {
       state.crewAssignments = assignments;
     },
-    SET_SCENERY_TYPES(state, sceneryTypes) {
+    SET_SCENERY_TYPES(state: StageState, sceneryTypes: SceneryType[]) {
       state.sceneryTypes = sceneryTypes;
     },
-    SET_SCENERY_LIST(state, sceneryList) {
+    SET_SCENERY_LIST(state: StageState, sceneryList: Scenery[]) {
       state.sceneryList = sceneryList;
     },
-    SET_PROP_TYPES(state, propTypes) {
+    SET_PROP_TYPES(state: StageState, propTypes: PropType[]) {
       state.propTypes = propTypes;
     },
-    SET_PROPS_LIST(state, propsList) {
+    SET_PROPS_LIST(state: StageState, propsList: Props[]) {
       state.propsList = propsList;
     },
-    SET_PROPS_ALLOCATIONS(state, allocations) {
+    SET_PROPS_ALLOCATIONS(state: StageState, allocations: PropsAllocation[]) {
       state.propsAllocations = allocations;
     },
-    SET_SCENERY_ALLOCATIONS(state, allocations) {
+    SET_SCENERY_ALLOCATIONS(state: StageState, allocations: SceneryAllocation[]) {
       state.sceneryAllocations = allocations;
     },
   },
@@ -50,52 +77,46 @@ export default {
         log.error('Unable to get crew list');
       }
     },
-    async ADD_CREW_MEMBER(context, crewMember) {
+    async ADD_CREW_MEMBER(context, crewMember: Partial<Crew>) {
       const response = await fetch(`${makeURL('/api/v1/show/stage/crew')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(crewMember),
       });
       if (response.ok) {
         context.dispatch('GET_CREW_LIST');
-        Vue.$toast.success('Added new crew member!');
+        VueToast.$toast.success('Added new crew member!');
       } else {
         log.error('Unable to add new crew member');
-        Vue.$toast.error('Unable to add new crew member');
+        VueToast.$toast.error('Unable to add new crew member');
       }
     },
-    async DELETE_CREW_MEMBER(context, crewId) {
-      const searchParams = new URLSearchParams({ id: crewId });
+    async DELETE_CREW_MEMBER(context, crewId: number) {
+      const searchParams = new URLSearchParams({ id: String(crewId) });
       const response = await fetch(`${makeURL('/api/v1/show/stage/crew')}?${searchParams}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         context.dispatch('GET_CREW_LIST');
-        Vue.$toast.success('Deleted crew member!');
+        VueToast.$toast.success('Deleted crew member!');
       } else {
         log.error('Unable to delete crew member');
-        Vue.$toast.error('Unable to delete crew member');
+        VueToast.$toast.error('Unable to delete crew member');
       }
     },
-    async UPDATE_CREW_MEMBER(context, crewMember) {
+    async UPDATE_CREW_MEMBER(context, crewMember: Partial<Crew>) {
       const response = await fetch(`${makeURL('/api/v1/show/stage/crew')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(crewMember),
       });
       if (response.ok) {
         context.dispatch('GET_CREW_LIST');
-        Vue.$toast.success('Updated crew member!');
+        VueToast.$toast.success('Updated crew member!');
       } else {
         log.error('Unable to edit crew member');
-        Vue.$toast.error('Unable to edit crew member');
+        VueToast.$toast.error('Unable to edit crew member');
       }
     },
     async GET_SCENERY_TYPES(context) {
@@ -107,58 +128,47 @@ export default {
         log.error('Unable to get scenery types list');
       }
     },
-    async ADD_SCENERY_TYPE(context, sceneryType) {
+    async ADD_SCENERY_TYPE(context, sceneryType: Partial<SceneryType>) {
       const response = await fetch(`${makeURL('/api/v1/show/stage/scenery/types')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(sceneryType),
       });
       if (response.ok) {
         context.dispatch('GET_SCENERY_TYPES');
-        Vue.$toast.success('Added new scenery type!');
+        VueToast.$toast.success('Added new scenery type!');
       } else {
         log.error('Unable to add new scenery type');
-        Vue.$toast.error('Unable to add new scenery type');
+        VueToast.$toast.error('Unable to add new scenery type');
       }
     },
-    async DELETE_SCENERY_TYPE(context, sceneryTypeId) {
-      const searchParams = new URLSearchParams({
-        id: sceneryTypeId,
-      });
+    async DELETE_SCENERY_TYPE(context, sceneryTypeId: number) {
+      const searchParams = new URLSearchParams({ id: String(sceneryTypeId) });
       const response = await fetch(
         `${makeURL('/api/v1/show/stage/scenery/types')}?${searchParams}`,
-        {
-          method: 'DELETE',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        }
+        { method: 'DELETE', headers: { 'Content-Type': 'application/json' } }
       );
       if (response.ok) {
         context.dispatch('GET_SCENERY_TYPES');
         context.dispatch('GET_SCENERY_LIST');
-        Vue.$toast.success('Deleted scenery type!');
+        VueToast.$toast.success('Deleted scenery type!');
       } else {
         log.error('Unable to delete scenery type');
-        Vue.$toast.error('Unable to delete scenery type');
+        VueToast.$toast.error('Unable to delete scenery type');
       }
     },
-    async UPDATE_SCENERY_TYPE(context, sceneryType) {
+    async UPDATE_SCENERY_TYPE(context, sceneryType: Partial<SceneryType>) {
       const response = await fetch(`${makeURL('/api/v1/show/stage/scenery/types')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(sceneryType),
       });
       if (response.ok) {
         context.dispatch('GET_SCENERY_TYPES');
-        Vue.$toast.success('Updated scenery type!');
+        VueToast.$toast.success('Updated scenery type!');
       } else {
         log.error('Unable to edit scenery type');
-        Vue.$toast.error('Unable to edit scenery type');
+        VueToast.$toast.error('Unable to edit scenery type');
       }
     },
     async GET_SCENERY_LIST(context) {
@@ -170,54 +180,46 @@ export default {
         log.error('Unable to get scenery list');
       }
     },
-    async ADD_SCENERY(context, sceneryMember) {
+    async ADD_SCENERY(context, sceneryMember: Partial<Scenery>) {
       const response = await fetch(`${makeURL('/api/v1/show/stage/scenery')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(sceneryMember),
       });
       if (response.ok) {
         context.dispatch('GET_SCENERY_LIST');
-        Vue.$toast.success('Added new scenery member!');
+        VueToast.$toast.success('Added new scenery member!');
       } else {
         log.error('Unable to add new scenery member');
-        Vue.$toast.error('Unable to add new scenery member');
+        VueToast.$toast.error('Unable to add new scenery member');
       }
     },
-    async DELETE_SCENERY(context, sceneryId) {
-      const searchParams = new URLSearchParams({
-        id: sceneryId,
-      });
+    async DELETE_SCENERY(context, sceneryId: number) {
+      const searchParams = new URLSearchParams({ id: String(sceneryId) });
       const response = await fetch(`${makeURL('/api/v1/show/stage/scenery')}?${searchParams}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         context.dispatch('GET_SCENERY_LIST');
-        Vue.$toast.success('Deleted scenery member!');
+        VueToast.$toast.success('Deleted scenery member!');
       } else {
         log.error('Unable to delete scenery member');
-        Vue.$toast.error('Unable to delete scenery member');
+        VueToast.$toast.error('Unable to delete scenery member');
       }
     },
-    async UPDATE_SCENERY(context, sceneryMember) {
+    async UPDATE_SCENERY(context, sceneryMember: Partial<Scenery>) {
       const response = await fetch(`${makeURL('/api/v1/show/stage/scenery')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(sceneryMember),
       });
       if (response.ok) {
         context.dispatch('GET_SCENERY_LIST');
-        Vue.$toast.success('Updated scenery member!');
+        VueToast.$toast.success('Updated scenery member!');
       } else {
         log.error('Unable to edit scenery member');
-        Vue.$toast.error('Unable to edit scenery member');
+        VueToast.$toast.error('Unable to edit scenery member');
       }
     },
     async GET_PROP_TYPES(context) {
@@ -229,55 +231,47 @@ export default {
         log.error('Unable to get prop types list');
       }
     },
-    async ADD_PROP_TYPE(context, propType) {
+    async ADD_PROP_TYPE(context, propType: Partial<PropType>) {
       const response = await fetch(`${makeURL('/api/v1/show/stage/props/types')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(propType),
       });
       if (response.ok) {
         context.dispatch('GET_PROP_TYPES');
-        Vue.$toast.success('Added new prop type!');
+        VueToast.$toast.success('Added new prop type!');
       } else {
         log.error('Unable to add new prop type');
-        Vue.$toast.error('Unable to add new prop type');
+        VueToast.$toast.error('Unable to add new prop type');
       }
     },
-    async DELETE_PROP_TYPE(context, propTypeId) {
-      const searchParams = new URLSearchParams({
-        id: propTypeId,
-      });
+    async DELETE_PROP_TYPE(context, propTypeId: number) {
+      const searchParams = new URLSearchParams({ id: String(propTypeId) });
       const response = await fetch(`${makeURL('/api/v1/show/stage/props/types')}?${searchParams}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         context.dispatch('GET_PROP_TYPES');
         context.dispatch('GET_PROPS_LIST');
-        Vue.$toast.success('Deleted prop type!');
+        VueToast.$toast.success('Deleted prop type!');
       } else {
         log.error('Unable to delete prop type');
-        Vue.$toast.error('Unable to delete prop type');
+        VueToast.$toast.error('Unable to delete prop type');
       }
     },
-    async UPDATE_PROP_TYPE(context, propType) {
+    async UPDATE_PROP_TYPE(context, propType: Partial<PropType>) {
       const response = await fetch(`${makeURL('/api/v1/show/stage/props/types')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(propType),
       });
       if (response.ok) {
         context.dispatch('GET_PROP_TYPES');
-        Vue.$toast.success('Updated prop type!');
+        VueToast.$toast.success('Updated prop type!');
       } else {
         log.error('Unable to edit prop type');
-        Vue.$toast.error('Unable to edit prop type');
+        VueToast.$toast.error('Unable to edit prop type');
       }
     },
     async GET_PROPS_LIST(context) {
@@ -289,54 +283,46 @@ export default {
         log.error('Unable to get props list');
       }
     },
-    async ADD_PROP(context, propsMember) {
+    async ADD_PROP(context, propsMember: Partial<Props>) {
       const response = await fetch(`${makeURL('/api/v1/show/stage/props')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(propsMember),
       });
       if (response.ok) {
         context.dispatch('GET_PROPS_LIST');
-        Vue.$toast.success('Added new props member!');
+        VueToast.$toast.success('Added new props member!');
       } else {
         log.error('Unable to add new props member');
-        Vue.$toast.error('Unable to add new props member');
+        VueToast.$toast.error('Unable to add new props member');
       }
     },
-    async DELETE_PROP(context, propsId) {
-      const searchParams = new URLSearchParams({
-        id: propsId,
-      });
+    async DELETE_PROP(context, propsId: number) {
+      const searchParams = new URLSearchParams({ id: String(propsId) });
       const response = await fetch(`${makeURL('/api/v1/show/stage/props')}?${searchParams}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         context.dispatch('GET_PROPS_LIST');
-        Vue.$toast.success('Deleted props member!');
+        VueToast.$toast.success('Deleted props member!');
       } else {
         log.error('Unable to delete props member');
-        Vue.$toast.error('Unable to delete props member');
+        VueToast.$toast.error('Unable to delete props member');
       }
     },
-    async UPDATE_PROP(context, propsMember) {
+    async UPDATE_PROP(context, propsMember: Partial<Props>) {
       const response = await fetch(`${makeURL('/api/v1/show/stage/props')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(propsMember),
       });
       if (response.ok) {
         context.dispatch('GET_PROPS_LIST');
-        Vue.$toast.success('Updated props member!');
+        VueToast.$toast.success('Updated props member!');
       } else {
         log.error('Unable to edit props member');
-        Vue.$toast.error('Unable to edit props member');
+        VueToast.$toast.error('Unable to edit props member');
       }
     },
     async GET_PROPS_ALLOCATIONS(context) {
@@ -348,41 +334,32 @@ export default {
         log.error('Unable to get props allocations');
       }
     },
-    async ADD_PROPS_ALLOCATION(context, allocation) {
+    async ADD_PROPS_ALLOCATION(context, allocation: Partial<PropsAllocation>) {
       const response = await fetch(`${makeURL('/api/v1/show/stage/props/allocations')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(allocation),
       });
       if (response.ok) {
         context.dispatch('GET_PROPS_ALLOCATIONS');
-        Vue.$toast.success('Added prop allocation!');
+        VueToast.$toast.success('Added prop allocation!');
       } else {
         log.error('Unable to add prop allocation');
-        Vue.$toast.error('Unable to add prop allocation');
+        VueToast.$toast.error('Unable to add prop allocation');
       }
     },
-    async DELETE_PROPS_ALLOCATION(context, allocationId) {
-      const searchParams = new URLSearchParams({
-        id: allocationId,
-      });
+    async DELETE_PROPS_ALLOCATION(context, allocationId: number) {
+      const searchParams = new URLSearchParams({ id: String(allocationId) });
       const response = await fetch(
         `${makeURL('/api/v1/show/stage/props/allocations')}?${searchParams}`,
-        {
-          method: 'DELETE',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        }
+        { method: 'DELETE', headers: { 'Content-Type': 'application/json' } }
       );
       if (response.ok) {
         context.dispatch('GET_PROPS_ALLOCATIONS');
-        Vue.$toast.success('Deleted prop allocation!');
+        VueToast.$toast.success('Deleted prop allocation!');
       } else {
         log.error('Unable to delete prop allocation');
-        Vue.$toast.error('Unable to delete prop allocation');
+        VueToast.$toast.error('Unable to delete prop allocation');
       }
     },
     async GET_SCENERY_ALLOCATIONS(context) {
@@ -394,41 +371,32 @@ export default {
         log.error('Unable to get scenery allocations');
       }
     },
-    async ADD_SCENERY_ALLOCATION(context, allocation) {
+    async ADD_SCENERY_ALLOCATION(context, allocation: Partial<SceneryAllocation>) {
       const response = await fetch(`${makeURL('/api/v1/show/stage/scenery/allocations')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(allocation),
       });
       if (response.ok) {
         context.dispatch('GET_SCENERY_ALLOCATIONS');
-        Vue.$toast.success('Added scenery allocation!');
+        VueToast.$toast.success('Added scenery allocation!');
       } else {
         log.error('Unable to add scenery allocation');
-        Vue.$toast.error('Unable to add scenery allocation');
+        VueToast.$toast.error('Unable to add scenery allocation');
       }
     },
-    async DELETE_SCENERY_ALLOCATION(context, allocationId) {
-      const searchParams = new URLSearchParams({
-        id: allocationId,
-      });
+    async DELETE_SCENERY_ALLOCATION(context, allocationId: number) {
+      const searchParams = new URLSearchParams({ id: String(allocationId) });
       const response = await fetch(
         `${makeURL('/api/v1/show/stage/scenery/allocations')}?${searchParams}`,
-        {
-          method: 'DELETE',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        }
+        { method: 'DELETE', headers: { 'Content-Type': 'application/json' } }
       );
       if (response.ok) {
         context.dispatch('GET_SCENERY_ALLOCATIONS');
-        Vue.$toast.success('Deleted scenery allocation!');
+        VueToast.$toast.success('Deleted scenery allocation!');
       } else {
         log.error('Unable to delete scenery allocation');
-        Vue.$toast.error('Unable to delete scenery allocation');
+        VueToast.$toast.error('Unable to delete scenery allocation');
       }
     },
     async GET_CREW_ASSIGNMENTS(context) {
@@ -440,62 +408,55 @@ export default {
         log.error('Unable to get crew assignments');
       }
     },
-    async ADD_CREW_ASSIGNMENT(context, assignment) {
+    async ADD_CREW_ASSIGNMENT(context, assignment: Partial<CrewAssignment>) {
       const response = await fetch(`${makeURL('/api/v1/show/stage/crew/assignments')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(assignment),
       });
       if (response.ok) {
         context.dispatch('GET_CREW_ASSIGNMENTS');
-        Vue.$toast.success('Added crew assignment!');
+        VueToast.$toast.success('Added crew assignment!');
         return { success: true };
       } else {
         const errorData = await response.json().catch(() => ({}));
         const errorMsg = errorData.message || 'Unable to add crew assignment';
         log.error(errorMsg);
-        Vue.$toast.error(errorMsg);
+        VueToast.$toast.error(errorMsg);
         return { success: false, error: errorMsg };
       }
     },
-    async DELETE_CREW_ASSIGNMENT(context, assignmentId) {
-      const searchParams = new URLSearchParams({ id: assignmentId });
+    async DELETE_CREW_ASSIGNMENT(context, assignmentId: number) {
+      const searchParams = new URLSearchParams({ id: String(assignmentId) });
       const response = await fetch(
         `${makeURL('/api/v1/show/stage/crew/assignments')}?${searchParams}`,
-        {
-          method: 'DELETE',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        }
+        { method: 'DELETE', headers: { 'Content-Type': 'application/json' } }
       );
       if (response.ok) {
         context.dispatch('GET_CREW_ASSIGNMENTS');
-        Vue.$toast.success('Deleted crew assignment!');
+        VueToast.$toast.success('Deleted crew assignment!');
       } else {
         const errorData = await response.json().catch(() => ({}));
         const errorMsg = errorData.message || 'Unable to delete crew assignment';
         log.error(errorMsg);
-        Vue.$toast.error(errorMsg);
+        VueToast.$toast.error(errorMsg);
       }
     },
   },
   getters: {
-    CREW_LIST(state) {
+    CREW_LIST(state: StageState) {
       return state.crewList;
     },
-    PROP_BY_ID: (state) => (propId) => {
+    PROP_BY_ID: (state: StageState) => (propId: number | null) => {
       if (propId == null) return null;
       return state.propsList.find((p) => p.id === propId) || null;
     },
-    SCENERY_BY_ID: (state) => (sceneryId) => {
+    SCENERY_BY_ID: (state: StageState) => (sceneryId: number | null) => {
       if (sceneryId == null) return null;
       return state.sceneryList.find((s) => s.id === sceneryId) || null;
     },
-    PROPS_ALLOCATIONS_BY_ITEM(state) {
-      const result = {};
+    PROPS_ALLOCATIONS_BY_ITEM(state: StageState) {
+      const result: Record<number, PropsAllocation[]> = {};
       state.propsAllocations.forEach((alloc) => {
         if (!result[alloc.props_id]) {
           result[alloc.props_id] = [];
@@ -504,8 +465,8 @@ export default {
       });
       return result;
     },
-    SCENERY_ALLOCATIONS_BY_ITEM(state) {
-      const result = {};
+    SCENERY_ALLOCATIONS_BY_ITEM(state: StageState) {
+      const result: Record<number, SceneryAllocation[]> = {};
       state.sceneryAllocations.forEach((alloc) => {
         if (!result[alloc.scenery_id]) {
           result[alloc.scenery_id] = [];
@@ -514,61 +475,57 @@ export default {
       });
       return result;
     },
-    SCENERY_TYPES(state) {
+    SCENERY_TYPES(state: StageState) {
       return state.sceneryTypes;
     },
-    SCENERY_TYPES_DICT(state) {
+    SCENERY_TYPES_DICT(state: StageState) {
       return Object.fromEntries(
         state.sceneryTypes.map((sceneryType) => [sceneryType.id, sceneryType])
       );
     },
-    SCENERY_TYPE_BY_ID: (state, getters) => (sceneryTypeId) => {
-      if (sceneryTypeId == null) {
-        return null;
-      }
+    SCENERY_TYPE_BY_ID: (_state: StageState, getters) => (sceneryTypeId: number | null) => {
+      if (sceneryTypeId == null) return null;
       const sceneryTypeStr = sceneryTypeId.toString();
       if (Object.keys(getters.SCENERY_TYPES_DICT).includes(sceneryTypeStr)) {
         return getters.SCENERY_TYPES_DICT[sceneryTypeStr];
       }
       return null;
     },
-    SCENERY_LIST(state) {
+    SCENERY_LIST(state: StageState) {
       return state.sceneryList;
     },
-    PROP_TYPES(state) {
+    PROP_TYPES(state: StageState) {
       return state.propTypes;
     },
-    PROP_TYPES_DICT(state) {
+    PROP_TYPES_DICT(state: StageState) {
       return Object.fromEntries(state.propTypes.map((propType) => [propType.id, propType]));
     },
-    PROP_TYPE_BY_ID: (state, getters) => (propTypeId) => {
-      if (propTypeId == null) {
-        return null;
-      }
+    PROP_TYPE_BY_ID: (_state: StageState, getters) => (propTypeId: number | null) => {
+      if (propTypeId == null) return null;
       const propTypeStr = propTypeId.toString();
       if (Object.keys(getters.PROP_TYPES_DICT).includes(propTypeStr)) {
         return getters.PROP_TYPES_DICT[propTypeStr];
       }
       return null;
     },
-    PROPS_LIST(state) {
+    PROPS_LIST(state: StageState) {
       return state.propsList;
     },
-    PROPS_ALLOCATIONS(state) {
+    PROPS_ALLOCATIONS(state: StageState) {
       return state.propsAllocations;
     },
-    SCENERY_ALLOCATIONS(state) {
+    SCENERY_ALLOCATIONS(state: StageState) {
       return state.sceneryAllocations;
     },
-    CREW_ASSIGNMENTS(state) {
+    CREW_ASSIGNMENTS(state: StageState) {
       return state.crewAssignments;
     },
-    CREW_MEMBER_BY_ID: (state) => (crewId) => {
+    CREW_MEMBER_BY_ID: (state: StageState) => (crewId: number | null) => {
       if (crewId == null) return null;
       return state.crewList.find((c) => c.id === crewId) || null;
     },
-    CREW_ASSIGNMENTS_BY_PROP(state) {
-      const result = {};
+    CREW_ASSIGNMENTS_BY_PROP(state: StageState) {
+      const result: Record<number, CrewAssignment[]> = {};
       state.crewAssignments.forEach((assignment) => {
         if (assignment.prop_id != null) {
           if (!result[assignment.prop_id]) {
@@ -579,8 +536,8 @@ export default {
       });
       return result;
     },
-    CREW_ASSIGNMENTS_BY_SCENERY(state) {
-      const result = {};
+    CREW_ASSIGNMENTS_BY_SCENERY(state: StageState) {
+      const result: Record<number, CrewAssignment[]> = {};
       state.crewAssignments.forEach((assignment) => {
         if (assignment.scenery_id != null) {
           if (!result[assignment.scenery_id]) {
@@ -591,8 +548,8 @@ export default {
       });
       return result;
     },
-    CREW_ASSIGNMENTS_BY_CREW(state) {
-      const result = {};
+    CREW_ASSIGNMENTS_BY_CREW(state: StageState) {
+      const result: Record<number, CrewAssignment[]> = {};
       state.crewAssignments.forEach((assignment) => {
         if (!result[assignment.crew_id]) {
           result[assignment.crew_id] = [];
@@ -601,8 +558,8 @@ export default {
       });
       return result;
     },
-    CREW_ASSIGNMENTS_BY_SCENE(state) {
-      const result = {};
+    CREW_ASSIGNMENTS_BY_SCENE(state: StageState) {
+      const result: Record<number, CrewAssignment[]> = {};
       state.crewAssignments.forEach((assignment) => {
         if (!result[assignment.scene_id]) {
           result[assignment.scene_id] = [];
@@ -613,3 +570,5 @@ export default {
     },
   },
 };
+
+export default module;

--- a/client/src/store/modules/system.ts
+++ b/client/src/store/modules/system.ts
@@ -1,9 +1,21 @@
 import log from 'loglevel';
+import type { Module } from 'vuex';
 
 import router from '@/router';
 import { makeURL } from '@/js/utils';
+import type { RootState } from '@/types/store';
+import type { Show } from '@/types/api/show';
+import type { SystemSettings } from '@/types/api/settings';
 
-export default {
+interface SystemState {
+  settings: SystemSettings | Record<string, never>;
+  availableShows: Show[];
+  rawSettings: Record<string, unknown>;
+  rbacRoles: Array<{ key: string; value: number }>;
+  settingsCategories: Record<string, unknown>;
+}
+
+const module: Module<SystemState, RootState> = {
   state: {
     settings: {},
     availableShows: [],
@@ -12,19 +24,19 @@ export default {
     settingsCategories: {},
   },
   mutations: {
-    UPDATE_SETTINGS(state, settings) {
+    UPDATE_SETTINGS(state: SystemState, settings: SystemSettings) {
       state.settings = settings;
     },
-    UPDATE_SHOWS(state, shows) {
+    UPDATE_SHOWS(state: SystemState, shows: Show[]) {
       state.availableShows = shows;
     },
-    UPDATE_RAW_SETTINGS(state, settings) {
+    UPDATE_RAW_SETTINGS(state: SystemState, settings: Record<string, unknown>) {
       state.rawSettings = settings;
     },
-    UPDATE_RBAC_ROLES(state, rbac) {
+    UPDATE_RBAC_ROLES(state: SystemState, rbac: Array<{ key: string; value: number }>) {
       state.rbacRoles = rbac;
     },
-    UPDATE_SETTINGS_CATEGORIES(state, categories) {
+    UPDATE_SETTINGS_CATEGORIES(state: SystemState, categories: Record<string, unknown>) {
       state.settingsCategories = categories;
     },
   },
@@ -56,7 +68,7 @@ export default {
         log.error('Unable to fetch settings');
       }
     },
-    async UPDATE_SETTINGS(context, payload) {
+    async UPDATE_SETTINGS(context, payload: SystemSettings) {
       context.commit('UPDATE_SETTINGS', payload);
       await context.dispatch('SETTINGS_CHANGED');
     },
@@ -65,7 +77,7 @@ export default {
 
       if (context.state.settings.current_show) {
         const currShow = context.state.settings.current_show;
-        if (!context.state.currentShow || context.state.currentShow.id !== currShow) {
+        if (!context.rootState.currentShow || context.rootState.currentShow.id !== currShow) {
           const response = await fetch(`${makeURL('/api/v1/show')}`);
           if (response.ok) {
             const show = await response.json();
@@ -103,20 +115,22 @@ export default {
     },
   },
   getters: {
-    AVAILABLE_SHOWS(state) {
+    AVAILABLE_SHOWS(state: SystemState) {
       return state.availableShows;
     },
-    SETTINGS(state) {
+    SETTINGS(state: SystemState) {
       return state.settings;
     },
-    RAW_SETTINGS(state) {
+    RAW_SETTINGS(state: SystemState) {
       return state.rawSettings;
     },
-    RBAC_ROLES(state) {
+    RBAC_ROLES(state: SystemState) {
       return state.rbacRoles;
     },
-    SETTINGS_CATEGORIES(state) {
+    SETTINGS_CATEGORIES(state: SystemState) {
       return state.settingsCategories;
     },
   },
 };
+
+export default module;

--- a/client/src/store/modules/user/settings.ts
+++ b/client/src/store/modules/user/settings.ts
@@ -1,22 +1,39 @@
 import Vue from 'vue';
 import log from 'loglevel';
+import type { Module } from 'vuex';
 
 import { makeURL } from '@/js/utils';
+import type { RootState } from '@/types/store';
+import type { StageDirectionStyle } from '@/types/api/script';
+import type { CueColourOverride } from '@/types/api/user';
 
-export default {
+interface SettingsState {
+  userSettings: Record<string, unknown>;
+  stageDirectionStyleOverrides: StageDirectionStyle[];
+  cueColourOverrides: CueColourOverride[];
+}
+
+const VueToast = Vue as typeof Vue & {
+  $toast: {
+    success: (m: string) => void;
+    error: (m: string) => void;
+  };
+};
+
+const module: Module<SettingsState, RootState> = {
   state: {
     userSettings: {},
     stageDirectionStyleOverrides: [],
     cueColourOverrides: [],
   },
   mutations: {
-    SET_USER_SETTINGS(state, settings) {
+    SET_USER_SETTINGS(state: SettingsState, settings: Record<string, unknown>) {
       state.userSettings = settings;
     },
-    SET_STAGE_DIRECTION_STYLE_OVERRIDES(state, overrides) {
+    SET_STAGE_DIRECTION_STYLE_OVERRIDES(state: SettingsState, overrides: StageDirectionStyle[]) {
       state.stageDirectionStyleOverrides = overrides;
     },
-    SET_CUE_COLOUR_OVERRIDES(state, overrides) {
+    SET_CUE_COLOUR_OVERRIDES(state: SettingsState, overrides: CueColourOverride[]) {
       state.cueColourOverrides = overrides;
     },
   },
@@ -37,12 +54,7 @@ export default {
     async GET_STAGE_DIRECTION_STYLE_OVERRIDES(context) {
       const response = await fetch(
         `${makeURL('/api/v1/user/settings/stage_direction_overrides')}`,
-        {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        }
+        { method: 'GET', headers: { 'Content-Type': 'application/json' } }
       );
       if (response.ok) {
         const respJson = await response.json();
@@ -51,68 +63,57 @@ export default {
         log.error('Unable to load stage direction style overrides');
       }
     },
-    async ADD_STAGE_DIRECTION_STYLE_OVERRIDE(context, style) {
+    async ADD_STAGE_DIRECTION_STYLE_OVERRIDE(context, style: StageDirectionStyle) {
       const response = await fetch(
         `${makeURL('/api/v1/user/settings/stage_direction_overrides')}`,
         {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(style),
         }
       );
       if (response.ok) {
         context.dispatch('GET_STAGE_DIRECTION_STYLE_OVERRIDES');
-        Vue.$toast.success('Added new stage direction style override!');
+        VueToast.$toast.success('Added new stage direction style override!');
       } else {
         log.error('Unable to add new stage direction style override');
-        Vue.$toast.error('Unable to add new stage direction style override');
+        VueToast.$toast.error('Unable to add new stage direction style override');
       }
     },
-    async DELETE_STAGE_DIRECTION_STYLE_OVERRIDE(context, styleId) {
+    async DELETE_STAGE_DIRECTION_STYLE_OVERRIDE(context, styleId: number) {
       const response = await fetch(
         `${makeURL('/api/v1/user/settings/stage_direction_overrides')}?id=${styleId}`,
-        {
-          method: 'DELETE',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        }
+        { method: 'DELETE', headers: { 'Content-Type': 'application/json' } }
       );
       if (response.ok) {
         context.dispatch('GET_STAGE_DIRECTION_STYLE_OVERRIDES');
-        Vue.$toast.success('Deleted stage direction style override!');
+        VueToast.$toast.success('Deleted stage direction style override!');
       } else {
         log.error('Unable to delete stage direction style override');
-        Vue.$toast.error('Unable to delete stage direction style override');
+        VueToast.$toast.error('Unable to delete stage direction style override');
       }
     },
-    async UPDATE_STAGE_DIRECTION_STYLE_OVERRIDE(context, style) {
+    async UPDATE_STAGE_DIRECTION_STYLE_OVERRIDE(context, style: StageDirectionStyle) {
       const response = await fetch(
         `${makeURL('/api/v1/user/settings/stage_direction_overrides')}`,
         {
           method: 'PATCH',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(style),
         }
       );
       if (response.ok) {
         context.dispatch('GET_STAGE_DIRECTION_STYLE_OVERRIDES');
-        Vue.$toast.success('Updated stage direction style override!');
+        VueToast.$toast.success('Updated stage direction style override!');
       } else {
         log.error('Unable to edit stage direction style override');
-        Vue.$toast.error('Unable to edit stage direction style override');
+        VueToast.$toast.error('Unable to edit stage direction style override');
       }
     },
     async GET_CUE_COLOUR_OVERRIDES(context) {
       const response = await fetch(`${makeURL('/api/v1/user/settings/cue_colour_overrides')}`, {
         method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         const respJson = await response.json();
@@ -121,66 +122,59 @@ export default {
         log.error('Unable to load cue colour overrides');
       }
     },
-    async ADD_CUE_COLOUR_OVERRIDE(context, override) {
+    async ADD_CUE_COLOUR_OVERRIDE(context, override: CueColourOverride) {
       const response = await fetch(`${makeURL('/api/v1/user/settings/cue_colour_overrides')}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(override),
       });
       if (response.ok) {
         context.dispatch('GET_CUE_COLOUR_OVERRIDES');
-        Vue.$toast.success('Added new cue colour override!');
+        VueToast.$toast.success('Added new cue colour override!');
       } else {
         log.error('Unable to add new cue colour override');
-        Vue.$toast.error('Unable to add new cue colour override');
+        VueToast.$toast.error('Unable to add new cue colour override');
       }
     },
-    async DELETE_CUE_COLOUR_OVERRIDE(context, overrideId) {
+    async DELETE_CUE_COLOUR_OVERRIDE(context, overrideId: number) {
       const response = await fetch(
         `${makeURL(`/api/v1/user/settings/cue_colour_overrides?id=${overrideId}`)}`,
-        {
-          method: 'DELETE',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        }
+        { method: 'DELETE', headers: { 'Content-Type': 'application/json' } }
       );
       if (response.ok) {
         context.dispatch('GET_CUE_COLOUR_OVERRIDES');
-        Vue.$toast.success('Deleted cue colour override!');
+        VueToast.$toast.success('Deleted cue colour override!');
       } else {
         log.error('Unable to delete cue colour override');
-        Vue.$toast.error('Unable to delete cue colour override');
+        VueToast.$toast.error('Unable to delete cue colour override');
       }
     },
-    async UPDATE_CUE_COLOUR_OVERRIDE(context, override) {
+    async UPDATE_CUE_COLOUR_OVERRIDE(context, override: CueColourOverride) {
       const response = await fetch(`${makeURL('/api/v1/user/settings/cue_colour_overrides')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(override),
       });
       if (response.ok) {
         context.dispatch('GET_CUE_COLOUR_OVERRIDES');
-        Vue.$toast.success('Updated cue colour override!');
+        VueToast.$toast.success('Updated cue colour override!');
       } else {
         log.error('Unable to edit cue colour override');
-        Vue.$toast.error('Unable to edit cue colour override');
+        VueToast.$toast.error('Unable to edit cue colour override');
       }
     },
   },
   getters: {
-    USER_SETTINGS(state) {
+    USER_SETTINGS(state: SettingsState) {
       return state.userSettings;
     },
-    STAGE_DIRECTION_STYLE_OVERRIDES(state) {
+    STAGE_DIRECTION_STYLE_OVERRIDES(state: SettingsState) {
       return state.stageDirectionStyleOverrides;
     },
-    CUE_COLOUR_OVERRIDES(state) {
+    CUE_COLOUR_OVERRIDES(state: SettingsState) {
       return state.cueColourOverrides;
     },
   },
 };
+
+export default module;

--- a/client/src/store/modules/user/user.ts
+++ b/client/src/store/modules/user/user.ts
@@ -1,12 +1,27 @@
 import Vue from 'vue';
 import log from 'loglevel';
 import { isEmpty } from 'lodash';
+import type { Module } from 'vuex';
 
 import router from '@/router';
 import { makeURL } from '@/js/utils';
+import type { RootState } from '@/types/store';
+import type { User } from '@/types/api/user';
 import settings from './settings';
 
-export default {
+interface UserState {
+  currentUser: User | null;
+  currentRbac: Record<string, [number, number][]> | null;
+  users: User[];
+  authToken: string | null;
+  tokenRefreshInterval: ReturnType<typeof setInterval> | null;
+}
+
+const VueToast = Vue as typeof Vue & {
+  $toast: { success: (m: string) => void; error: (m: string) => void };
+};
+
+const module: Module<UserState, RootState> = {
   state: {
     currentUser: null,
     currentRbac: null,
@@ -15,16 +30,16 @@ export default {
     tokenRefreshInterval: null,
   },
   mutations: {
-    SET_CURRENT_USER(state, user) {
+    SET_CURRENT_USER(state: UserState, user: User | null) {
       state.currentUser = user;
     },
-    SET_USERS(state, users) {
+    SET_USERS(state: UserState, users: User[]) {
       state.users = users;
     },
-    SET_CURRENT_RBAC(state, rbac) {
+    SET_CURRENT_RBAC(state: UserState, rbac: Record<string, [number, number][]> | null) {
       state.currentRbac = rbac;
     },
-    SET_AUTH_TOKEN(state, token) {
+    SET_AUTH_TOKEN(state: UserState, token: string | null) {
       state.authToken = token;
       if (token) {
         localStorage.setItem('digiscript_auth_token', token);
@@ -32,7 +47,10 @@ export default {
         localStorage.removeItem('digiscript_auth_token');
       }
     },
-    SET_TOKEN_REFRESH_INTERVAL(state, intervalId) {
+    SET_TOKEN_REFRESH_INTERVAL(
+      state: UserState,
+      intervalId: ReturnType<typeof setInterval> | null
+    ) {
       if (state.tokenRefreshInterval) {
         clearInterval(state.tokenRefreshInterval);
       }
@@ -50,7 +68,7 @@ export default {
         await context.commit('SET_USERS', users.users);
       } else {
         log.error('Unable to get users');
-        Vue.$toast.error('Unable to fetch users!');
+        VueToast.$toast.error('Unable to fetch users!');
       }
     },
     async CREATE_USER(context, user) {
@@ -61,14 +79,14 @@ export default {
       });
       if (response.ok) {
         await context.dispatch('GET_USERS');
-        Vue.$toast.success('User created!');
+        VueToast.$toast.success('User created!');
       } else {
         const responseBody = await response.json();
         log.error('Unable to create user');
-        Vue.$toast.error(`Unable to create user: ${responseBody.message || 'Unknown error'}`);
+        VueToast.$toast.error(`Unable to create user: ${responseBody.message || 'Unknown error'}`);
       }
     },
-    async DELETE_USER(context, userId) {
+    async DELETE_USER(context, userId: number) {
       const response = await fetch(makeURL('/api/v1/auth/delete'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -76,14 +94,14 @@ export default {
       });
       if (response.ok) {
         await context.dispatch('GET_USERS');
-        Vue.$toast.success('User deleted!');
+        VueToast.$toast.success('User deleted!');
       } else {
         const responseBody = await response.json();
         log.error('Unable to delete user');
-        Vue.$toast.error(`Unable to delete user: ${responseBody.message || 'Unknown error'}`);
+        VueToast.$toast.error(`Unable to delete user: ${responseBody.message || 'Unknown error'}`);
       }
     },
-    async USER_LOGIN(context, user) {
+    async USER_LOGIN(context, user: { username: string; password: string }) {
       const response = await fetch(makeURL('/api/v1/auth/login'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -98,23 +116,21 @@ export default {
         if (data.access_token) {
           await context.commit('SET_AUTH_TOKEN', data.access_token);
         }
-
         await context.dispatch('GET_RBAC_ROLES');
         await context.dispatch('GET_CURRENT_USER');
         await context.dispatch('GET_CURRENT_RBAC');
         await context.dispatch('GET_USER_SETTINGS');
-
         await context.dispatch('AUTHENTICATE_WEBSOCKET');
         await context.dispatch('SETUP_TOKEN_REFRESH');
-        Vue.$toast.success('Successfully logged in!');
+        VueToast.$toast.success('Successfully logged in!');
         return true;
       }
       const responseBody = await response.json();
       log.error('Unable to log in');
-      Vue.$toast.error(`Unable to log in! ${responseBody.message}.`);
+      VueToast.$toast.error(`Unable to log in! ${responseBody.message}.`);
       return false;
     },
-    async TOKEN_REFRESH(context, payload) {
+    async TOKEN_REFRESH(context, payload: { DATA: { access_token: string } }) {
       log.info('Received token refresh from server');
       const newToken = payload.DATA.access_token;
       if (newToken) {
@@ -128,16 +144,13 @@ export default {
         clearInterval(context.state.tokenRefreshInterval);
         context.commit('SET_TOKEN_REFRESH_INTERVAL', null);
       }
-
       const token = context.state.authToken;
-
       await context.commit('SET_AUTH_TOKEN', null);
       await context.commit('SET_CURRENT_USER', null);
       await context.commit('SET_CURRENT_RBAC', null);
       await context.commit('SET_USER_SETTINGS', []);
       await context.commit('SET_STAGE_DIRECTION_STYLE_OVERRIDES', []);
       await context.commit('CLEAR_WS_AUTHENTICATION');
-
       if (token) {
         try {
           const response = await fetch(makeURL('/api/v1/auth/logout'), {
@@ -146,9 +159,7 @@ export default {
               'Content-Type': 'application/json',
               Authorization: `Bearer ${token}`,
             },
-            body: JSON.stringify({
-              session_id: context.rootGetters.INTERNAL_UUID,
-            }),
+            body: JSON.stringify({ session_id: context.rootGetters.INTERNAL_UUID }),
           });
           if (!response.ok) {
             log.error('Logout response was not OK, but local state was cleared');
@@ -159,7 +170,7 @@ export default {
       } else {
         log.info('Logout completed without API call - token already invalid');
       }
-      Vue.$toast.success('Successfully logged out!');
+      VueToast.$toast.success('Successfully logged out!');
       if (router.currentRoute.path !== '/') {
         router.push('/');
       }
@@ -215,10 +226,9 @@ export default {
         },
         1000 * 60 * 30
       );
-
       await context.commit('SET_TOKEN_REFRESH_INTERVAL', refreshInterval);
     },
-    async GENERATE_API_TOKEN(context) {
+    async GENERATE_API_TOKEN() {
       const response = await fetch(makeURL('/api/v1/auth/api-token/generate'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -226,53 +236,56 @@ export default {
       });
       if (response.ok) {
         const data = await response.json();
-        Vue.$toast.success('API token generated successfully!');
+        VueToast.$toast.success('API token generated successfully!');
         return data;
       }
       const responseBody = await response.json();
       log.error('Unable to generate API token');
-      Vue.$toast.error(`Unable to generate API token: ${responseBody.message || 'Unknown error'}`);
+      VueToast.$toast.error(
+        `Unable to generate API token: ${responseBody.message || 'Unknown error'}`
+      );
       return null;
     },
-    async REVOKE_API_TOKEN(context) {
+    async REVOKE_API_TOKEN() {
       const response = await fetch(makeURL('/api/v1/auth/api-token/revoke'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({}),
       });
       if (response.ok) {
-        Vue.$toast.success('API token revoked successfully!');
+        VueToast.$toast.success('API token revoked successfully!');
         return true;
       }
       const responseBody = await response.json();
       log.error('Unable to revoke API token');
-      Vue.$toast.error(`Unable to revoke API token: ${responseBody.message || 'Unknown error'}`);
+      VueToast.$toast.error(
+        `Unable to revoke API token: ${responseBody.message || 'Unknown error'}`
+      );
       return false;
     },
-    async GET_API_TOKEN(context) {
+    async GET_API_TOKEN() {
       const response = await fetch(makeURL('/api/v1/auth/api-token'), {
         method: 'GET',
       });
       if (response.ok) {
-        const data = await response.json();
-        return data;
+        return response.json();
       }
       log.error('Unable to get API token');
-      Vue.$toast.error('Unable to get API token!');
+      VueToast.$toast.error('Unable to get API token!');
       return null;
     },
   },
   getters: {
-    CURRENT_USER(state) {
+    CURRENT_USER(state: UserState) {
       return state.currentUser;
     },
-    USERS(state) {
+    USERS(state: UserState) {
       return state.users;
     },
-    CURRENT_USER_RBAC(state) {
+    CURRENT_USER_RBAC(state: UserState) {
       return state.currentRbac;
     },
-    AUTH_TOKEN(state) {
+    AUTH_TOKEN(state: UserState) {
       return state.authToken;
     },
   },
@@ -280,3 +293,5 @@ export default {
     settings,
   },
 };
+
+export default module;

--- a/client/src/store/modules/websocket.ts
+++ b/client/src/store/modules/websocket.ts
@@ -1,18 +1,42 @@
 import Vue from 'vue';
 import log from 'loglevel';
 import { debounce } from 'lodash';
+import type { Module } from 'vuex';
 
 import router from '@/router';
+import type { RootState } from '@/types/store';
+
+interface WebsocketState {
+  isConnected: boolean;
+  message: string;
+  reconnectError: boolean;
+  internalUUID: string | null;
+  errorCount: number;
+  error: boolean;
+  authenticated: boolean;
+  authenticationInProgress: boolean;
+  pendingAuthentication: boolean;
+  newConnection: boolean;
+  authSucceeded: boolean;
+}
+
+const VueToast = Vue as typeof Vue & {
+  $toast: {
+    success: (m: string) => void;
+    error: (m: string) => void;
+    info: (m: string) => void;
+  };
+};
 
 const settingsToast = debounce(
   () => {
-    Vue.$toast.info('Settings synced from server');
+    VueToast.$toast.info('Settings synced from server');
   },
   1000,
   { leading: true, trailing: false }
 );
 
-export default {
+const module: Module<WebsocketState, RootState> = {
   state: {
     isConnected: false,
     message: '',
@@ -27,29 +51,28 @@ export default {
     authSucceeded: false,
   },
   mutations: {
-    SOCKET_ONOPEN(state, event) {
-      Vue.prototype.$socket = event.currentTarget;
+    SOCKET_ONOPEN(state: WebsocketState, event: Event) {
+      Vue.prototype.$socket = (event as { currentTarget: unknown }).currentTarget;
       state.isConnected = true;
       state.error = false;
       state.reconnectError = false;
       if (state.errorCount !== 0) {
-        Vue.$toast.success(`Websocket reconnected after ${state.errorCount} attempts`);
+        VueToast.$toast.success(`Websocket reconnected after ${state.errorCount} attempts`);
         state.errorCount = 0;
-        if (router.currentRoute !== '/') {
+        if (router.currentRoute.path !== '/') {
           window.location.reload();
         }
       }
     },
-    SOCKET_ONCLOSE(state, event) {
+    SOCKET_ONCLOSE(state: WebsocketState) {
       state.isConnected = false;
       state.authenticated = false;
     },
-    SOCKET_ONERROR(state, event) {
+    SOCKET_ONERROR(state: WebsocketState) {
       state.error = true;
     },
-    // default handler called for all methods
-    SOCKET_ONMESSAGE(state, message) {
-      state.message = message;
+    SOCKET_ONMESSAGE(state: WebsocketState, message: { OP: string; DATA: unknown }) {
+      state.message = JSON.stringify(message);
       switch (message.OP) {
         case 'SET_UUID':
           if (state.internalUUID != null) {
@@ -60,7 +83,7 @@ export default {
             });
           } else {
             log.debug('Connecting to WebSocket as new client, with UUID:', message.DATA);
-            state.internalUUID = message.DATA;
+            state.internalUUID = message.DATA as string;
             state.newConnection = true;
           }
           if (!state.authenticated && !state.authenticationInProgress) {
@@ -88,12 +111,12 @@ export default {
         case 'GET_CAST_LIST':
           break;
         case 'START_SHOW':
-          if (router.currentRoute !== '/live') {
+          if (router.currentRoute.path !== '/live') {
             router.push('/live');
           }
           break;
         case 'STOP_SHOW':
-          if (router.currentRoute !== '/') {
+          if (router.currentRoute.path !== '/') {
             router.push('/');
           }
           break;
@@ -104,32 +127,31 @@ export default {
           log.error(`Unknown OP received from websocket: ${message.OP}`);
       }
     },
-    // mutations for reconnect methods
-    SOCKET_RECONNECT(state, count) {
+    SOCKET_RECONNECT(state: WebsocketState, count: number) {
       if (state.errorCount === 0) {
-        Vue.$toast.error('Websocket connection lost');
+        VueToast.$toast.error('Websocket connection lost');
       }
       state.errorCount = count;
       state.authenticated = false;
     },
-    SOCKET_RECONNECT_ERROR(state) {
+    SOCKET_RECONNECT_ERROR(state: WebsocketState) {
       state.reconnectError = true;
     },
-    CLEAR_WS_AUTHENTICATION(state) {
+    CLEAR_WS_AUTHENTICATION(state: WebsocketState) {
       state.authenticated = false;
       state.authSucceeded = false;
       state.pendingAuthentication = true;
     },
-    SET_WS_AUTHENTICATION_IN_PROGRESS(state, value) {
+    SET_WS_AUTHENTICATION_IN_PROGRESS(state: WebsocketState, value: boolean) {
       state.authenticationInProgress = value;
     },
-    CLEAR_PENDING_AUTHENTICATION(state) {
+    CLEAR_PENDING_AUTHENTICATION(state: WebsocketState) {
       state.pendingAuthentication = false;
     },
-    CLEAR_NEW_CONNECTION(state) {
+    CLEAR_NEW_CONNECTION(state: WebsocketState) {
       state.newConnection = false;
     },
-    CLEAR_AUTH_SUCCEEDED(state) {
+    CLEAR_AUTH_SUCCEEDED(state: WebsocketState) {
       state.authSucceeded = false;
     },
   },
@@ -180,7 +202,6 @@ export default {
       log.debug('Sent WebSocket authentication request');
     },
     async HANDLE_WS_AUTH_SUCCESS(context) {
-      // After successful authentication, register as a new client if this is a new connection
       if (context.state.newConnection) {
         if (Vue.prototype.$socket && Vue.prototype.$socket.readyState === WebSocket.OPEN) {
           Vue.prototype.$socket.sendObj({
@@ -209,14 +230,16 @@ export default {
     },
   },
   getters: {
-    WEBSOCKET_HEALTHY(state) {
+    WEBSOCKET_HEALTHY(state: WebsocketState) {
       return !state.error && state.isConnected && !state.reconnectError && state.errorCount === 0;
     },
-    INTERNAL_UUID(state) {
+    INTERNAL_UUID(state: WebsocketState) {
       return state.internalUUID;
     },
-    WEBSOCKET_HAS_PENDING_OPERATIONS(state) {
+    WEBSOCKET_HAS_PENDING_OPERATIONS(state: WebsocketState) {
       return state.pendingAuthentication || state.newConnection || state.authSucceeded;
     },
   },
 };
+
+export default module;

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -5,6 +5,7 @@ import log from 'loglevel';
 
 import { makeURL } from '@/js/utils';
 import { getStorageAdapter } from '@/js/platform';
+import type { Show } from '@/types/api/show';
 import user from '@/store/modules/user/user';
 import websocket from './modules/websocket';
 import system from './modules/system';
@@ -16,12 +17,16 @@ import stage from './modules/stage';
 
 Vue.use(Vuex);
 
-export default new Vuex.Store({
+const VueToast = Vue as typeof Vue & {
+  $toast: { success: (m: string) => void; error: (m: string) => void };
+};
+
+export default new Vuex.Store<{ currentShow: Show | null }>({
   state: {
     currentShow: null,
   },
   mutations: {
-    SET_CURRENT_SHOW(state, currShow) {
+    SET_CURRENT_SHOW(state, currShow: Show | null) {
       state.currentShow = currShow;
     },
   },
@@ -35,20 +40,18 @@ export default new Vuex.Store({
         log.error('Unable to get show details');
       }
     },
-    async UPDATE_SHOW(context, showDetails) {
+    async UPDATE_SHOW(context, showDetails: Partial<Show>) {
       const response = await fetch(`${makeURL('/api/v1/show')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(showDetails),
       });
       if (response.ok) {
         context.dispatch('GET_SHOW_DETAILS');
-        Vue.$toast.success('Updated show!');
+        VueToast.$toast.success('Updated show!');
       } else {
         log.error('Unable to edit show');
-        Vue.$toast.error('Unable to edit show');
+        VueToast.$toast.error('Unable to edit show');
       }
     },
     async SHOW_CHANGED(context) {
@@ -63,136 +66,109 @@ export default new Vuex.Store({
     CURRENT_SHOW(state) {
       return state.currentShow;
     },
-    IS_ADMIN_USER(state, getters) {
+    IS_ADMIN_USER(_state, getters) {
       return getters.CURRENT_USER != null && getters.CURRENT_USER.is_admin;
     },
-    IS_SHOW_EDITOR(state, getters) {
-      if (getters.IS_ADMIN_USER) {
-        return true;
-      }
-      if (getters.RBAC_ROLES.length === 0) {
-        return false;
-      }
+    IS_SHOW_EDITOR(_state, getters) {
+      if (getters.IS_ADMIN_USER) return true;
+      if (getters.RBAC_ROLES.length === 0) return false;
       if (
         getters.CURRENT_USER_RBAC == null ||
         !Object.keys(getters.CURRENT_USER_RBAC).includes('shows')
       ) {
         return false;
       }
-      const writeMask = getters.RBAC_ROLES.find((x) => x.key === 'WRITE').value;
+      const writeMask = getters.RBAC_ROLES.find((x: { key: string }) => x.key === 'WRITE').value;
       return (
         getters.CURRENT_USER != null && (getters.CURRENT_USER_RBAC.shows[0][1] & writeMask) !== 0
       );
     },
-    IS_SHOW_READER(state, getters) {
-      if (getters.IS_ADMIN_USER) {
-        return true;
-      }
-      if (getters.RBAC_ROLES.length === 0) {
-        return false;
-      }
+    IS_SHOW_READER(_state, getters) {
+      if (getters.IS_ADMIN_USER) return true;
+      if (getters.RBAC_ROLES.length === 0) return false;
       if (
         getters.CURRENT_USER_RBAC == null ||
         !Object.keys(getters.CURRENT_USER_RBAC).includes('shows')
       ) {
         return false;
       }
-      const readMask = getters.RBAC_ROLES.find((x) => x.key === 'READ').value;
+      const readMask = getters.RBAC_ROLES.find((x: { key: string }) => x.key === 'READ').value;
       return (
         getters.CURRENT_USER != null && (getters.CURRENT_USER_RBAC.shows[0][1] & readMask) !== 0
       );
     },
-    IS_SHOW_EXECUTOR(state, getters) {
-      if (getters.IS_ADMIN_USER) {
-        return true;
-      }
-      if (getters.RBAC_ROLES.length === 0) {
-        return false;
-      }
+    IS_SHOW_EXECUTOR(_state, getters) {
+      if (getters.IS_ADMIN_USER) return true;
+      if (getters.RBAC_ROLES.length === 0) return false;
       if (
         getters.CURRENT_USER_RBAC == null ||
         !Object.keys(getters.CURRENT_USER_RBAC).includes('shows')
       ) {
         return false;
       }
-      const execMask = getters.RBAC_ROLES.find((x) => x.key === 'EXECUTE').value;
-
+      const execMask = getters.RBAC_ROLES.find((x: { key: string }) => x.key === 'EXECUTE').value;
       return (
         getters.CURRENT_USER != null && (getters.CURRENT_USER_RBAC.shows[0][1] & execMask) !== 0
       );
     },
-    IS_SCRIPT_EDITOR(state, getters) {
-      if (getters.IS_ADMIN_USER) {
-        return true;
-      }
-      if (getters.RBAC_ROLES.length === 0) {
-        return false;
-      }
+    IS_SCRIPT_EDITOR(_state, getters) {
+      if (getters.IS_ADMIN_USER) return true;
+      if (getters.RBAC_ROLES.length === 0) return false;
       if (
         getters.CURRENT_USER_RBAC == null ||
         !Object.keys(getters.CURRENT_USER_RBAC).includes('script')
       ) {
         return false;
       }
-      const writeMask = getters.RBAC_ROLES.find((x) => x.key === 'WRITE').value;
+      const writeMask = getters.RBAC_ROLES.find((x: { key: string }) => x.key === 'WRITE').value;
       return (
         getters.CURRENT_USER != null && (getters.CURRENT_USER_RBAC.script[0][1] & writeMask) !== 0
       );
     },
-    IS_SCRIPT_READER(state, getters) {
-      if (getters.IS_ADMIN_USER) {
-        return true;
-      }
-      if (getters.RBAC_ROLES.length === 0) {
-        return false;
-      }
+    IS_SCRIPT_READER(_state, getters) {
+      if (getters.IS_ADMIN_USER) return true;
+      if (getters.RBAC_ROLES.length === 0) return false;
       if (
         getters.CURRENT_USER_RBAC == null ||
         !Object.keys(getters.CURRENT_USER_RBAC).includes('script')
       ) {
         return false;
       }
-      const readMask = getters.RBAC_ROLES.find((x) => x.key === 'READ').value;
+      const readMask = getters.RBAC_ROLES.find((x: { key: string }) => x.key === 'READ').value;
       return (
         getters.CURRENT_USER != null && (getters.CURRENT_USER_RBAC.script[0][1] & readMask) !== 0
       );
     },
-    IS_CUE_EDITOR(state, getters) {
-      if (getters.IS_ADMIN_USER) {
-        return true;
-      }
-      if (getters.RBAC_ROLES.length === 0) {
-        return false;
-      }
+    IS_CUE_EDITOR(_state, getters) {
+      if (getters.IS_ADMIN_USER) return true;
+      if (getters.RBAC_ROLES.length === 0) return false;
       if (
         getters.CURRENT_USER_RBAC == null ||
         !Object.keys(getters.CURRENT_USER_RBAC).includes('cuetypes')
       ) {
         return false;
       }
-      const writeMask = getters.RBAC_ROLES.find((x) => x.key === 'WRITE').value;
+      const writeMask = getters.RBAC_ROLES.find((x: { key: string }) => x.key === 'WRITE').value;
       return (
         getters.CURRENT_USER != null &&
-        getters.CURRENT_USER_RBAC.cuetypes.filter((x) => (x[1] & writeMask) !== 0).length > 0
+        getters.CURRENT_USER_RBAC.cuetypes.filter((x: [number, number]) => (x[1] & writeMask) !== 0)
+          .length > 0
       );
     },
-    IS_CUE_READER(state, getters) {
-      if (getters.IS_ADMIN_USER) {
-        return true;
-      }
-      if (getters.RBAC_ROLES.length === 0) {
-        return false;
-      }
+    IS_CUE_READER(_state, getters) {
+      if (getters.IS_ADMIN_USER) return true;
+      if (getters.RBAC_ROLES.length === 0) return false;
       if (
         getters.CURRENT_USER_RBAC == null ||
         !Object.keys(getters.CURRENT_USER_RBAC).includes('cuetypes')
       ) {
         return false;
       }
-      const readMask = getters.RBAC_ROLES.find((x) => x.key === 'READ').value;
+      const readMask = getters.RBAC_ROLES.find((x: { key: string }) => x.key === 'READ').value;
       return (
         getters.CURRENT_USER != null &&
-        getters.CURRENT_USER_RBAC.cuetypes.filter((x) => (x[1] & readMask) !== 0).length > 0
+        getters.CURRENT_USER_RBAC.cuetypes.filter((x: [number, number]) => (x[1] & readMask) !== 0)
+          .length > 0
       );
     },
   },

--- a/client/src/types/api/settings.ts
+++ b/client/src/types/api/settings.ts
@@ -2,3 +2,10 @@ export interface SystemSetting {
   key: string;
   value: string;
 }
+
+export interface SystemSettings {
+  current_show: number | null;
+  client_log_enabled: boolean | null;
+  client_log_level: string | null;
+  [key: string]: unknown;
+}

--- a/client/src/types/api/user.ts
+++ b/client/src/types/api/user.ts
@@ -8,6 +8,12 @@ export interface User {
   token_version: number;
 }
 
+export interface CueColourOverride {
+  id: number;
+  cue_type_id: number | null;
+  colour: string | null;
+}
+
 export interface UserSettings {
   enable_script_auto_save: boolean | null;
   script_auto_save_interval: number | null;

--- a/client/src/types/shims/vue-shims.d.ts
+++ b/client/src/types/shims/vue-shims.d.ts
@@ -9,11 +9,9 @@ declare module 'vue/types/vue' {
     info(message: string, options?: Record<string, unknown>): unknown;
     clear(): void;
   }
+  // Instance-level access (this.$toast in Vue components)
   interface Vue {
     $socket: WebSocket & { sendObj: (obj: object) => void };
-    $toast: VueToastPlugin;
-  }
-  interface VueConstructor {
     $toast: VueToastPlugin;
   }
 }

--- a/client/src/types/store.ts
+++ b/client/src/types/store.ts
@@ -1,0 +1,5 @@
+import type { Show } from './api/show';
+
+export interface RootState {
+  currentShow: Show | null;
+}


### PR DESCRIPTION
## Summary

- Renames all 10 Vuex store modules from `.js` to `.ts`
- Introduces `src/types/store.ts` with the `RootState` interface
- Extends `src/types/api/settings.ts` with `SystemSettings` and `src/types/api/user.ts` with `CueColourOverride`
- Each module gets a named `<Module>State` interface and a `Module<ModuleState, RootState>` type wrapper
- Mutation parameters and action payload types added throughout all modules
- Fixes latent bug in `websocket.ts`: `router.currentRoute` (a `Route` object) was compared directly to a string literal — corrected to `.path`
- Uses local `VueToast` cast pattern (established in Stage 2) uniformly across all modules

Targets `feature/typescript-migration` as the base for this stage PR.

## Test plan

- [x] `npm run test:run` — 106/106 tests pass
- [x] `npm run typecheck` — `tsc --noEmit` exits 0
- [x] `npm run ci-lint` — ESLint + Prettier clean
- [x] `npm run build` — Vite production build succeeds

🤖 Generated with [Claude Code](https://claude.ai/claude-code)