### PR TITLE
TypeScript migration Stage 5A: leaf components and simple views

### DIFF
--- a/client/eslint.config.mjs
+++ b/client/eslint.config.mjs
@@ -30,7 +30,10 @@ export default [
       sourceType: 'module',
       parser: pluginVue.processors['.vue'].parser,
       parserOptions: {
-        parser: babelParser,
+        parser: {
+          js: babelParser,
+          ts: tsParser,
+        },
         requireConfigFile: false,
         ecmaVersion: 13,
         sourceType: 'module',

--- a/client/src/views/404View.vue
+++ b/client/src/views/404View.vue
@@ -5,10 +5,12 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
   name: '404View',
-};
+});
 </script>
 
 <style scoped>

--- a/client/src/views/AboutView.vue
+++ b/client/src/views/AboutView.vue
@@ -11,3 +11,11 @@
     </ul>
   </div>
 </template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'AboutView',
+});
+</script>

--- a/client/src/views/HomeView.vue
+++ b/client/src/views/HomeView.vue
@@ -21,16 +21,17 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent } from 'vue';
 import { mapGetters } from 'vuex';
 
-export default {
+export default defineComponent({
   name: 'HomeView',
   computed: {
-    isAdminUser() {
+    isAdminUser(): boolean {
       return this.CURRENT_USER != null && this.CURRENT_USER.is_admin;
     },
     ...mapGetters(['SETTINGS', 'CURRENT_SHOW_SESSION', 'CURRENT_SHOW', 'CURRENT_USER']),
   },
-};
+});
 </script>

--- a/client/src/views/help/HelpDocView.vue
+++ b/client/src/views/help/HelpDocView.vue
@@ -10,30 +10,31 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent } from 'vue';
 import { mapGetters, mapActions } from 'vuex';
 import MarkdownRenderer from '@/vue_components/MarkdownRenderer.vue';
 
-export default {
+export default defineComponent({
   name: 'HelpDocView',
   components: {
     MarkdownRenderer,
   },
   computed: {
     ...mapGetters(['CURRENT_DOCUMENT_CONTENT', 'IS_LOADING', 'ERROR', 'DOCUMENTATION_MANIFEST']),
-    documentContent() {
+    documentContent(): string | null {
       return this.CURRENT_DOCUMENT_CONTENT;
     },
-    loading() {
+    loading(): boolean {
       return this.IS_LOADING;
     },
-    error() {
+    error(): string | null {
       return this.ERROR;
     },
   },
   watch: {
     '$route.params.slug': {
-      handler(newSlug) {
+      handler(newSlug: string) {
         if (newSlug) {
           this.loadDocument(newSlug);
         }
@@ -43,19 +44,18 @@ export default {
   },
   methods: {
     ...mapActions(['LOAD_DOCUMENT', 'LOAD_MANIFEST']),
-    async loadDocument(slug) {
-      // Wait for manifest to load if it hasn't been loaded yet
+    async loadDocument(slug: string): Promise<void> {
       if (!this.DOCUMENTATION_MANIFEST || this.DOCUMENTATION_MANIFEST.length === 0) {
-        await this.LOAD_MANIFEST();
+        await (this as any).LOAD_MANIFEST();
       }
-      await this.LOAD_DOCUMENT(slug);
+      await (this as any).LOAD_DOCUMENT(slug);
     },
-    async retry() {
+    async retry(): Promise<void> {
       const { slug } = this.$route.params;
       if (slug) {
         await this.loadDocument(slug);
       }
     },
   },
-};
+});
 </script>

--- a/client/src/views/user/ForcePasswordChangeView.vue
+++ b/client/src/views/user/ForcePasswordChangeView.vue
@@ -76,11 +76,12 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent } from 'vue';
 import { makeURL } from '@/js/utils';
 import passwordValidationMixin from '@/mixins/passwordValidation';
 
-export default {
+export default defineComponent({
   name: 'ForcePasswordChangeView',
   mixins: [passwordValidationMixin],
   data() {
@@ -95,20 +96,20 @@ export default {
   validations() {
     return {
       state: {
-        newPassword: this.getPasswordValidations(),
-        confirmPassword: this.getConfirmPasswordValidations('newPassword'),
+        newPassword: (this as any).getPasswordValidations(),
+        confirmPassword: (this as any).getConfirmPasswordValidations('newPassword'),
       },
     };
   },
   computed: {
-    isDisabled() {
-      return Boolean(this.$v.state.$invalid);
+    isDisabled(): boolean {
+      return Boolean((this as any).$v.state.$invalid);
     },
   },
   methods: {
-    async handlePasswordChange() {
-      this.$v.state.$touch();
-      if (this.$v.state.$anyError) {
+    async handlePasswordChange(): Promise<void> {
+      (this as any).$v.state.$touch();
+      if ((this as any).$v.state.$anyError) {
         return;
       }
 
@@ -117,45 +118,34 @@ export default {
       try {
         const response = await fetch(makeURL('/api/v1/auth/change-password'), {
           method: 'PATCH',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            new_password: this.state.newPassword,
-          }),
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ new_password: this.state.newPassword }),
         });
 
         if (response.ok) {
           const data = await response.json();
-
-          // Update auth token with new token
           if (data.access_token) {
             await this.$store.commit('SET_AUTH_TOKEN', data.access_token);
           }
-
-          // Refresh current user to clear requires_password_change flag
           await this.$store.dispatch('GET_CURRENT_USER');
-
           this.$toast.success('Password changed successfully!');
-
-          // Redirect to home page
           this.$router.push('/');
         } else {
           const error = await response.json();
           this.$toast.error(error.message || 'Failed to change password');
         }
-      } catch (error) {
+      } catch {
         this.$toast.error('An error occurred while changing password');
       } finally {
         this.loading = false;
       }
     },
-    async handleLogout() {
+    async handleLogout(): Promise<void> {
       await this.$store.dispatch('USER_LOGOUT');
       this.$router.push('/login');
     },
   },
-};
+});
 </script>
 
 <style scoped>

--- a/client/src/views/user/LoginView.vue
+++ b/client/src/views/user/LoginView.vue
@@ -47,11 +47,12 @@
   </b-container>
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent } from 'vue';
 import { required } from 'vuelidate/lib/validators';
 import { mapActions } from 'vuex';
 
-export default {
+export default defineComponent({
   name: 'LoginView',
   data() {
     return {
@@ -64,31 +65,27 @@ export default {
   },
   validations: {
     state: {
-      username: {
-        required,
-      },
-      password: {
-        required,
-      },
+      username: { required },
+      password: { required },
     },
   },
   computed: {
-    isDisabled() {
-      return Boolean(this.$v.state.$invalid);
+    isDisabled(): boolean {
+      return Boolean((this as any).$v.state.$invalid);
     },
   },
   methods: {
-    validateState(name) {
-      const { $dirty, $error } = this.$v.state[name];
+    validateState(name: string): boolean | null {
+      const { $dirty, $error } = (this as any).$v.state[name];
       return $dirty ? !$error : null;
     },
-    async doLogin(event) {
-      this.$v.state.$touch();
-      if (this.$v.state.$anyError) {
+    async doLogin(event: Event): Promise<void> {
+      (this as any).$v.state.$touch();
+      if ((this as any).$v.state.$anyError) {
         event.preventDefault();
       } else {
         this.showLoginFeedback = false;
-        const loginSuccess = await this.USER_LOGIN(this.state);
+        const loginSuccess = await (this as any).USER_LOGIN(this.state);
         if (loginSuccess) {
           this.$router.replace('/');
         } else {
@@ -98,7 +95,7 @@ export default {
     },
     ...mapActions(['USER_LOGIN']),
   },
-};
+});
 </script>
 
 <style scoped></style>

--- a/client/src/views/user/Settings.vue
+++ b/client/src/views/user/Settings.vue
@@ -24,7 +24,8 @@
   </b-container>
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent } from 'vue';
 import StageDirectionStyles from '@/vue_components/user/settings/StageDirectionStyles.vue';
 import CueColourPreferences from '@/vue_components/user/settings/CueColourPreferences.vue';
 import AboutUser from '@/vue_components/user/settings/AboutUser.vue';
@@ -32,7 +33,7 @@ import UserSettingsConfig from '@/vue_components/user/settings/Settings.vue';
 import ApiToken from '@/vue_components/user/settings/ApiToken.vue';
 import ChangePassword from '@/vue_components/user/settings/ChangePassword.vue';
 
-export default {
+export default defineComponent({
   name: 'UserSettings',
   components: {
     UserSettingsConfig,
@@ -42,5 +43,5 @@ export default {
     ApiToken,
     ChangePassword,
   },
-};
+});
 </script>

--- a/client/src/vue_components/MarkdownRenderer.vue
+++ b/client/src/vue_components/MarkdownRenderer.vue
@@ -4,11 +4,12 @@
   <!-- eslint-enable vue/no-v-html -->
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent } from 'vue';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 
-export default {
+export default defineComponent({
   name: 'MarkdownRenderer',
   props: {
     content: {
@@ -17,11 +18,11 @@ export default {
     },
   },
   computed: {
-    renderedHtml() {
+    renderedHtml(): string {
       if (!this.content) return '';
 
       try {
-        const rawHtml = marked.parse(this.content);
+        const rawHtml = marked.parse(this.content) as string;
         let transformedHtml = this.transformImagePaths(rawHtml);
         transformedHtml = this.transformMarkdownLinks(transformedHtml);
         return DOMPurify.sanitize(transformedHtml, {
@@ -55,39 +56,34 @@ export default {
           ALLOWED_ATTR: ['href', 'src', 'alt', 'title', 'class'],
         });
       } catch (error) {
-        this.$log.error('Error rendering markdown:', error);
+        (this as any).$log.error('Error rendering markdown:', error);
         return '<p class="text-danger">Error rendering documentation</p>';
       }
     },
   },
   methods: {
-    transformImagePaths(html) {
-      // Transform: ../images/topic/file.png → /docs/images/topic/file.png
-      // Also handles: ../../images/topic/file.png for nested docs
+    transformImagePaths(html: string): string {
       return html
         .replace(/src="\.\.\/\.\.\/images\//g, 'src="/docs/images/')
         .replace(/src="\.\.\/images\//g, 'src="/docs/images/');
     },
-    transformMarkdownLinks(html) {
-      // Transform internal .md links to /help routes
-      // Examples:
-      // href="./pages/getting_started.md" → href="/help/getting-started"
-      // href="../pages/show_config.md" → href="/help/show-config"
+    transformMarkdownLinks(html: string): string {
       return html
-        .replace(/href="(\.\.\/)*(pages\/[^"]+)\.md"/g, (match, dots, path) => {
-          // Remove 'pages/' prefix and convert underscores to dashes
-          const withoutPages = path.replace(/^pages\//, '');
-          const slug = withoutPages.replace(/_/g, '-');
-          return `href="/help/${slug}"`;
-        })
-        .replace(/href="\.\/([^"]+)\.md"/g, (match, path) => {
-          // Handle same-directory links
+        .replace(
+          /href="(\.\.\/)*(pages\/[^"]+)\.md"/g,
+          (_match: string, _dots: string, path: string) => {
+            const withoutPages = path.replace(/^pages\//, '');
+            const slug = withoutPages.replace(/_/g, '-');
+            return `href="/help/${slug}"`;
+          }
+        )
+        .replace(/href="\.\/([^"]+)\.md"/g, (_match: string, path: string) => {
           const slug = path.replace(/_/g, '-');
           return `href="/help/${slug}"`;
         });
     },
   },
-};
+});
 </script>
 
 <style scoped>

--- a/client/src/vue_components/config/ConfigLogs.vue
+++ b/client/src/vue_components/config/ConfigLogs.vue
@@ -106,16 +106,25 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent } from 'vue';
 import $ from 'jquery';
 import { debounce } from 'lodash';
 import { makeURL } from '@/js/utils';
 
-export default {
+interface LogEntry {
+  ts: string;
+  level: string;
+  filename: string;
+  lineno: number;
+  message: string;
+}
+
+export default defineComponent({
   name: 'ConfigLogs',
   data() {
     return {
-      entries: [],
+      entries: [] as LogEntry[],
       totalEntries: 0,
       source: 'server',
       levelFilter: '',
@@ -124,9 +133,13 @@ export default {
       limit: 500,
       liveRefresh: false,
       loading: false,
-      error: null,
+      error: null as string | null,
       autoScroll: true,
-      debounceContentSize: debounce(this.computeContentSize, 100),
+      searchDebounceTimer: null as ReturnType<typeof setTimeout> | null,
+      usernameDebounceTimer: null as ReturnType<typeof setTimeout> | null,
+      streamReader: null as ReadableStreamDefaultReader<Uint8Array> | null,
+      streamAborted: false,
+      debounceContentSize: null as ((...args: unknown[]) => void) | null,
 
       sourceOptions: [
         { text: 'Server', value: 'server' },
@@ -143,7 +156,7 @@ export default {
     };
   },
   watch: {
-    source() {
+    source(): void {
       this.usernameInput = '';
       if (this.liveRefresh) {
         this.restartStream();
@@ -151,15 +164,15 @@ export default {
         this.fetchLogs();
       }
     },
-    levelFilter() {
+    levelFilter(): void {
       if (this.liveRefresh) {
         this.restartStream();
       } else {
         this.fetchLogs();
       }
     },
-    searchInput() {
-      clearTimeout(this.searchDebounceTimer);
+    searchInput(): void {
+      clearTimeout(this.searchDebounceTimer ?? undefined);
       this.searchDebounceTimer = setTimeout(() => {
         if (this.liveRefresh) {
           this.restartStream();
@@ -168,8 +181,8 @@ export default {
         }
       }, 400);
     },
-    usernameInput() {
-      clearTimeout(this.usernameDebounceTimer);
+    usernameInput(): void {
+      clearTimeout(this.usernameDebounceTimer ?? undefined);
       this.usernameDebounceTimer = setTimeout(() => {
         if (this.liveRefresh) {
           this.restartStream();
@@ -178,7 +191,7 @@ export default {
         }
       }, 400);
     },
-    liveRefresh(val) {
+    liveRefresh(val: boolean): void {
       if (val) {
         this.startStream();
       } else {
@@ -186,35 +199,26 @@ export default {
       }
     },
   },
-  created() {
-    this.searchDebounceTimer = null;
-    this.usernameDebounceTimer = null;
-    // Non-reactive stream state kept off Vue's reactivity system.
-    this.streamReader = null;
-    this.streamAborted = false;
-  },
   async mounted() {
+    this.debounceContentSize = debounce(this.computeContentSize, 100);
     await this.fetchLogs();
     this.computeContentSize();
     window.addEventListener('resize', this.debounceContentSize);
   },
   beforeDestroy() {
     this.stopStream();
-    clearTimeout(this.searchDebounceTimer);
-    clearTimeout(this.usernameDebounceTimer);
+    clearTimeout(this.searchDebounceTimer ?? undefined);
+    clearTimeout(this.usernameDebounceTimer ?? undefined);
     window.removeEventListener('resize', this.debounceContentSize);
   },
   methods: {
-    computeContentSize() {
+    computeContentSize(): void {
       const scriptContainer = $('#log-console');
-      const startPos = scriptContainer.offset().top;
+      const startPos = scriptContainer.offset()!.top;
       const boxHeight = document.documentElement.clientHeight - startPos;
       scriptContainer.height(boxHeight - 50);
     },
-    // ------------------------------------------------------------------ //
-    // One-shot snapshot fetch (used when live stream is off)
-    // ------------------------------------------------------------------ //
-    async fetchLogs() {
+    async fetchLogs(): Promise<void> {
       this.loading = true;
       this.error = null;
       try {
@@ -240,16 +244,13 @@ export default {
         if (wasAtBottom) {
           this.$nextTick(() => this.scrollToBottom());
         }
-      } catch (err) {
+      } catch (err: any) {
         this.error = err.message || 'Failed to fetch logs';
       } finally {
         this.loading = false;
       }
     },
-    // ------------------------------------------------------------------ //
-    // SSE live stream (used when liveRefresh is true)
-    // ------------------------------------------------------------------ //
-    buildStreamUrl() {
+    buildStreamUrl(): string {
       const params = new URLSearchParams({
         source: this.source,
         level: this.levelFilter,
@@ -260,15 +261,15 @@ export default {
       }
       return `${makeURL('/api/v1/logs/stream')}?${params}`;
     },
-    async startStream() {
+    async startStream(): Promise<void> {
       this.stopStream();
       this.streamAborted = false;
       this.error = null;
 
-      let response;
+      let response: Response;
       try {
         response = await fetch(this.buildStreamUrl());
-      } catch (err) {
+      } catch (err: any) {
         this.error = err.message || 'Failed to connect to log stream';
         return;
       }
@@ -278,17 +279,12 @@ export default {
         return;
       }
 
-      // Clear existing entries — the stream sends backfill from scratch.
       this.entries = [];
       this.totalEntries = 0;
 
-      const reader = response.body.getReader();
+      const reader = response.body!.getReader();
       this.streamReader = reader;
       const decoder = new TextDecoder();
-
-      // SSE events are separated by "\n\n".  Because TCP packets don't align
-      // with event boundaries, we accumulate chunks in a string buffer and
-      // split on the separator, keeping any incomplete trailing chunk.
       let buffer = '';
 
       try {
@@ -297,9 +293,8 @@ export default {
           if (done) break;
 
           buffer += decoder.decode(value, { stream: true });
-
           const events = buffer.split('\n\n');
-          buffer = events.pop(); // last element may be an incomplete event
+          buffer = events.pop()!;
 
           for (const event of events) {
             if (event.startsWith('data: ')) {
@@ -315,10 +310,9 @@ export default {
                   this.$nextTick(() => this.scrollToBottom());
                 }
               } catch {
-                // Ignore malformed JSON — should never happen in practice.
+                // ignore malformed SSE JSON
               }
             }
-            // Comment lines (": keepalive") are intentionally ignored.
           }
         }
       } catch {
@@ -330,22 +324,18 @@ export default {
         this.streamReader = null;
       }
     },
-    stopStream() {
+    stopStream(): void {
       if (this.streamReader) {
         this.streamAborted = true;
         this.streamReader.cancel();
         this.streamReader = null;
       }
     },
-    restartStream() {
+    restartStream(): void {
       this.stopStream();
       this.startStream();
     },
-
-    // ------------------------------------------------------------------ //
-    // Formatting helpers
-    // ------------------------------------------------------------------ //
-    formatEntry(entry) {
+    formatEntry(entry: LogEntry): string {
       const dt = new Date(entry.ts);
       const yy = String(dt.getUTCFullYear()).slice(2);
       const mo = String(dt.getUTCMonth() + 1).padStart(2, '0');
@@ -357,7 +347,7 @@ export default {
       const letter = this.levelLetter(entry.level);
       return `[${letter} ${yy}-${mo}-${dd} ${hh}:${mm}:${ss}.${ms} ${entry.filename}:${entry.lineno}] ${entry.message}`;
     },
-    levelClass(level) {
+    levelClass(level: string): string {
       switch (level) {
         case 'TRACE':
           return 'text-secondary';
@@ -376,8 +366,8 @@ export default {
           return 'text-light';
       }
     },
-    levelLetter(level) {
-      const map = {
+    levelLetter(level: string): string {
+      const map: Record<string, string> = {
         TRACE: 'T',
         DEBUG: 'D',
         INFO: 'I',
@@ -388,16 +378,16 @@ export default {
       };
       return map[level] || level[0];
     },
-    onScroll() {
-      const el = this.$refs.console;
+    onScroll(): void {
+      const el = this.$refs.console as HTMLElement | undefined;
       if (!el) return;
       const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
       this.autoScroll = atBottom;
     },
-    scrollToBottom() {
-      const el = this.$refs.console;
+    scrollToBottom(): void {
+      const el = this.$refs.console as HTMLElement | undefined;
       if (el) el.scrollTop = el.scrollHeight;
     },
   },
-};
+});
 </script>

--- a/client/src/vue_components/config/ConfigSettings.vue
+++ b/client/src/vue_components/config/ConfigSettings.vue
@@ -115,39 +115,50 @@
   </b-container>
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent } from 'vue';
 import { mapGetters, mapActions } from 'vuex';
 import { required, integer } from 'vuelidate/lib/validators';
 import log from 'loglevel';
-
 import { makeURL } from '@/js/utils';
 
-export default {
+export default defineComponent({
   name: 'ConfigSettings',
   data() {
     return {
       loaded: false,
-      editSettings: {},
+      editSettings: {} as Record<string, unknown>,
       toggle: 0,
-      expandedCategories: ['General'],
+      expandedCategories: ['General'] as string[],
     };
+  },
+  validations() {
+    const editSettings: Record<string, unknown> = {};
+    Object.keys(this.editSettings).forEach((x) => {
+      if ((this as any).RAW_SETTINGS[x].type === 'int') {
+        editSettings[x] = { required, integer };
+      } else {
+        editSettings[x] = {};
+      }
+    });
+    return { editSettings };
   },
   computed: {
     ...mapGetters(['RAW_SETTINGS', 'SETTINGS_CATEGORIES']),
-    visibleSettings() {
-      const visibleSettings = {};
-      Object.keys(this.RAW_SETTINGS).forEach((x) => {
-        if (!this.RAW_SETTINGS[x].hide_from_ui) {
-          visibleSettings[x] = this.RAW_SETTINGS[x];
+    visibleSettings(): Record<string, any> {
+      const visibleSettings: Record<string, any> = {};
+      Object.keys((this as any).RAW_SETTINGS).forEach((x) => {
+        if (!(this as any).RAW_SETTINGS[x].hide_from_ui) {
+          visibleSettings[x] = (this as any).RAW_SETTINGS[x];
         }
       });
       return visibleSettings;
     },
-    settingsByCategory() {
-      const settingsByCategory = {};
-      Object.keys(this.SETTINGS_CATEGORIES).forEach((category) => {
+    settingsByCategory(): Record<string, Record<string, any>> {
+      const settingsByCategory: Record<string, Record<string, any>> = {};
+      Object.keys((this as any).SETTINGS_CATEGORIES).forEach((category) => {
         settingsByCategory[category] = {};
-        this.SETTINGS_CATEGORIES[category].forEach((setting) => {
+        (this as any).SETTINGS_CATEGORIES[category].forEach((setting: string) => {
           if (Object.keys(this.visibleSettings).includes(setting)) {
             settingsByCategory[category][setting] = this.visibleSettings[setting];
           }
@@ -155,24 +166,24 @@ export default {
       });
       return settingsByCategory;
     },
-    hasChanges() {
+    hasChanges(): boolean {
       return Object.keys(this.editSettings).some(
-        (key) => this.editSettings[key] !== this.RAW_SETTINGS[key]?.value
+        (key) => this.editSettings[key] !== (this as any).RAW_SETTINGS[key]?.value
       );
     },
-    dirtySettingsByCategory() {
-      const dirtySettingsByCategory = {};
-      Object.keys(this.SETTINGS_CATEGORIES).forEach((category) => {
-        dirtySettingsByCategory[category] = 0;
-        this.SETTINGS_CATEGORIES[category].forEach((setting) => {
+    dirtySettingsByCategory(): Record<string, number> {
+      const dirty: Record<string, number> = {};
+      Object.keys((this as any).SETTINGS_CATEGORIES).forEach((category) => {
+        dirty[category] = 0;
+        (this as any).SETTINGS_CATEGORIES[category].forEach((setting: string) => {
           if (Object.keys(this.visibleSettings).includes(setting)) {
-            if (this.$v.editSettings[setting].$dirty) {
-              dirtySettingsByCategory[category] += 1;
+            if ((this as any).$v.editSettings[setting].$dirty) {
+              dirty[category] += 1;
             }
           }
         });
       });
-      return dirtySettingsByCategory;
+      return dirty;
     },
   },
   watch: {
@@ -184,55 +195,33 @@ export default {
     },
   },
   async mounted() {
-    await this.GET_SETTINGS_CATEGORIES();
+    await (this as any).GET_SETTINGS_CATEGORIES();
     this.resetEditSettings();
     this.loaded = true;
   },
-  validations() {
-    const editSettings = {};
-    Object.keys(this.editSettings).forEach((x) => {
-      if (this.RAW_SETTINGS[x].type === 'int') {
-        editSettings[x] = {
-          required,
-          integer,
-        };
-      } else {
-        editSettings[x] = {};
-      }
-    }, this);
-    return { editSettings };
-  },
   methods: {
-    inputType(fieldType) {
-      const mapping = {
-        int: 'number',
-        str: 'text',
-      };
-      if (!Object.keys(mapping).includes(fieldType)) {
-        return 'text';
-      }
-      return mapping[fieldType];
+    inputType(fieldType: string): string {
+      const mapping: Record<string, string> = { int: 'number', str: 'text' };
+      return mapping[fieldType] ?? 'text';
     },
-    getChoiceOptions(setting) {
-      const options = [];
+    getChoiceOptions(setting: any): Array<{ value: unknown; text: string }> {
+      const options: Array<{ value: unknown; text: string }> = [];
       if (setting._nullable) {
         options.push({ value: null, text: 'N/A' });
       }
-      setting.choice_options.forEach((option) => {
-        options.push({ value: option, text: option });
+      setting.choice_options.forEach((option: unknown) => {
+        options.push({ value: option, text: String(option) });
       });
       return options;
     },
-    validateState(name) {
-      const { $dirty, $error } = this.$v.editSettings[name];
+    validateState(name: string): boolean | null {
+      const { $dirty, $error } = (this as any).$v.editSettings[name];
       return $dirty ? !$error : null;
     },
-    async handleSubmit() {
+    async handleSubmit(): Promise<void> {
       const response = await fetch(`${makeURL('/api/v1/settings')}`, {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(this.editSettings),
       });
       if (!response.ok) {
@@ -242,35 +231,31 @@ export default {
         this.$toast.success('Saved settings');
       }
     },
-    resetEditSettings() {
-      Object.keys(this.visibleSettings).forEach(function setEditSettings(x) {
+    resetEditSettings(): void {
+      Object.keys(this.visibleSettings).forEach((x) => {
         this.editSettings[x] = this.visibleSettings[x].value;
-      }, this);
+      });
     },
-    resetForm(toggleLoaded) {
-      if (toggleLoaded) {
-        this.loaded = false;
-      }
-      this.toggle = !this.toggle;
-      Object.keys(this.RAW_SETTINGS).forEach(function resetEditSettings(x) {
-        this.editSettings[x] = this.RAW_SETTINGS[x].value;
-      }, this);
-      this.$v.editSettings.$reset();
-      if (toggleLoaded) {
-        this.loaded = true;
-      }
+    resetForm(toggleLoaded: boolean): void {
+      if (toggleLoaded) this.loaded = false;
+      this.toggle = this.toggle === 0 ? 1 : 0;
+      Object.keys((this as any).RAW_SETTINGS).forEach((x) => {
+        this.editSettings[x] = (this as any).RAW_SETTINGS[x].value;
+      });
+      (this as any).$v.editSettings.$reset();
+      if (toggleLoaded) this.loaded = true;
     },
-    expandCategory(category) {
+    expandCategory(category: string): void {
       if (this.categoryExpanded(category)) {
         this.expandedCategories = this.expandedCategories.filter((x) => x !== category);
       } else {
         this.expandedCategories.push(category);
       }
     },
-    categoryExpanded(category) {
+    categoryExpanded(category: string): boolean {
       return this.expandedCategories.includes(category);
     },
     ...mapActions(['GET_SETTINGS_CATEGORIES']),
   },
-};
+});
 </script>

--- a/client/src/vue_components/config/ConfigShows.vue
+++ b/client/src/vue_components/config/ConfigShows.vue
@@ -133,13 +133,14 @@
   </b-container>
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent } from 'vue';
 import { required, maxLength } from 'vuelidate/lib/validators';
 import { mapGetters, mapActions } from 'vuex';
 import { makeURL } from '@/js/utils';
 import log from 'loglevel';
 
-export default {
+export default defineComponent({
   name: 'ConfigShows',
   data() {
     return {
@@ -157,10 +158,10 @@ export default {
       isSubmittingLoad: false,
       isSubmittingShow: false,
       formState: {
-        name: null,
-        start: null,
-        end: null,
-        script_mode: null,
+        name: null as string | null,
+        start: null as string | null,
+        end: null as string | null,
+        script_mode: null as number | null,
       },
     };
   },
@@ -172,36 +173,34 @@ export default {
       },
       start: {
         required,
-        beforeEnd: (value, vm) =>
-          value == null && vm.end != null ? false : new Date(value) <= new Date(vm.end),
+        beforeEnd: (value: string | null, vm: { end: string | null }) =>
+          value == null && vm.end != null ? false : new Date(value!) <= new Date(vm.end!),
       },
       end: {
         required,
-        afterStart: (value, vm) =>
-          value == null && vm.start != null ? false : new Date(value) >= new Date(vm.start),
+        afterStart: (value: string | null, vm: { start: string | null }) =>
+          value == null && vm.start != null ? false : new Date(value!) >= new Date(vm.start!),
       },
-      script_mode: {
-        required,
-      },
+      script_mode: { required },
     },
   },
   computed: {
     ...mapGetters(['AVAILABLE_SHOWS', 'CURRENT_SHOW', 'SCRIPT_MODES']),
   },
   async mounted() {
-    await Promise.all([this.GET_AVAILABLE_SHOWS(), this.GET_SCRIPT_MODES()]);
+    await Promise.all([(this as any).GET_AVAILABLE_SHOWS(), (this as any).GET_SCRIPT_MODES()]);
     this.loaded = true;
   },
   methods: {
-    async saveAndLoad(event) {
+    async saveAndLoad(event: Event): Promise<void> {
       await this.saveShow(event, true);
     },
-    async onSubmit(event) {
+    async onSubmit(event: Event): Promise<void> {
       await this.saveShow(event, false);
     },
-    async saveShow(event, load) {
-      this.$v.formState.$touch();
-      if (this.$v.formState.$anyError) {
+    async saveShow(event: Event, load: boolean): Promise<void> {
+      (this as any).$v.formState.$touch();
+      if ((this as any).$v.formState.$anyError) {
         event.preventDefault();
         return;
       }
@@ -214,20 +213,16 @@ export default {
       this.isSubmittingShow = true;
 
       try {
-        const searchParams = new URLSearchParams({
-          load,
-        });
+        const searchParams = new URLSearchParams({ load: String(load) });
         const response = await fetch(`${makeURL('/api/v1/show')}?${searchParams}`, {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(this.formState),
         });
         if (response.ok) {
-          await this.GET_AVAILABLE_SHOWS();
+          await (this as any).GET_AVAILABLE_SHOWS();
           this.$toast.success('Created new show!');
-          this.$bvModal.hide('show-config');
+          (this as any).$bvModal.hide('show-config');
           this.resetForm();
         } else {
           this.$toast.error('Unable to save show');
@@ -242,26 +237,20 @@ export default {
         this.isSubmittingShow = false;
       }
     },
-    async loadShow(show) {
-      if (this.isSubmittingLoad) {
-        return;
-      }
+    async loadShow(show: { id: number }): Promise<void> {
+      if (this.isSubmittingLoad) return;
 
       this.isSubmittingLoad = true;
 
       try {
         const response = await fetch(`${makeURL('/api/v1/settings')}`, {
           method: 'PATCH',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            current_show: show.id,
-          }),
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ current_show: show.id }),
         });
         if (response.ok) {
           this.$toast.success('Loaded show!');
-          this.$bvModal.hide('show-load');
+          (this as any).$bvModal.hide('show-load');
         } else {
           this.$toast.error('Unable to load show');
           log.error('Unable to load show');
@@ -273,24 +262,23 @@ export default {
         this.isSubmittingLoad = false;
       }
     },
-    validateState(name) {
-      const { $dirty, $error } = this.$v.formState[name];
+    validateState(name: string): boolean | null {
+      const { $dirty, $error } = (this as any).$v.formState[name];
       return $dirty ? !$error : null;
     },
-    resetForm() {
+    resetForm(): void {
       this.formState = {
         name: null,
         start: null,
         end: null,
-        script_mode: this.SCRIPT_MODES[0].value,
+        script_mode: (this as any).SCRIPT_MODES[0].value,
       };
       this.isSubmittingShow = false;
-
       this.$nextTick(() => {
-        this.$v.$reset();
+        (this as any).$v.$reset();
       });
     },
     ...mapActions(['GET_AVAILABLE_SHOWS', 'GET_SCRIPT_MODES']),
   },
-};
+});
 </script>

--- a/client/src/vue_components/config/ConfigSystem.vue
+++ b/client/src/vue_components/config/ConfigSystem.vue
@@ -84,17 +84,26 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent } from 'vue';
 import log from 'loglevel';
-
 import { makeURL } from '@/js/utils';
 
-export default {
+interface VersionStatus {
+  current_version: string | null;
+  latest_version: string | null;
+  update_available: boolean;
+  release_url: string | null;
+  last_checked: string | null;
+  check_error: string | null;
+}
+
+export default defineComponent({
   name: 'ConfigSystem',
   data() {
     return {
       perPage: 5,
-      connectedClients: [],
+      connectedClients: [] as unknown[],
       currentPageClients: 1,
       clientFields: [
         { key: 'internal_id', label: 'UUID' },
@@ -103,7 +112,7 @@ export default {
         'last_ping',
         'last_pong',
       ],
-      clientTimeout: null,
+      clientTimeout: null as ReturnType<typeof setTimeout> | null,
       loading: true,
       versionStatus: {
         current_version: null,
@@ -112,30 +121,28 @@ export default {
         release_url: null,
         last_checked: null,
         check_error: null,
-      },
+      } as VersionStatus,
       isCheckingVersion: false,
       currentTime: Date.now(),
-      timeUpdateInterval: null,
+      timeUpdateInterval: null as ReturnType<typeof setInterval> | null,
     };
   },
   async mounted() {
     await Promise.all([this.getConnectedClients(), this.getVersionStatus()]);
     this.loading = false;
-
-    // Start time update interval for reactive "time ago" display
     this.timeUpdateInterval = setInterval(() => {
       this.currentTime = Date.now();
     }, 1000);
   },
   destroyed() {
-    clearTimeout(this.clientTimeout);
+    clearTimeout(this.clientTimeout ?? undefined);
     if (this.timeUpdateInterval) {
       clearInterval(this.timeUpdateInterval);
       this.timeUpdateInterval = null;
     }
   },
   methods: {
-    async getConnectedClients() {
+    async getConnectedClients(): Promise<void> {
       const response = await fetch(`${makeURL('/api/v1/ws/sessions')}`);
       if (response.ok) {
         const sessions = await response.json();
@@ -145,7 +152,7 @@ export default {
       }
       this.clientTimeout = setTimeout(this.getConnectedClients, 1000);
     },
-    async getVersionStatus() {
+    async getVersionStatus(): Promise<void> {
       try {
         const response = await fetch(`${makeURL('/api/v1/version/status')}`);
         if (response.ok) {
@@ -157,17 +164,13 @@ export default {
         log.error('Error fetching version status:', error);
       }
     },
-    async checkForUpdates() {
-      if (this.isCheckingVersion) {
-        return;
-      }
+    async checkForUpdates(): Promise<void> {
+      if (this.isCheckingVersion) return;
 
       this.isCheckingVersion = true;
 
       try {
-        const response = await fetch(`${makeURL('/api/v1/version/check')}`, {
-          method: 'POST',
-        });
+        const response = await fetch(`${makeURL('/api/v1/version/check')}`, { method: 'POST' });
         if (response.ok) {
           this.versionStatus = await response.json();
           if (this.versionStatus.update_available) {
@@ -186,52 +189,30 @@ export default {
         this.isCheckingVersion = false;
       }
     },
-    getVersionStatusVariant() {
-      if (!this.versionStatus.current_version) {
-        return 'secondary';
-      }
-      if (this.versionStatus.check_error) {
-        return 'danger';
-      }
-      if (this.versionStatus.update_available) {
-        return 'warning';
-      }
+    getVersionStatusVariant(): string {
+      if (!this.versionStatus.current_version) return 'secondary';
+      if (this.versionStatus.check_error) return 'danger';
+      if (this.versionStatus.update_available) return 'warning';
       return 'success';
     },
-    getVersionStatusText() {
-      if (!this.versionStatus.current_version) {
-        return 'Loading...';
-      }
-      if (this.versionStatus.check_error) {
-        return 'Unable to check';
-      }
-      if (this.versionStatus.update_available) {
-        return 'Update Available';
-      }
+    getVersionStatusText(): string {
+      if (!this.versionStatus.current_version) return 'Loading...';
+      if (this.versionStatus.check_error) return 'Unable to check';
+      if (this.versionStatus.update_available) return 'Update Available';
       return 'Up to date';
     },
-    formatTimeAgo(isoTimestamp) {
-      if (!isoTimestamp) {
-        return 'Never';
-      }
+    formatTimeAgo(isoTimestamp: string | null): string {
+      if (!isoTimestamp) return 'Never';
 
       const timestamp = new Date(isoTimestamp).getTime();
       const seconds = Math.floor((this.currentTime - timestamp) / 1000);
 
-      if (seconds < 10) {
-        return 'Just now';
-      }
-      if (seconds < 60) {
-        return `${seconds} seconds ago`;
-      }
-      if (seconds < 3600) {
-        return `${Math.floor(seconds / 60)} minutes ago`;
-      }
-      if (seconds < 86400) {
-        return `${Math.floor(seconds / 3600)} hours ago`;
-      }
+      if (seconds < 10) return 'Just now';
+      if (seconds < 60) return `${seconds} seconds ago`;
+      if (seconds < 3600) return `${Math.floor(seconds / 60)} minutes ago`;
+      if (seconds < 86400) return `${Math.floor(seconds / 3600)} hours ago`;
       return `${Math.floor(seconds / 86400)} days ago`;
     },
   },
-};
+});
 </script>

--- a/client/src/vue_components/config/ConfigUsers.vue
+++ b/client/src/vue_components/config/ConfigUsers.vue
@@ -80,27 +80,28 @@
   </b-container>
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent } from 'vue';
 import { mapActions, mapGetters } from 'vuex';
 
 import CreateUser from '@/vue_components/user/CreateUser.vue';
 import ConfigRbac from '@/vue_components/user/ConfigRbac.vue';
 import ResetPassword from '@/vue_components/user/ResetPassword.vue';
 
-export default {
+export default defineComponent({
   name: 'ConfigUsers',
   components: { CreateUser, ConfigRbac, ResetPassword },
   data() {
     return {
       userFields: ['username', 'last_login', 'last_seen', 'is_admin', { key: 'btn', label: '' }],
-      editUser: null,
-      resetUser: null,
-      clientTimeout: null,
+      editUser: null as number | null,
+      resetUser: null as { id: number; username: string } | null,
+      clientTimeout: null as ReturnType<typeof setTimeout> | null,
     };
   },
   computed: {
-    allAdmins() {
-      return this.USERS.filter((user) => user.is_admin);
+    allAdmins(): unknown[] {
+      return (this.USERS as any[]).filter((user) => user.is_admin);
     },
     ...mapGetters(['USERS', 'CURRENT_SHOW', 'CURRENT_USER']),
   },
@@ -108,40 +109,40 @@ export default {
     await this.getUsers();
   },
   destroyed() {
-    clearTimeout(this.clientTimeout);
+    clearTimeout(this.clientTimeout ?? undefined);
   },
   methods: {
-    resetNewForm() {
-      this.$bvModal.hide('new-user');
+    resetNewForm(): void {
+      (this as any).$bvModal.hide('new-user');
     },
-    resetNewAdminForm() {
-      this.$bvModal.hide('new-admin-user');
+    resetNewAdminForm(): void {
+      (this as any).$bvModal.hide('new-admin-user');
     },
-    setEditUser(userId) {
+    setEditUser(userId: number): void {
       this.editUser = userId;
     },
-    setResetUser(user) {
+    setResetUser(user: { id: number; username: string }): void {
       this.resetUser = user;
     },
-    async handlePasswordReset() {
+    async handlePasswordReset(): Promise<void> {
       await this.getUsers();
     },
-    closeResetPasswordModal() {
-      this.$bvModal.hide('reset-password');
+    closeResetPasswordModal(): void {
+      (this as any).$bvModal.hide('reset-password');
       this.resetUser = null;
     },
-    async deleteUser(data) {
+    async deleteUser(data: any): Promise<void> {
       const msg = `Are you sure you want to delete ${data.item.username}?`;
-      const action = await this.$bvModal.msgBoxConfirm(msg, {});
+      const action = await (this as any).$bvModal.msgBoxConfirm(msg, {});
       if (action === true) {
-        await this.DELETE_USER(data.item.id);
+        await (this as any).DELETE_USER(data.item.id);
       }
     },
-    async getUsers() {
-      await this.GET_USERS();
+    async getUsers(): Promise<void> {
+      await (this as any).GET_USERS();
       this.clientTimeout = setTimeout(this.getUsers, 5000);
     },
     ...mapActions(['GET_USERS', 'DELETE_USER']),
   },
-};
+});
 </script>

--- a/client/src/vue_components/user/ConfigRbac.vue
+++ b/client/src/vue_components/user/ConfigRbac.vue
@@ -23,11 +23,12 @@
   </b-container>
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent } from 'vue';
 import { makeURL } from '@/js/utils';
 import RbacResource from '@/vue_components/user/RbacResource.vue';
 
-export default {
+export default defineComponent({
   name: 'ConfigRBAC',
   components: { RbacResource },
   props: {
@@ -40,16 +41,14 @@ export default {
     return {
       loaded: false,
       error: false,
-      rbacResources: null,
+      rbacResources: null as string[] | null,
     };
   },
   async mounted() {
     try {
       const response = await fetch(`${makeURL('/api/v1/rbac/user/resources')}`, {
         method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
       });
       if (response.ok) {
         const rbacResources = await response.json();
@@ -64,5 +63,5 @@ export default {
     }
     this.loaded = true;
   },
-};
+});
 </script>

--- a/client/src/vue_components/user/CreateUser.vue
+++ b/client/src/vue_components/user/CreateUser.vue
@@ -62,19 +62,22 @@
   </b-form>
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent } from 'vue';
 import { required, minLength, sameAs } from 'vuelidate/lib/validators';
 import { mapActions, mapGetters } from 'vuex';
 
-function isUsernameUnique(value) {
+function isUsernameUnique(this: any, value: string): boolean {
   if (value === '') return true;
   if (this.USERS) {
-    return !this.USERS.map((x) => x.username.toLowerCase()).includes(value.toLowerCase());
+    return !this.USERS.map((x: { username: string }) => x.username.toLowerCase()).includes(
+      value.toLowerCase()
+    );
   }
   return true;
 }
 
-export default {
+export default defineComponent({
   name: 'CreateUser',
   props: {
     isFirstAdmin: {
@@ -98,39 +101,30 @@ export default {
   },
   validations: {
     state: {
-      username: {
-        required,
-        isUsernameUnique,
-      },
-      password: {
-        required,
-        minLength: minLength(6),
-      },
-      confirmPassword: {
-        required,
-        sameAsPassword: sameAs('password'),
-      },
+      username: { required, isUsernameUnique },
+      password: { required, minLength: minLength(6) },
+      confirmPassword: { required, sameAsPassword: sameAs('password') },
     },
   },
   computed: {
-    isDisabled() {
-      return Boolean(this.$v.state.$invalid);
+    isDisabled(): boolean {
+      return Boolean((this as any).$v.state.$invalid);
     },
     ...mapGetters(['USERS']),
   },
   methods: {
-    validateState(name) {
-      const { $dirty, $error } = this.$v.state[name];
+    validateState(name: string): boolean | null {
+      const { $dirty, $error } = (this as any).$v.state[name];
       return $dirty ? !$error : null;
     },
-    async createUser(event) {
-      this.$v.state.$touch();
-      if (this.$v.state.$anyError) {
+    async createUser(event: Event): Promise<void> {
+      (this as any).$v.state.$touch();
+      if ((this as any).$v.state.$anyError) {
         event.preventDefault();
       } else {
-        await this.CREATE_USER(this.state);
+        await (this as any).CREATE_USER(this.state);
         if (this.isFirstAdmin) {
-          await this.USER_LOGIN({
+          await (this as any).USER_LOGIN({
             username: this.state.username,
             password: this.state.password,
           });
@@ -140,5 +134,5 @@ export default {
     },
     ...mapActions(['CREATE_USER', 'USER_LOGIN']),
   },
-};
+});
 </script>

--- a/client/src/vue_components/user/RbacResource.vue
+++ b/client/src/vue_components/user/RbacResource.vue
@@ -40,10 +40,16 @@
   </b-container>
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent } from 'vue';
 import { makeURL } from '@/js/utils';
 
-export default {
+interface RbacRole {
+  key: string;
+  value: number;
+}
+
+export default defineComponent({
   name: 'RbacResource',
   props: {
     resource: {
@@ -59,19 +65,19 @@ export default {
     return {
       loaded: false,
       error: false,
-      rbacObjects: null,
-      displayFields: null,
-      roles: null,
+      rbacObjects: null as Array<[unknown, number]> | null,
+      displayFields: null as string[] | null,
+      roles: null as RbacRole[] | null,
       processing: false,
     };
   },
   computed: {
-    rbacRoles() {
-      return this.roles.map((x) => x.key);
+    rbacRoles(): string[] {
+      return (this.roles ?? []).map((x) => x.key);
     },
-    rbacRolesDict() {
-      const ret = {};
-      this.roles.forEach((role) => {
+    rbacRolesDict(): Record<string, number> {
+      const ret: Record<string, number> = {};
+      (this.roles ?? []).forEach((role) => {
         ret[role.key] = role.value;
       });
       return ret;
@@ -83,16 +89,14 @@ export default {
     this.loaded = true;
   },
   methods: {
-    getCellName(slot) {
+    getCellName(slot: string): string {
       return `cell(${slot})`;
     },
-    async getRoles() {
+    async getRoles(): Promise<void> {
       try {
         const response = await fetch(`${makeURL('/api/v1/rbac/roles')}`, {
           method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers: { 'Content-Type': 'application/json' },
         });
         if (response.ok) {
           const rbacRoles = await response.json();
@@ -106,17 +110,15 @@ export default {
         this.error = true;
       }
     },
-    async getObjects() {
+    async getObjects(): Promise<void> {
       const searchParams = new URLSearchParams({
         resource: this.resource,
-        user: this.userId,
+        user: String(this.userId),
       });
       try {
         const response = await fetch(`${makeURL('/api/v1/rbac/user/objects')}?${searchParams}`, {
           method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers: { 'Content-Type': 'application/json' },
         });
         if (response.ok) {
           const rbacObjects = await response.json();
@@ -131,20 +133,13 @@ export default {
         this.error = true;
       }
     },
-    async giveRole(object, role) {
+    async giveRole(object: unknown, role: number): Promise<void> {
       this.processing = true;
       try {
         const response = await fetch(`${makeURL('/api/v1/rbac/user/roles/grant')}`, {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            resource: this.resource,
-            user: this.userId,
-            object,
-            role,
-          }),
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ resource: this.resource, user: this.userId, object, role }),
         });
         if (response.ok) {
           this.$toast.success('Granted role to user');
@@ -157,20 +152,13 @@ export default {
       await this.getObjects();
       this.processing = false;
     },
-    async revokeRole(object, role) {
+    async revokeRole(object: unknown, role: number): Promise<void> {
       this.processing = true;
       try {
         const response = await fetch(`${makeURL('/api/v1/rbac/user/roles/revoke')}`, {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            resource: this.resource,
-            user: this.userId,
-            object,
-            role,
-          }),
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ resource: this.resource, user: this.userId, object, role }),
         });
         if (response.ok) {
           this.$toast.success('Revoked role from user');
@@ -184,5 +172,5 @@ export default {
       this.processing = false;
     },
   },
-};
+});
 </script>

--- a/client/src/vue_components/user/ResetPassword.vue
+++ b/client/src/vue_components/user/ResetPassword.vue
@@ -59,10 +59,11 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent } from 'vue';
 import { makeURL } from '@/js/utils';
 
-export default {
+export default defineComponent({
   name: 'ResetPassword',
   props: {
     userId: {
@@ -77,23 +78,19 @@ export default {
   data() {
     return {
       loading: false,
-      temporaryPassword: null,
+      temporaryPassword: null as string | null,
       showPassword: false,
     };
   },
   methods: {
-    async handleReset() {
+    async handleReset(): Promise<void> {
       this.loading = true;
 
       try {
         const response = await fetch(makeURL('/api/v1/auth/reset-password'), {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            user_id: this.userId,
-          }),
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ user_id: this.userId }),
         });
 
         if (response.ok) {
@@ -105,20 +102,20 @@ export default {
           const error = await response.json();
           this.$toast.error(error.message || 'Failed to reset password');
         }
-      } catch (error) {
+      } catch {
         this.$toast.error('An error occurred while resetting password');
       } finally {
         this.loading = false;
       }
     },
-    async copyToClipboard() {
+    async copyToClipboard(): Promise<void> {
       try {
-        await navigator.clipboard.writeText(this.temporaryPassword);
+        await navigator.clipboard.writeText(this.temporaryPassword!);
         this.$toast.success('Password copied to clipboard');
-      } catch (error) {
+      } catch {
         this.$toast.error('Failed to copy to clipboard');
       }
     },
   },
-};
+});
 </script>


### PR DESCRIPTION
## Summary

- Converts 17 Vue SFCs to `<script lang="ts">` with `defineComponent` wrappers (views + simple config/user components)
- Updates `eslint.config.mjs` to route `<script lang="ts">` blocks inside `.vue` files through `tsParser` — previously only `.ts` files had the TS parser, causing ESLint parse errors on TypeScript syntax inside SFCs
- Adds typed local interfaces (`LogEntry`, `VersionStatus`, `RbacRole`) where the data shape was previously implicit
- Moves `ConfigLogs`'s non-reactive stream/timer state from `created()` into `data()` with explicit null types so TypeScript can track them

## Files changed

| Category | Files |
|----------|-------|
| Views | `404View`, `AboutView`, `HomeView`, `HelpDocView`, `ForcePasswordChangeView`, `LoginView`, `Settings` |
| User components | `ConfigRbac`, `CreateUser`, `RbacResource`, `ResetPassword` |
| Config components | `ConfigLogs`, `ConfigSettings`, `ConfigShows`, `ConfigSystem`, `ConfigUsers` |
| Other | `MarkdownRenderer`, `eslint.config.mjs` |

## Validation
- `npm run test:run` — 106/106 tests pass
- `npm run typecheck` — clean
- `npm run ci-lint` — clean
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)