### PR TITLE
Fix stage direction text input not auto-focusing on add (#1017)

### DIFF
--- a/client/src/vue_components/show/config/script/ScriptLinePart.vue
+++ b/client/src/vue_components/show/config/script/ScriptLinePart.vue
@@ -146,8 +146,16 @@ export default defineComponent({
   mounted(): void {
     (this as any).$v.state.$touch();
     if (this.focusInput) {
-      this.$nextTick(() => {
-        (this.$refs.partInput as HTMLElement).focus();
+      // Use rAF + $nextTick so our focus fires after Bootstrap Vue's dropdown
+      // focusToggler (which runs in its own rAF → $nextTick chain). Our rAF is
+      // registered during the post-click microtask phase, so it fires after the
+      // dropdown's earlier-registered rAF. Our $nextTick then runs last and wins.
+      requestAnimationFrame(() => {
+        this.$nextTick(() => {
+          if (this.$refs.partInput) {
+            (this.$refs.partInput as HTMLElement).focus();
+          }
+        });
       });
     }
   },

--- a/client/src/vue_components/show/config/script/ScriptLinePart.vue
+++ b/client/src/vue_components/show/config/script/ScriptLinePart.vue
@@ -146,7 +146,9 @@ export default defineComponent({
   mounted(): void {
     (this as any).$v.state.$touch();
     if (this.focusInput) {
-      (this.$refs.partInput as HTMLElement).focus();
+      this.$nextTick(() => {
+        (this.$refs.partInput as HTMLElement).focus();
+      });
     }
   },
   methods: {


### PR DESCRIPTION
## Summary

- Fixes cursor not auto-focusing when a new stage direction is added (#1017)
- Closes #1017

## Root Cause

Bootstrap Vue's `b-dropdown-item` uses this sequence on click:
1. Emits the click event → `addStageDirection()` runs
2. Calls `closeDropdown()` → `requestAnimationFrame(() => bvDropdown.hide(true))`

`hide(true)` triggers `focusToggler()`, which uses `$nextTick` to restore focus to the toggle button. A plain `$nextTick` in `ScriptLinePart.mounted()` ran **before** the dropdown's rAF fired, so the dropdown's subsequent `focusToggler → $nextTick` stole focus back.

## Fix

Use `requestAnimationFrame + $nextTick` in `ScriptLinePart.mounted()`:

- `ScriptLinePart` mounts as part of Vue's reactive flush (microtask phase), **before** any animation frame fires
- Our `requestAnimationFrame` is therefore registered after the dropdown's rAF but in the **same frame**, so it fires second
- Our `$nextTick` is then queued **after** `focusToggler`'s `$nextTick`, meaning our input focus wins

## Test plan

- [ ] Add a new stage direction — cursor should immediately appear in the text input without clicking
- [ ] Add a new dialogue line — same auto-focus behaviour confirmed  
- [ ] Click "Edit" on an existing stage direction — cursor should appear in the first text input
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)