### PR TITLE
Add character MRU sort setting (#1018)

### DIFF
--- a/client/src/js/mruSortUtils.test.ts
+++ b/client/src/js/mruSortUtils.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { buildMruCharacterOptions, buildMruCharacterGroupOptions } from './mruSortUtils';
+
+const CHARS = [
+  { id: 1, name: 'Alice' },
+  { id: 2, name: 'Bob' },
+  { id: 3, name: 'Carol' },
+];
+
+const GROUPS = [
+  { id: 10, name: 'Ensemble' },
+  { id: 11, name: 'Chorus' },
+];
+
+function makePage(
+  entries: Array<{ character_id?: number | null; character_group_id?: number | null }>
+) {
+  return entries.map((e) => ({ line_parts: [e] }));
+}
+
+describe('buildMruCharacterOptions', () => {
+  it('returns null when tmpScript is empty', () => {
+    expect(buildMruCharacterOptions(CHARS, {})).toBeNull();
+  });
+
+  it('returns null when no line parts have a character_id set', () => {
+    const script = { '1': makePage([{ character_id: null }, { character_group_id: 10 }]) };
+    expect(buildMruCharacterOptions(CHARS, script)).toBeNull();
+  });
+
+  it('sorts characters by descending frequency', () => {
+    const script = {
+      '1': makePage([{ character_id: 2 }, { character_id: 2 }, { character_id: 1 }]),
+    };
+    const result = buildMruCharacterOptions(CHARS, script)!;
+    const ids = result.slice(1).map((o) => o.value);
+    expect(ids).toEqual([2, 1, 3]);
+  });
+
+  it('always prepends the N/A null option', () => {
+    const script = { '1': makePage([{ character_id: 1 }]) };
+    const result = buildMruCharacterOptions(CHARS, script)!;
+    expect(result[0]).toEqual({ value: null, text: 'N/A' });
+  });
+
+  it('preserves original order for characters with equal frequency', () => {
+    const script = {
+      '1': makePage([{ character_id: 1 }, { character_id: 2 }]),
+    };
+    const result = buildMruCharacterOptions(CHARS, script)!;
+    const ids = result.slice(1).map((o) => o.value);
+    expect(ids).toEqual([1, 2, 3]);
+  });
+
+  it('places characters absent from script after those that appear', () => {
+    const script = { '1': makePage([{ character_id: 3 }]) };
+    const result = buildMruCharacterOptions(CHARS, script)!;
+    const ids = result.slice(1).map((o) => o.value);
+    expect(ids[0]).toBe(3);
+  });
+
+  it('aggregates counts across multiple pages', () => {
+    const script = {
+      '1': makePage([{ character_id: 1 }]),
+      '2': makePage([{ character_id: 2 }, { character_id: 2 }]),
+      '3': makePage([{ character_id: 1 }]),
+    };
+    const result = buildMruCharacterOptions(CHARS, script)!;
+    const ids = result.slice(1).map((o) => o.value);
+    // Bob (2): count 2, Alice (1): count 2, Carol: 0 — equal count keeps original order
+    expect(ids).toEqual([1, 2, 3]);
+  });
+
+  it('handles lines with no line_parts gracefully', () => {
+    const script = { '1': [{ line_parts: undefined as any }, { line_parts: [] }] };
+    expect(buildMruCharacterOptions(CHARS, script)).toBeNull();
+  });
+});
+
+describe('buildMruCharacterGroupOptions', () => {
+  it('returns null when tmpScript is empty', () => {
+    expect(buildMruCharacterGroupOptions(GROUPS, {})).toBeNull();
+  });
+
+  it('returns null when no line parts have a character_group_id set', () => {
+    const script = { '1': makePage([{ character_id: 1 }]) };
+    expect(buildMruCharacterGroupOptions(GROUPS, script)).toBeNull();
+  });
+
+  it('sorts groups by descending frequency', () => {
+    const script = {
+      '1': makePage([
+        { character_group_id: 11 },
+        { character_group_id: 11 },
+        { character_group_id: 10 },
+      ]),
+    };
+    const result = buildMruCharacterGroupOptions(GROUPS, script)!;
+    const ids = result.slice(1).map((o) => o.value);
+    expect(ids).toEqual([11, 10]);
+  });
+
+  it('always prepends the N/A null option', () => {
+    const script = { '1': makePage([{ character_group_id: 10 }]) };
+    const result = buildMruCharacterGroupOptions(GROUPS, script)!;
+    expect(result[0]).toEqual({ value: null, text: 'N/A' });
+  });
+
+  it('aggregates counts across multiple pages', () => {
+    const script = {
+      '1': makePage([{ character_group_id: 10 }]),
+      '2': makePage([{ character_group_id: 11 }, { character_group_id: 11 }]),
+    };
+    const result = buildMruCharacterGroupOptions(GROUPS, script)!;
+    const ids = result.slice(1).map((o) => o.value);
+    expect(ids).toEqual([11, 10]);
+  });
+});

--- a/client/src/js/mruSortUtils.ts
+++ b/client/src/js/mruSortUtils.ts
@@ -1,0 +1,51 @@
+type NamedItem = { id: number; name: string };
+type LinePart = { character_id?: number | null; character_group_id?: number | null };
+type ScriptLine = { line_parts?: LinePart[] };
+type TmpScript = Record<string, ScriptLine[]>;
+export type SelectOption = { value: number | null; text: string };
+
+function countOccurrences(
+  tmpScript: TmpScript,
+  field: 'character_id' | 'character_group_id'
+): Record<number, number> {
+  const counts: Record<number, number> = {};
+  Object.values(tmpScript).forEach((page) => {
+    page.forEach((line) => {
+      (line.line_parts ?? []).forEach((part) => {
+        const id = part[field];
+        if (id != null) {
+          counts[id] = (counts[id] || 0) + 1;
+        }
+      });
+    });
+  });
+  return counts;
+}
+
+/**
+ * Returns character options sorted by frequency across the loaded script pages,
+ * or null if no character data is present in tmpScript (caller should use default order).
+ */
+export function buildMruCharacterOptions(
+  characters: NamedItem[],
+  tmpScript: TmpScript
+): SelectOption[] | null {
+  const counts = countOccurrences(tmpScript, 'character_id');
+  if (Object.keys(counts).length === 0) return null;
+  const sorted = [...characters].sort((a, b) => (counts[b.id] || 0) - (counts[a.id] || 0));
+  return [{ value: null, text: 'N/A' }, ...sorted.map((c) => ({ value: c.id, text: c.name }))];
+}
+
+/**
+ * Returns character group options sorted by frequency across the loaded script pages,
+ * or null if no group data is present in tmpScript (caller should use default order).
+ */
+export function buildMruCharacterGroupOptions(
+  characterGroups: NamedItem[],
+  tmpScript: TmpScript
+): SelectOption[] | null {
+  const counts = countOccurrences(tmpScript, 'character_group_id');
+  if (Object.keys(counts).length === 0) return null;
+  const sorted = [...characterGroups].sort((a, b) => (counts[b.id] || 0) - (counts[a.id] || 0));
+  return [{ value: null, text: 'N/A' }, ...sorted.map((g) => ({ value: g.id, text: g.name }))];
+}

--- a/client/src/types/api/user.ts
+++ b/client/src/types/api/user.ts
@@ -20,4 +20,5 @@ export interface UserSettings {
   cue_position_right: boolean | null;
   script_text_alignment: number;
   console_log_level: string;
+  character_mru_sort: boolean;
 }

--- a/client/src/vue_components/show/config/script/ScriptEditor.vue
+++ b/client/src/vue_components/show/config/script/ScriptEditor.vue
@@ -228,6 +228,8 @@ import { makeURL, randInt } from '@/js/utils';
 import { notNull, notNullAndGreaterThanZero } from '@/js/customValidators';
 import { LINE_TYPES } from '@/constants/lineTypes';
 
+const MRU_LOOK_BACK = 4;
+
 export default defineComponent({
   name: 'ScriptConfig',
   components: { BulkActSceneModal, ScriptLineViewer, ScriptLineEditor },
@@ -829,8 +831,13 @@ export default defineComponent({
       this.changingPage = false;
     },
     async goToPageInner(pageNo: number): Promise<void> {
-      if (pageNo > 1) {
-        await (this as any).LOAD_SCRIPT_PAGE(pageNo - 1);
+      const loadedPages = new Set(Object.keys((this as any).TMP_SCRIPT).map(Number));
+      const lookBackStart = Math.max(1, pageNo - MRU_LOOK_BACK);
+      for (let p = lookBackStart; p < pageNo; p++) {
+        if (!loadedPages.has(p)) {
+          await (this as any).LOAD_SCRIPT_PAGE(p);
+          (this as any).ADD_BLANK_PAGE(p);
+        }
       }
       await (this as any).LOAD_SCRIPT_PAGE(pageNo);
       this.currentEditPage = pageNo;

--- a/client/src/vue_components/show/config/script/ScriptLinePart.vue
+++ b/client/src/vue_components/show/config/script/ScriptLinePart.vue
@@ -61,8 +61,10 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { mapGetters } from 'vuex';
 import { required, requiredIf } from 'vuelidate/lib/validators';
 import { LINE_TYPES } from '@/constants/lineTypes';
+import { buildMruCharacterOptions, buildMruCharacterGroupOptions } from '@/js/mruSortUtils';
 
 export default defineComponent({
   name: 'ScriptLinePart',
@@ -127,19 +129,27 @@ export default defineComponent({
     };
   },
   computed: {
+    ...mapGetters(['USER_SETTINGS', 'TMP_SCRIPT']),
     characterOptions(): any[] {
+      const chars = this.characters as any[];
+      if ((this.USER_SETTINGS as any)?.character_mru_sort) {
+        const sorted = buildMruCharacterOptions(chars, this.TMP_SCRIPT);
+        if (sorted) return sorted;
+      }
       return [
         { value: null, text: 'N/A' },
-        ...(this.characters as any[]).map((char: any) => ({ value: char.id, text: char.name })),
+        ...chars.map((c: any) => ({ value: c.id, text: c.name })),
       ];
     },
     characterGroupOptions(): any[] {
+      const groups = this.characterGroups as any[];
+      if ((this.USER_SETTINGS as any)?.character_mru_sort) {
+        const sorted = buildMruCharacterGroupOptions(groups, this.TMP_SCRIPT);
+        if (sorted) return sorted;
+      }
       return [
         { value: null, text: 'N/A' },
-        ...(this.characterGroups as any[]).map((char: any) => ({
-          value: char.id,
-          text: char.name,
-        })),
+        ...groups.map((g: any) => ({ value: g.id, text: g.name })),
       ];
     },
   },

--- a/client/src/vue_components/user/settings/Settings.vue
+++ b/client/src/vue_components/user/settings/Settings.vue
@@ -78,6 +78,18 @@
                   :state="validateState('console_log_level')"
                 />
               </b-form-group>
+              <b-form-group
+                :label-cols="true"
+                label="Sort characters by most recently used"
+                label-for="character-mru-sort-input"
+              >
+                <b-form-checkbox
+                  id="character-mru-sort-input"
+                  v-model="$v.editSettings.character_mru_sort.$model"
+                  name="character-mru-sort-input"
+                  :switch="true"
+                />
+              </b-form-group>
               <b-button-group size="md" style="float: right">
                 <b-button type="reset" variant="danger" :disabled="!$v.$anyDirty"> Reset </b-button>
                 <b-button type="submit" variant="primary" :disabled="!$v.$anyDirty || $v.$anyError">
@@ -115,6 +127,7 @@ export default defineComponent({
         cue_position_right: false,
         script_text_alignment: TEXT_ALIGNMENT.CENTER,
         console_log_level: 'WARN',
+        character_mru_sort: false,
       },
       textAlignmentOptions: [
         { value: TEXT_ALIGNMENT.LEFT, text: 'Left' },
@@ -156,6 +169,7 @@ export default defineComponent({
         integer,
       },
       console_log_level: { required },
+      character_mru_sort: {},
     },
   },
   mounted(): void {

--- a/docs/pages/user_settings.md
+++ b/docs/pages/user_settings.md
@@ -18,11 +18,15 @@ The Settings tab allows you to configure personal preferences for your DigiScrip
 
 Configure the script autosave interval to automatically save your script changes while editing. You can set the autosave interval in minutes, or disable autosave entirely if you prefer manual saves.
 
-####
-
- Cue Position
+#### Cue Position
 
 Choose whether cues are displayed on the left or right side of the script during live shows. This allows you to customize the layout to match your workflow or screen arrangement.
+
+#### Sort Characters by Most Recently Used
+
+When enabled, the character and character group dropdown menus in the script editor are reordered so that the characters you have used most frequently appear at the top. The ordering is based on how many times you have selected each character across the last 5 pages you have edited, so characters that appear heavily in the current scene naturally rise to the top.
+
+This setting is particularly useful when entering a scene with a known cast, as it reduces the need to scroll through the full character list. The ordering updates automatically as you make selections and resets when you load a different show.
 
 ### Stage Direction Styles
 

--- a/server/alembic_config/versions/c515969c1a51_add_character_mru_sort_to_user_settings.py
+++ b/server/alembic_config/versions/c515969c1a51_add_character_mru_sort_to_user_settings.py
@@ -1,0 +1,43 @@
+"""add_character_mru_sort_to_user_settings
+
+Revision ID: c515969c1a51
+Revises: 897ae2963f6d
+Create Date: 2026-05-12 19:48:43.975135
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c515969c1a51"
+down_revision: Union[str, None] = "897ae2963f6d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add column as nullable first so existing rows can be backfilled
+    with op.batch_alter_table("user_settings", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("character_mru_sort", sa.Boolean(), nullable=True)
+        )
+
+    # Backfill existing rows to False
+    op.execute(
+        "UPDATE user_settings SET character_mru_sort = 0 WHERE character_mru_sort IS NULL"
+    )
+
+    # Make column non-nullable
+    with op.batch_alter_table("user_settings", schema=None) as batch_op:
+        batch_op.alter_column(
+            "character_mru_sort", existing_type=sa.Boolean(), nullable=False
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("user_settings", schema=None) as batch_op:
+        batch_op.drop_column("character_mru_sort")

--- a/server/models/user.py
+++ b/server/models/user.py
@@ -87,6 +87,7 @@ class UserSettings(db.Model):
         TextAlignmentCol, default=TextAlignment.CENTER
     )
     console_log_level: Mapped[str] = mapped_column(default="WARN")
+    character_mru_sort: Mapped[bool] = mapped_column(default=False)
 
     __table_args__ = (
         CheckConstraint(


### PR DESCRIPTION
## Summary

- Adds an optional user setting **"Sort characters by most recently used"** that sorts character and character group dropdowns in the script editor by frequency of appearance across the surrounding script pages
- When enabled, characters with the most lines in the nearby pages float to the top; characters with no recent lines retain their original API order (stable sort)
- Sorting is computed from `TMP_SCRIPT` (the editable working copy), so in-progress edits are reflected immediately

## Implementation

**Backend**
- `character_mru_sort: Mapped[bool]` added to `UserSettings` model (default `False`)
- Alembic migration backfills existing rows before converting column to `NOT NULL`

**Frontend**
- `mruSortUtils.ts` — pure `buildMruCharacterOptions` / `buildMruCharacterGroupOptions` helpers; 13 Vitest unit tests
- `ScriptLinePart.vue` — maps `TMP_SCRIPT`; `characterOptions` / `characterGroupOptions` computed properties delegate to the sort helpers when the setting is on
- `ScriptEditor.vue` — `MRU_LOOK_BACK = 4` constant; `goToPageInner` pre-loads and copies up to 4 look-back pages into `TMP_SCRIPT` on any page navigation (mirrors the existing `decrPage` pattern; skips pages already present to avoid overwriting unsaved edits)
- `Settings.vue` — toggle switch in user settings form
- `docs/pages/user_settings.md` — user documentation updated

## Test plan

- [ ] Backend: `cd server && python3 main.py` — Alembic migration runs without errors
- [ ] User → Settings: "Sort characters by most recently used" toggle appears, saves, and persists
- [ ] Setting **off**: character dropdown order unchanged from API order
- [ ] Setting **on**: jump to a page mid-show via "Go to Page" — characters frequent on surrounding pages rank above rarely-seen ones
- [ ] Unsaved edits on a look-back page are preserved (page already in TMP_SCRIPT is skipped by the guard)
- [ ] Save script — no unexpected pages saved (look-back pages produce an empty diff)
- [ ] `cd server && pytest` — 587 tests pass
- [ ] `cd client && npm run ci-lint && npm run typecheck && npm run test:run` — all 119 tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)