### PR TITLE
Add backup database file management UI (#1025)

### DIFF
--- a/client/src/assets/styles/dark.scss
+++ b/client/src/assets/styles/dark.scss
@@ -5,6 +5,10 @@
 @import '../../../node_modules/bootswatch/dist/darkly/variables';
 @import 'bootstrap/scss/bootstrap';
 @import '../../../node_modules/bootswatch/dist/darkly/bootswatch';
+// Use white-fill sort icons so they're visible on the dark background
+$b-table-sort-icon-bg-not-sorted: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='101' height='101' view-box='0 0 101 101' preserveAspectRatio='none'><path fill='white' opacity='.5' d='M51 1l25 23 24 22H1l25-22zM51 101l25-23 24-22H1l25 22z'/></svg>");
+$b-table-sort-icon-bg-ascending: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='101' height='101' view-box='0 0 101 101' preserveAspectRatio='none'><path fill='white' d='M51 1l25 23 24 22H1l25-22z'/><path fill='white' opacity='.5' d='M51 101l25-23 24-22H1l25 22z'/></svg>");
+$b-table-sort-icon-bg-descending: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='101' height='101' view-box='0 0 101 101' preserveAspectRatio='none'><path fill='white' opacity='.5' d='M51 1l25 23 24 22H1l25-22z'/><path fill='white' d='M51 101l25-23 24-22H1l25 22z'/></svg>");
 @import 'bootstrap-vue/src/index.scss';
 
 :root {

--- a/client/src/types/api/backup.ts
+++ b/client/src/types/api/backup.ts
@@ -1,0 +1,11 @@
+export interface BackupFile {
+  filename: string;
+  size_bytes: number;
+  created_at: number;
+}
+
+export interface BackupsResponse {
+  backups: BackupFile[];
+  count: number;
+  total_size_bytes: number;
+}

--- a/client/src/views/config/ConfigView.vue
+++ b/client/src/views/config/ConfigView.vue
@@ -19,6 +19,9 @@
           <b-tab title="Logs">
             <config-logs />
           </b-tab>
+          <b-tab title="Backups">
+            <config-backups />
+          </b-tab>
         </b-tabs>
       </b-col>
     </b-row>
@@ -32,9 +35,10 @@ import ConfigSettings from '@/vue_components/config/ConfigSettings.vue';
 import ConfigUsers from '@/vue_components/config/ConfigUsers.vue';
 import ConfigShows from '@/vue_components/config/ConfigShows.vue';
 import ConfigLogs from '@/vue_components/config/ConfigLogs.vue';
+import ConfigBackups from '@/vue_components/config/ConfigBackups.vue';
 
 export default defineComponent({
   name: 'ConfigView',
-  components: { ConfigShows, ConfigUsers, ConfigSettings, ConfigSystem, ConfigLogs },
+  components: { ConfigShows, ConfigUsers, ConfigSettings, ConfigSystem, ConfigLogs, ConfigBackups },
 });
 </script>

--- a/client/src/vue_components/config/ConfigBackups.vue
+++ b/client/src/vue_components/config/ConfigBackups.vue
@@ -1,0 +1,124 @@
+<template>
+  <div v-if="!loading">
+    <div v-if="backups.length > 0">
+      <p class="text-muted mb-3">
+        {{ count }} {{ count === 1 ? 'backup' : 'backups' }} &middot;
+        {{ formatBytes(totalSizeBytes) }} total
+      </p>
+      <b-table :items="backups" :fields="fields" sort-by="created_at" :sort-desc="true">
+        <template #cell(size_bytes)="data">
+          {{ formatBytes(data.item.size_bytes) }}
+        </template>
+        <template #cell(created_at)="data">
+          {{ formatDate(data.item.created_at) }}
+        </template>
+        <template #cell(actions)="data">
+          <b-button
+            variant="danger"
+            size="sm"
+            :disabled="isDeleting"
+            @click="deleteBackup(data.item)"
+          >
+            Delete
+          </b-button>
+        </template>
+      </b-table>
+    </div>
+    <b-alert v-else variant="info" show>
+      No backup files found. Backups are created automatically before database migrations.
+    </b-alert>
+  </div>
+  <div v-else class="text-center center-spinner">
+    <b-spinner style="width: 10rem; height: 10rem" variant="info" />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import log from 'loglevel';
+import { makeURL } from '@/js/utils';
+import type { BackupFile, BackupsResponse } from '@/types/api/backup';
+
+export default defineComponent({
+  name: 'ConfigBackups',
+  data() {
+    return {
+      backups: [] as BackupFile[],
+      count: 0,
+      totalSizeBytes: 0,
+      loading: true,
+      isDeleting: false,
+      fields: [
+        { key: 'filename', label: 'Filename' },
+        { key: 'size_bytes', label: 'Size', sortable: true },
+        { key: 'created_at', label: 'Date Created', sortable: true },
+        { key: 'actions', label: '' },
+      ],
+    };
+  },
+  async mounted() {
+    await this.fetchBackups();
+    this.loading = false;
+  },
+  methods: {
+    async fetchBackups(): Promise<void> {
+      try {
+        const response = await fetch(makeURL('/api/v1/admin/db-backups'));
+        if (response.ok) {
+          const data: BackupsResponse = await response.json();
+          this.backups = data.backups;
+          this.count = data.count;
+          this.totalSizeBytes = data.total_size_bytes;
+        } else {
+          log.error('Unable to fetch backup files');
+        }
+      } catch (error) {
+        log.error('Error fetching backup files:', error);
+      }
+    },
+    async deleteBackup(backup: BackupFile): Promise<void> {
+      const confirmed = await (this as any).$bvModal.msgBoxConfirm(
+        `Are you sure you want to permanently delete "${backup.filename}"? This cannot be undone.`,
+        { title: 'Delete Backup', okVariant: 'danger', okTitle: 'Delete' }
+      );
+      if (!confirmed) return;
+
+      this.isDeleting = true;
+      try {
+        const response = await fetch(
+          makeURL(`/api/v1/admin/db-backups?timestamp=${backup.created_at}`),
+          { method: 'DELETE' }
+        );
+        if (response.ok) {
+          this.$toast.success('Backup deleted');
+          await this.fetchBackups();
+        } else {
+          const body = await response.json();
+          this.$toast.error(`Failed to delete backup: ${body.message}`);
+        }
+      } catch (error) {
+        this.$toast.error('Failed to delete backup');
+        log.error('Error deleting backup:', error);
+      } finally {
+        this.isDeleting = false;
+      }
+    },
+    formatBytes(bytes: number): string {
+      if (bytes === 0) return '0 B';
+      const units = ['B', 'KB', 'MB', 'GB'];
+      const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+      return `${(bytes / 1024 ** i).toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+    },
+    formatDate(unixTimestamp: number): string {
+      const d = new Date(unixTimestamp * 1000);
+      const day = String(d.getDate()).padStart(2, '0');
+      const month = String(d.getMonth() + 1).padStart(2, '0');
+      const year = d.getFullYear();
+      const hours = String(d.getHours()).padStart(2, '0');
+      const minutes = String(d.getMinutes()).padStart(2, '0');
+      const seconds = String(d.getSeconds()).padStart(2, '0');
+      return `${day}/${month}/${year} ${hours}:${minutes}:${seconds}`;
+    },
+  },
+});
+</script>

--- a/docs/pages/user_config.md
+++ b/docs/pages/user_config.md
@@ -66,6 +66,18 @@ Once users have been created, their permissions can be configured by clicking th
 
 RBAC configuration determines what shows a user can access and what actions they can perform within those shows.
 
+### Backup Management
+
+The **Backups** tab allows admin users to view and manage database backup files. DigiScript automatically creates a timestamped copy of the database file before running any database migration, ensuring you can recover data if a migration causes issues.
+
+The tab displays:
+- A summary line showing the total number of backups and combined disk usage
+- A table listing each backup file with its filename, size, and creation date
+
+To delete a backup, click the **Delete** button next to it and confirm the action. Deletion is permanent and cannot be undone.
+
+> **Note:** Backup files accumulate over time as you upgrade DigiScript. Periodically reviewing and removing old backups helps reclaim disk space once you are confident the corresponding migrations completed successfully.
+
 ### RBAC Roles and Mappings
 
 The current RBAC mappings are as follows:

--- a/server/controllers/api/db_backups.py
+++ b/server/controllers/api/db_backups.py
@@ -1,0 +1,92 @@
+import os
+
+from utils.web.base_controller import BaseAPIController
+from utils.web.route import ApiRoute, ApiVersion
+from utils.web.web_decorators import api_authenticated, require_admin
+
+
+def _get_db_file_path(application) -> str:
+    """
+    :return: Absolute filesystem path to the SQLite database file.
+    :rtype: str
+    """
+    db_path: str = application.digi_settings.settings.get("db_path").get_value()
+    if db_path.startswith("sqlite:///"):
+        db_path = db_path.replace("sqlite:///", "")
+    return db_path
+
+
+def _list_backups(db_path: str) -> list[dict]:
+    """
+    :param db_path: Filesystem path to the main database file.
+    :type db_path: str
+    :return: List of backup file dicts, sorted newest first.
+    :rtype: list[dict]
+    """
+    db_dir = os.path.dirname(db_path) or "."
+    db_basename = os.path.basename(db_path)
+    prefix = db_basename + "."
+
+    backups = []
+    if os.path.isdir(db_dir):
+        for fname in os.listdir(db_dir):
+            if not fname.startswith(prefix):
+                continue
+            suffix = fname[len(prefix) :]
+            if not suffix.isdigit():
+                continue
+            full_path = os.path.join(db_dir, fname)
+            stat = os.stat(full_path)
+            backups.append(
+                {
+                    "filename": fname,
+                    "size_bytes": stat.st_size,
+                    "created_at": int(suffix),
+                }
+            )
+
+    backups.sort(key=lambda x: x["created_at"], reverse=True)
+    return backups
+
+
+@ApiRoute("admin/db-backups", ApiVersion.V1)
+class BackupsController(BaseAPIController):
+    @api_authenticated
+    @require_admin
+    async def get(self):
+        db_path = _get_db_file_path(self.application)
+        backups = _list_backups(db_path)
+        total_size = sum(b["size_bytes"] for b in backups)
+        self.set_status(200)
+        await self.finish(
+            {
+                "backups": backups,
+                "count": len(backups),
+                "total_size_bytes": total_size,
+            }
+        )
+
+    @api_authenticated
+    @require_admin
+    async def delete(self):
+        timestamp = self.get_argument("timestamp", None)
+        if not timestamp:
+            self.set_status(400)
+            await self.finish({"message": "timestamp query argument is required"})
+            return
+        if not timestamp.isdigit():
+            self.set_status(400)
+            await self.finish({"message": "timestamp must be a positive integer"})
+            return
+
+        db_path = _get_db_file_path(self.application)
+        backup_path = f"{db_path}.{timestamp}"
+
+        if not os.path.isfile(backup_path):
+            self.set_status(404)
+            await self.finish({"message": "Backup file not found"})
+            return
+
+        os.remove(backup_path)
+        self.set_status(200)
+        await self.finish({"message": "Backup deleted"})

--- a/server/test/controllers/api/test_db_backups.py
+++ b/server/test/controllers/api/test_db_backups.py
@@ -1,0 +1,219 @@
+"""Integration tests for GET /api/v1/admin/db-backups and DELETE /api/v1/admin/db-backups."""
+
+import os
+import shutil
+import tempfile
+
+from tornado import escape
+
+from test.conftest import DigiScriptTestCase
+
+
+class TestDbBackupsController(DigiScriptTestCase):
+    def setUp(self):
+        super().setUp()
+        self._tmp_dir = tempfile.mkdtemp()
+        self._db_file = os.path.join(self._tmp_dir, "digiscript.sqlite")
+        open(self._db_file, "wb").close()
+        # Point the db_path setting at our temp file so the controller can find it
+        self._app.digi_settings.settings.get("db_path").set_value(
+            f"sqlite:///{self._db_file}"
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp_dir, ignore_errors=True)
+        super().tearDown()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _create_backup(self, timestamp: int) -> str:
+        backup_path = f"{self._db_file}.{timestamp}"
+        with open(backup_path, "wb") as f:
+            f.write(b"x" * 1024)
+        return backup_path
+
+    def _create_and_login_admin(self, username="admin", password="adminpass"):
+        self.fetch(
+            "/api/v1/auth/create",
+            method="POST",
+            body=escape.json_encode(
+                {"username": username, "password": password, "is_admin": True}
+            ),
+        )
+        resp = self.fetch(
+            "/api/v1/auth/login",
+            method="POST",
+            body=escape.json_encode({"username": username, "password": password}),
+        )
+        return escape.json_decode(resp.body)["access_token"]
+
+    def _create_and_login_user(self, admin_token, username="user", password="userpass"):
+        self.fetch(
+            "/api/v1/auth/create",
+            method="POST",
+            body=escape.json_encode(
+                {"username": username, "password": password, "is_admin": False}
+            ),
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        resp = self.fetch(
+            "/api/v1/auth/login",
+            method="POST",
+            body=escape.json_encode({"username": username, "password": password}),
+        )
+        return escape.json_decode(resp.body)["access_token"]
+
+    def _fetch_backups(self, token=None):
+        headers = {}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        return self.fetch(
+            "/api/v1/admin/db-backups", headers=headers, raise_error=False
+        )
+
+    def _delete_backup(self, timestamp, token=None):
+        headers = {}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        return self.fetch(
+            f"/api/v1/admin/db-backups?timestamp={timestamp}",
+            method="DELETE",
+            headers=headers,
+            raise_error=False,
+        )
+
+    # ------------------------------------------------------------------
+    # GET — authentication
+    # ------------------------------------------------------------------
+
+    def test_get_unauthenticated_returns_401(self):
+        resp = self._fetch_backups()
+        self.assertEqual(401, resp.code)
+
+    def test_get_non_admin_returns_401(self):
+        admin_token = self._create_and_login_admin()
+        user_token = self._create_and_login_user(admin_token)
+        resp = self._fetch_backups(token=user_token)
+        self.assertEqual(401, resp.code)
+
+    # ------------------------------------------------------------------
+    # GET — response shape
+    # ------------------------------------------------------------------
+
+    def test_get_admin_no_backups_returns_empty_list(self):
+        token = self._create_and_login_admin()
+        resp = self._fetch_backups(token=token)
+        self.assertEqual(200, resp.code)
+        body = escape.json_decode(resp.body)
+        self.assertEqual([], body["backups"])
+        self.assertEqual(0, body["count"])
+        self.assertEqual(0, body["total_size_bytes"])
+
+    def test_get_admin_lists_backup_files(self):
+        token = self._create_and_login_admin()
+        ts_old = 1700000000
+        ts_new = 1700001000
+        self._create_backup(ts_old)
+        self._create_backup(ts_new)
+
+        resp = self._fetch_backups(token=token)
+        self.assertEqual(200, resp.code)
+        body = escape.json_decode(resp.body)
+        self.assertEqual(2, body["count"])
+        self.assertGreater(body["total_size_bytes"], 0)
+
+        timestamps = [b["created_at"] for b in body["backups"]]
+        self.assertEqual([ts_new, ts_old], timestamps, "Backups should be newest-first")
+
+    def test_get_backup_metadata_fields(self):
+        token = self._create_and_login_admin()
+        ts = 1700000000
+        self._create_backup(ts)
+
+        resp = self._fetch_backups(token=token)
+        body = escape.json_decode(resp.body)
+        backup = body["backups"][0]
+        self.assertIn("filename", backup)
+        self.assertIn("size_bytes", backup)
+        self.assertIn("created_at", backup)
+        self.assertEqual(ts, backup["created_at"])
+        self.assertEqual(1024, backup["size_bytes"])
+
+    def test_get_ignores_non_backup_files(self):
+        """Files without a digits-only suffix must not appear in the list."""
+        token = self._create_and_login_admin()
+        # Create a file that matches the prefix but has a non-digits suffix
+        open(f"{self._db_file}.notabackup", "wb").close()
+        open(f"{self._db_file}.123abc", "wb").close()
+
+        resp = self._fetch_backups(token=token)
+        body = escape.json_decode(resp.body)
+        self.assertEqual(0, body["count"])
+
+    # ------------------------------------------------------------------
+    # DELETE — authentication
+    # ------------------------------------------------------------------
+
+    def test_delete_unauthenticated_returns_401(self):
+        resp = self._delete_backup(1700000000)
+        self.assertEqual(401, resp.code)
+
+    def test_delete_non_admin_returns_401(self):
+        admin_token = self._create_and_login_admin()
+        user_token = self._create_and_login_user(admin_token)
+        resp = self._delete_backup(1700000000, token=user_token)
+        self.assertEqual(401, resp.code)
+
+    # ------------------------------------------------------------------
+    # DELETE — validation
+    # ------------------------------------------------------------------
+
+    def test_delete_missing_timestamp_returns_400(self):
+        token = self._create_and_login_admin()
+        resp = self.fetch(
+            "/api/v1/admin/db-backups",
+            method="DELETE",
+            headers={"Authorization": f"Bearer {token}"},
+            raise_error=False,
+        )
+        self.assertEqual(400, resp.code)
+
+    def test_delete_non_digits_timestamp_returns_400(self):
+        token = self._create_and_login_admin()
+        resp = self._delete_backup("abc123", token=token)
+        self.assertEqual(400, resp.code)
+
+    def test_delete_nonexistent_timestamp_returns_404(self):
+        token = self._create_and_login_admin()
+        resp = self._delete_backup(9999999999, token=token)
+        self.assertEqual(404, resp.code)
+
+    # ------------------------------------------------------------------
+    # DELETE — success
+    # ------------------------------------------------------------------
+
+    def test_delete_valid_backup_removes_file(self):
+        token = self._create_and_login_admin()
+        ts = 1700000000
+        backup_path = self._create_backup(ts)
+        self.assertTrue(os.path.isfile(backup_path))
+
+        resp = self._delete_backup(ts, token=token)
+        self.assertEqual(200, resp.code)
+        self.assertFalse(os.path.isfile(backup_path))
+
+    def test_delete_reduces_count_in_subsequent_get(self):
+        token = self._create_and_login_admin()
+        ts1 = 1700000000
+        ts2 = 1700001000
+        self._create_backup(ts1)
+        self._create_backup(ts2)
+
+        self._delete_backup(ts1, token=token)
+
+        resp = self._fetch_backups(token=token)
+        body = escape.json_decode(resp.body)
+        self.assertEqual(1, body["count"])
+        self.assertEqual(ts2, body["backups"][0]["created_at"])


### PR DESCRIPTION
## Summary

- Adds an admin-only **Backups** tab to the System Config page, addressing #1025
- New `GET /api/v1/admin/db-backups` endpoint lists all timestamped backup files created before Alembic migrations, returning filename, size, creation date, and aggregate stats (count + total size)
- New `DELETE /api/v1/admin/db-backups?timestamp={ts}` endpoint removes a specific backup after validating the timestamp is digits-only (prevents path traversal)
- `ConfigBackups.vue` shows a stats summary line ("3 backups · 6.3 MB total") above a sortable table with per-row delete confirmation dialogs
- Fixes sort icon visibility across the whole dark theme by overriding Bootstrap-Vue's `$b-table-sort-icon-bg-*` SCSS variables with white-fill SVGs before the import

## Test plan

- [ ] Run `pytest server/test/controllers/api/test_db_backups.py` — 13 tests covering GET/DELETE auth, response shape, validation, and file removal
- [ ] Run `ruff check server/ && ruff format --check server/` — no issues
- [ ] Run `npm run typecheck && npm run lint` in `client/` — no issues
- [ ] Log in as admin → System Config → Backups tab — backup files listed with correct sizes and DD/MM/YYYY HH:MM:SS dates
- [ ] Click Delete on a backup → confirm modal → file removed → list refreshes with updated stats
- [ ] Log in as non-admin — confirm Backups tab is inaccessible (401 from API)
- [ ] Check sort icons are visible in all sortable tables across the dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)