### PR TITLE
Add tagged stage directions (issue #660)

### DIFF
--- a/client/src/mixins/scriptDisplayMixin.ts
+++ b/client/src/mixins/scriptDisplayMixin.ts
@@ -96,6 +96,18 @@ export default defineComponent({
     needsHeadingsAll(): boolean {
       return (this as any).needsHeadings.every((x: boolean) => x === true);
     },
+    isTaggedStageDirection(): boolean {
+      const line: ScriptLine = (this as any).line;
+      const part = line.line_parts?.[0];
+      return (
+        line.line_type === LINE_TYPES.STAGE_DIRECTION &&
+        (part?.character_id != null || part?.character_group_id != null)
+      );
+    },
+    taggedStageDirectionHeadingName(): string {
+      const part = ((this as any).line as ScriptLine).line_parts?.[0];
+      return part ? (this as any).characterOrGroupName(part) : '';
+    },
     ...mapGetters(['USER_SETTINGS']),
   },
   mounted() {
@@ -122,6 +134,15 @@ export default defineComponent({
     }
   },
   methods: {
+    characterOrGroupName(part: any): string {
+      if (part.character_id != null) {
+        return (this as any).characters?.find((c: any) => c.id === part.character_id)?.name ?? '';
+      }
+      return (
+        (this as any).characterGroups?.find((c: any) => c.id === part.character_group_id)?.name ??
+        ''
+      );
+    },
     onClassChange(classAttrValue: string | null, oldClassAttrValue: string | null): void {
       const classList = classAttrValue?.split(' ') ?? [];
       const oldClassList = oldClassAttrValue?.split(' ') ?? [];

--- a/client/src/mixins/scriptNavigationMixin.ts
+++ b/client/src/mixins/scriptNavigationMixin.ts
@@ -11,7 +11,7 @@ export default defineComponent({
       let lineIndex: number | null = (this as any).previousLineIndex;
       while (
         previousLine != null &&
-        (previousLine.line_type === LINE_TYPES.STAGE_DIRECTION || this.isWholeLineCut(previousLine))
+        (this.checkIsUntaggedStageDirection(previousLine) || this.isWholeLineCut(previousLine))
       ) {
         [lineIndex, previousLine] = this.getPreviousLineForIndex(previousLine.page, lineIndex!);
       }
@@ -60,6 +60,13 @@ export default defineComponent({
         loopPageNo -= 1;
       }
       return [null, null];
+    },
+    checkIsUntaggedStageDirection(line: ScriptLine): boolean {
+      return (
+        line.line_type === LINE_TYPES.STAGE_DIRECTION &&
+        line.line_parts[0]?.character_id == null &&
+        line.line_parts[0]?.character_group_id == null
+      );
     },
     isWholeLineCut(line: ScriptLine): boolean {
       return isWholeLineCutUtil(line, (this as any).SCRIPT_CUTS);

--- a/client/src/vue_components/show/config/script/ScriptLineEditor.vue
+++ b/client/src/vue_components/show/config/script/ScriptLineEditor.vue
@@ -55,23 +55,15 @@
           :enable-add-button="state.line_parts.length < 4 && lineType === LINE_TYPES.DIALOGUE"
           :line-type="lineType"
           :line-parts="state.line_parts"
+          :stage-direction-styles="
+            lineType === LINE_TYPES.STAGE_DIRECTION ? stageDirectionStyles : []
+          "
+          :stage-direction-style-id="state.stage_direction_style_id"
           @input="stateChange"
           @addLinePart="addLinePart"
           @tryFinishLine="tryFinishLine"
+          @stage-direction-style-change="onStageDirectionStyleChange"
         />
-        <b-col
-          v-if="lineType === LINE_TYPES.STAGE_DIRECTION && stageDirectionStyles.length > 0"
-          cols="2"
-        >
-          <b-form-select
-            id="stage-direction-style"
-            v-model="$v.state.stage_direction_style_id.$model"
-            name="stage-direction-style"
-            :options="stageDirectionStylesOptions"
-            :state="validateState('stage_direction_style_id')"
-            @change="stateChange"
-          />
-        </b-col>
       </template>
       <b-col v-else cols="10" style="text-align: right">
         <b-button v-b-popover.hover.top="'Add line part'" @click="addLinePart">
@@ -400,6 +392,10 @@ export default defineComponent({
           }
         }
       }
+      this.stateChange();
+    },
+    onStageDirectionStyleChange(styleId: number | null): void {
+      (this as any).state.stage_direction_style_id = styleId;
       this.stateChange();
     },
     deleteLine(): void {

--- a/client/src/vue_components/show/config/script/ScriptLinePart.vue
+++ b/client/src/vue_components/show/config/script/ScriptLinePart.vue
@@ -1,6 +1,6 @@
 <template>
   <b-col>
-    <b-form-row v-if="lineType === LINE_TYPES.DIALOGUE">
+    <b-form-row v-if="lineType === LINE_TYPES.DIALOGUE || lineType === LINE_TYPES.STAGE_DIRECTION">
       <template v-if="USER_SETTINGS && USER_SETTINGS.character_combined_dropdown">
         <b-col>
           <b-form-group
@@ -56,6 +56,19 @@
           </b-form-group>
         </b-col>
       </template>
+      <b-col
+        v-if="lineType === LINE_TYPES.STAGE_DIRECTION && stageDirectionStyles.length > 0"
+        cols="3"
+      >
+        <b-form-group label-size="sm" label="Style" label-for="stage-direction-style-part">
+          <b-form-select
+            id="stage-direction-style-part"
+            :value="stageDirectionStyleId"
+            :options="stageDirectionStylesOptions"
+            @change="$emit('stage-direction-style-change', $event)"
+          />
+        </b-form-group>
+      </b-col>
     </b-form-row>
     <b-form-row>
       <b-col style="display: inline-flex">
@@ -124,6 +137,16 @@ export default defineComponent({
       required: true,
       type: Array,
     },
+    stageDirectionStyles: {
+      required: false,
+      type: Array,
+      default: () => [],
+    },
+    stageDirectionStyleId: {
+      required: false,
+      type: Number,
+      default: null,
+    },
     value: {
       required: true,
       type: Object,
@@ -176,6 +199,15 @@ export default defineComponent({
       return [
         { value: null, text: 'N/A' },
         ...groups.map((g: any) => ({ value: g.id, text: g.name })),
+      ];
+    },
+    stageDirectionStylesOptions(): { value: number | null; text: string }[] {
+      return [
+        { value: null, text: 'N/A' },
+        ...(this.stageDirectionStyles as any[]).map((s: any) => ({
+          value: s.id,
+          text: s.description,
+        })),
       ];
     },
     combinedOptions(): CombinedSelectOption[] {

--- a/client/src/vue_components/show/config/script/ScriptLineViewer.vue
+++ b/client/src/vue_components/show/config/script/ScriptLineViewer.vue
@@ -65,16 +65,7 @@
       <b-col :key="`line_${lineIndex}_stage_direction`" :style="{ textAlign: scriptTextAlign }">
         <b-row v-if="isTaggedStageDirection && needsHeadingsAny" style="margin-bottom: 1rem">
           <b-col :style="headingStyle">
-            <b>
-              <template v-if="line.line_parts[0].character_id != null">
-                {{ characters.find((c) => c.id === line.line_parts[0].character_id).name }}
-              </template>
-              <template v-else>
-                {{
-                  characterGroups.find((c) => c.id === line.line_parts[0].character_group_id).name
-                }}
-              </template>
-            </b>
+            <b>{{ taggedStageDirectionHeadingName }}</b>
           </b-col>
         </b-row>
         <i
@@ -312,6 +303,16 @@ export default defineComponent({
       return (
         line.line_type === LINE_TYPES.STAGE_DIRECTION &&
         (part?.character_id != null || part?.character_group_id != null)
+      );
+    },
+    taggedStageDirectionHeadingName(): string {
+      const part = (this.line as any).line_parts?.[0];
+      if (part?.character_id != null) {
+        return (this.characters as any[]).find((c: any) => c.id === part.character_id)?.name ?? '';
+      }
+      return (
+        (this.characterGroups as any[]).find((c: any) => c.id === part?.character_group_id)?.name ??
+        ''
       );
     },
     needsActSceneLabelSimple(): boolean {

--- a/client/src/vue_components/show/config/script/ScriptLineViewer.vue
+++ b/client/src/vue_components/show/config/script/ScriptLineViewer.vue
@@ -297,24 +297,6 @@ export default defineComponent({
       });
       return ret;
     },
-    isTaggedStageDirection(): boolean {
-      const line = this.line as any;
-      const part = line.line_parts?.[0];
-      return (
-        line.line_type === LINE_TYPES.STAGE_DIRECTION &&
-        (part?.character_id != null || part?.character_group_id != null)
-      );
-    },
-    taggedStageDirectionHeadingName(): string {
-      const part = (this.line as any).line_parts?.[0];
-      if (part?.character_id != null) {
-        return (this.characters as any[]).find((c: any) => c.id === part.character_id)?.name ?? '';
-      }
-      return (
-        (this.characterGroups as any[]).find((c: any) => c.id === part?.character_group_id)?.name ??
-        ''
-      );
-    },
     needsActSceneLabelSimple(): boolean {
       const line = this.line as any;
       const previousLine = this.previousLine as any;

--- a/client/src/vue_components/show/config/script/ScriptLineViewer.vue
+++ b/client/src/vue_components/show/config/script/ScriptLineViewer.vue
@@ -63,6 +63,20 @@
     </template>
     <template v-else-if="line.line_type === LINE_TYPES.STAGE_DIRECTION">
       <b-col :key="`line_${lineIndex}_stage_direction`" :style="{ textAlign: scriptTextAlign }">
+        <b-row v-if="isTaggedStageDirection && needsHeadingsAny" style="margin-bottom: 1rem">
+          <b-col :style="headingStyle">
+            <b>
+              <template v-if="line.line_parts[0].character_id != null">
+                {{ characters.find((c) => c.id === line.line_parts[0].character_id).name }}
+              </template>
+              <template v-else>
+                {{
+                  characterGroups.find((c) => c.id === line.line_parts[0].character_group_id).name
+                }}
+              </template>
+            </b>
+          </b-col>
+        </b-row>
         <i
           v-if="(canEdit && !IS_CUT_MODE) || !canEdit"
           class="viewable-line"
@@ -257,7 +271,12 @@ export default defineComponent({
       const line = this.line as any;
       let previousLine = this.previousLine as any;
       let previousLineIndex = this.lineIndex - 1;
-      while (previousLine != null && previousLine.line_type === LINE_TYPES.STAGE_DIRECTION) {
+      while (
+        previousLine != null &&
+        previousLine.line_type === LINE_TYPES.STAGE_DIRECTION &&
+        previousLine.line_parts[0]?.character_id == null &&
+        previousLine.line_parts[0]?.character_group_id == null
+      ) {
         if (previousLineIndex === 0) {
           break;
         }
@@ -286,6 +305,14 @@ export default defineComponent({
         }
       });
       return ret;
+    },
+    isTaggedStageDirection(): boolean {
+      const line = this.line as any;
+      const part = line.line_parts?.[0];
+      return (
+        line.line_type === LINE_TYPES.STAGE_DIRECTION &&
+        (part?.character_id != null || part?.character_group_id != null)
+      );
     },
     needsActSceneLabelSimple(): boolean {
       const line = this.line as any;

--- a/client/src/vue_components/show/live/ScriptLineViewer.vue
+++ b/client/src/vue_components/show/live/ScriptLineViewer.vue
@@ -336,24 +336,6 @@ export default defineComponent({
     };
   },
   computed: {
-    isTaggedStageDirection(): boolean {
-      const line = this.line as any;
-      const part = line.line_parts?.[0];
-      return (
-        line.line_type === LINE_TYPES.STAGE_DIRECTION &&
-        (part?.character_id != null || part?.character_group_id != null)
-      );
-    },
-    taggedStageDirectionHeadingName(): string {
-      const part = (this.line as any).line_parts?.[0];
-      if (part?.character_id != null) {
-        return (this.characters as any[]).find((c: any) => c.id === part.character_id)?.name ?? '';
-      }
-      return (
-        (this.characterGroups as any[]).find((c: any) => c.id === part?.character_group_id)?.name ??
-        ''
-      );
-    },
     isFirstRowIntervalBanner(): boolean {
       return (this as any).needsIntervalBanner;
     },

--- a/client/src/vue_components/show/live/ScriptLineViewer.vue
+++ b/client/src/vue_components/show/live/ScriptLineViewer.vue
@@ -108,6 +108,21 @@
         </template>
         <template v-else-if="line.line_type === LINE_TYPES.STAGE_DIRECTION">
           <b-col :key="`line_${lineIndex}_stage_direction`" :style="{ textAlign: scriptTextAlign }">
+            <b-row v-if="isTaggedStageDirection && needsHeadingsAny" style="margin-bottom: 1rem">
+              <b-col :style="headingStyle">
+                <b>
+                  <template v-if="line.line_parts[0].character_id != null">
+                    {{ characters.find((c) => c.id === line.line_parts[0].character_id).name }}
+                  </template>
+                  <template v-else>
+                    {{
+                      characterGroups.find((c) => c.id === line.line_parts[0].character_group_id)
+                        .name
+                    }}
+                  </template>
+                </b>
+              </b-col>
+            </b-row>
             <i class="viewable-line" :style="stageDirectionStyling">
               <template
                 v-if="stageDirectionStyle != null && stageDirectionStyle.text_format === 'upper'"
@@ -214,6 +229,21 @@
         </template>
         <template v-else-if="line.line_type === LINE_TYPES.STAGE_DIRECTION">
           <b-col :key="`line_${lineIndex}_stage_direction`" :style="{ textAlign: scriptTextAlign }">
+            <b-row v-if="isTaggedStageDirection && needsHeadingsAny" style="margin-bottom: 1rem">
+              <b-col :style="headingStyle">
+                <b>
+                  <template v-if="line.line_parts[0].character_id != null">
+                    {{ characters.find((c) => c.id === line.line_parts[0].character_id).name }}
+                  </template>
+                  <template v-else>
+                    {{
+                      characterGroups.find((c) => c.id === line.line_parts[0].character_group_id)
+                        .name
+                    }}
+                  </template>
+                </b>
+              </b-col>
+            </b-row>
             <i class="viewable-line" :style="stageDirectionStyling">
               <template
                 v-if="stageDirectionStyle != null && stageDirectionStyle.text_format === 'upper'"
@@ -326,6 +356,14 @@ export default defineComponent({
     };
   },
   computed: {
+    isTaggedStageDirection(): boolean {
+      const line = this.line as any;
+      const part = line.line_parts?.[0];
+      return (
+        line.line_type === LINE_TYPES.STAGE_DIRECTION &&
+        (part?.character_id != null || part?.character_group_id != null)
+      );
+    },
     isFirstRowIntervalBanner(): boolean {
       return (this as any).needsIntervalBanner;
     },

--- a/client/src/vue_components/show/live/ScriptLineViewer.vue
+++ b/client/src/vue_components/show/live/ScriptLineViewer.vue
@@ -110,17 +110,7 @@
           <b-col :key="`line_${lineIndex}_stage_direction`" :style="{ textAlign: scriptTextAlign }">
             <b-row v-if="isTaggedStageDirection && needsHeadingsAny" style="margin-bottom: 1rem">
               <b-col :style="headingStyle">
-                <b>
-                  <template v-if="line.line_parts[0].character_id != null">
-                    {{ characters.find((c) => c.id === line.line_parts[0].character_id).name }}
-                  </template>
-                  <template v-else>
-                    {{
-                      characterGroups.find((c) => c.id === line.line_parts[0].character_group_id)
-                        .name
-                    }}
-                  </template>
-                </b>
+                <b>{{ taggedStageDirectionHeadingName }}</b>
               </b-col>
             </b-row>
             <i class="viewable-line" :style="stageDirectionStyling">
@@ -231,17 +221,7 @@
           <b-col :key="`line_${lineIndex}_stage_direction`" :style="{ textAlign: scriptTextAlign }">
             <b-row v-if="isTaggedStageDirection && needsHeadingsAny" style="margin-bottom: 1rem">
               <b-col :style="headingStyle">
-                <b>
-                  <template v-if="line.line_parts[0].character_id != null">
-                    {{ characters.find((c) => c.id === line.line_parts[0].character_id).name }}
-                  </template>
-                  <template v-else>
-                    {{
-                      characterGroups.find((c) => c.id === line.line_parts[0].character_group_id)
-                        .name
-                    }}
-                  </template>
-                </b>
+                <b>{{ taggedStageDirectionHeadingName }}</b>
               </b-col>
             </b-row>
             <i class="viewable-line" :style="stageDirectionStyling">
@@ -362,6 +342,16 @@ export default defineComponent({
       return (
         line.line_type === LINE_TYPES.STAGE_DIRECTION &&
         (part?.character_id != null || part?.character_group_id != null)
+      );
+    },
+    taggedStageDirectionHeadingName(): string {
+      const part = (this.line as any).line_parts?.[0];
+      if (part?.character_id != null) {
+        return (this.characters as any[]).find((c: any) => c.id === part.character_id)?.name ?? '';
+      }
+      return (
+        (this.characterGroups as any[]).find((c: any) => c.id === part?.character_group_id)?.name ??
+        ''
       );
     },
     isFirstRowIntervalBanner(): boolean {

--- a/client/src/vue_components/show/live/ScriptLineViewerCompact.vue
+++ b/client/src/vue_components/show/live/ScriptLineViewerCompact.vue
@@ -119,7 +119,16 @@
         </b-col>
       </template>
       <template v-else-if="line.line_type === LINE_TYPES.STAGE_DIRECTION">
-        <b-col cols="2" class="cue-column" />
+        <b-col cols="2" class="cue-column line-part text-right">
+          <p v-if="isTaggedStageDirection">
+            <template v-if="line.line_parts[0].character_id != null">
+              {{ characters.find((c) => c.id === line.line_parts[0].character_id).name }}
+            </template>
+            <template v-else>
+              {{ characterGroups.find((c) => c.id === line.line_parts[0].character_group_id).name }}
+            </template>
+          </p>
+        </b-col>
         <b-col
           :key="`line_${lineIndex}_stage_direction`"
           :cols="cueAddMode ? 9 : 10"
@@ -256,6 +265,14 @@ export default defineComponent({
     };
   },
   computed: {
+    isTaggedStageDirection(): boolean {
+      const line = this.line as any;
+      const part = line.line_parts?.[0];
+      return (
+        line.line_type === LINE_TYPES.STAGE_DIRECTION &&
+        (part?.character_id != null || part?.character_group_id != null)
+      );
+    },
     isFirstRowActScene(): boolean {
       return (this as any).needsActSceneLabel;
     },

--- a/client/src/vue_components/show/live/ScriptLineViewerCompact.vue
+++ b/client/src/vue_components/show/live/ScriptLineViewerCompact.vue
@@ -84,14 +84,7 @@
               'first-row': isFirstRowContent && index === 0,
             }"
           >
-            <p v-if="needsHeadings[index]">
-              <template v-if="part.character_id != null">
-                {{ characters.find((char) => char.id === part.character_id).name }}
-              </template>
-              <template v-else>
-                {{ characterGroups.find((char) => char.id === part.character_group_id).name }}
-              </template>
-            </p>
+            <p v-if="needsHeadings[index]">{{ characterOrGroupName(part) }}</p>
           </b-col>
           <b-col
             :key="`text_${lineIndex}_part_${index}`"
@@ -120,14 +113,7 @@
       </template>
       <template v-else-if="line.line_type === LINE_TYPES.STAGE_DIRECTION">
         <b-col cols="2" class="cue-column line-part text-right">
-          <p v-if="isTaggedStageDirection">
-            <template v-if="line.line_parts[0].character_id != null">
-              {{ characters.find((c) => c.id === line.line_parts[0].character_id).name }}
-            </template>
-            <template v-else>
-              {{ characterGroups.find((c) => c.id === line.line_parts[0].character_group_id).name }}
-            </template>
-          </p>
+          <p v-if="isTaggedStageDirection">{{ characterOrGroupName(line.line_parts[0]) }}</p>
         </b-col>
         <b-col
           :key="`line_${lineIndex}_stage_direction`"
@@ -284,6 +270,15 @@ export default defineComponent({
     },
   },
   methods: {
+    characterOrGroupName(part: any): string {
+      if (part.character_id != null) {
+        return (this.characters as any[]).find((c: any) => c.id === part.character_id)?.name ?? '';
+      }
+      return (
+        (this.characterGroups as any[]).find((c: any) => c.id === part.character_group_id)?.name ??
+        ''
+      );
+    },
     addNewCue(): void {
       this.$emit('add-cue', (this.line as any).id);
     },

--- a/client/src/vue_components/show/live/ScriptLineViewerCompact.vue
+++ b/client/src/vue_components/show/live/ScriptLineViewerCompact.vue
@@ -251,14 +251,6 @@ export default defineComponent({
     };
   },
   computed: {
-    isTaggedStageDirection(): boolean {
-      const line = this.line as any;
-      const part = line.line_parts?.[0];
-      return (
-        line.line_type === LINE_TYPES.STAGE_DIRECTION &&
-        (part?.character_id != null || part?.character_group_id != null)
-      );
-    },
     isFirstRowActScene(): boolean {
       return (this as any).needsActSceneLabel;
     },
@@ -270,15 +262,6 @@ export default defineComponent({
     },
   },
   methods: {
-    characterOrGroupName(part: any): string {
-      if (part.character_id != null) {
-        return (this.characters as any[]).find((c: any) => c.id === part.character_id)?.name ?? '';
-      }
-      return (
-        (this.characterGroups as any[]).find((c: any) => c.id === part.character_group_id)?.name ??
-        ''
-      );
-    },
     addNewCue(): void {
       this.$emit('add-cue', (this.line as any).id);
     },

--- a/docs/pages/script_config.md
+++ b/docs/pages/script_config.md
@@ -124,13 +124,24 @@ To create a dialogue line:
 ##### Stage Direction Lines
 
 Non-dialogue text for describing actions, movements, or technical directions. Stage direction lines:
-- Contain a single text field (no character assignment)
+- Contain a single text field
 - Display in italic formatting with customizable styling
 - Can be styled with Stage Direction Styles (system-level or user preferences)
+- Optionally tagged to a character or character group (see below)
 
 ![](../images/config_show/script_stage_direction_editing.png)
 
 To create a stage direction, select **Add Stage Direction** from the dropdown menu.
+
+###### Tagged Stage Directions
+
+A stage direction can optionally be tagged to a **Character** or **Character Group**. This is useful when a stage direction is specific to a character and should appear visually under that character's heading in the script — for example, a move or action described directly after a character speaks.
+
+To tag a stage direction:
+1. In the line editor, use the **Character** or **Character Group** dropdown to select who the stage direction belongs to. Leave both as "N/A" for a generic (untagged) stage direction.
+2. Only one of character or character group can be set — not both.
+
+When a tagged stage direction is displayed in the script, a character heading appears above it (just as one does above dialogue) whenever the character has changed since the previous line. In the compact live view, the character name appears in the left-hand character column.
 
 ##### Cue Lines
 

--- a/server/test/controllers/api/show/script/test_script.py
+++ b/server/test/controllers/api/show/script/test_script.py
@@ -11,7 +11,7 @@ from models.script import (
     ScriptLineType,
     ScriptRevision,
 )
-from models.show import Act, Character, Scene, Show, ShowScriptType
+from models.show import Act, Character, CharacterGroup, Scene, Show, ShowScriptType
 from models.user import User
 from test.conftest import DigiScriptTestCase
 
@@ -1368,6 +1368,11 @@ class TestLineTypeValidation(DigiScriptTestCase):
             session.flush()
             self.character_id = character.id
 
+            character_group = CharacterGroup(show_id=show.id, name="Test Group")
+            session.add(character_group)
+            session.flush()
+            self.character_group_id = character_group.id
+
             admin = User(username="admin", is_admin=True, password="test")
             session.add(admin)
             session.flush()
@@ -1607,8 +1612,8 @@ class TestLineTypeValidation(DigiScriptTestCase):
         response_body = tornado.escape.json_decode(response.body)
         self.assertIn("must have exactly 1 line part", response_body["message"])
 
-    def test_post_stage_direction_rejects_with_character(self):
-        """Test STAGE_DIRECTION with character_id returns 400."""
+    def test_post_stage_direction_allows_with_character(self):
+        """Test STAGE_DIRECTION with character_id is accepted."""
         lines = [
             {
                 "id": None,
@@ -1623,6 +1628,38 @@ class TestLineTypeValidation(DigiScriptTestCase):
                         "part_index": 0,
                         "character_id": self.character_id,
                         "character_group_id": None,
+                        "line_text": "Enter stage left",
+                    }
+                ],
+                "stage_direction_style_id": None,
+            }
+        ]
+
+        response = self.fetch(
+            "/api/v1/show/script?page=1",
+            method="POST",
+            body=tornado.escape.json_encode(lines),
+            headers={"Authorization": f"Bearer {self.token}"},
+        )
+
+        self.assertEqual(200, response.code)
+
+    def test_post_stage_direction_rejects_with_both_character_and_group(self):
+        """Test STAGE_DIRECTION with both character_id and character_group_id returns 400."""
+        lines = [
+            {
+                "id": None,
+                "act_id": self.act_id,
+                "scene_id": self.scene_id,
+                "page": 1,
+                "line_type": 2,
+                "line_parts": [
+                    {
+                        "id": None,
+                        "line_id": None,
+                        "part_index": 0,
+                        "character_id": self.character_id,
+                        "character_group_id": self.character_group_id,
                         "line_text": "Enter",
                     }
                 ],
@@ -1639,7 +1676,9 @@ class TestLineTypeValidation(DigiScriptTestCase):
 
         self.assertEqual(400, response.code)
         response_body = tornado.escape.json_decode(response.body)
-        self.assertIn("cannot have characters", response_body["message"])
+        self.assertIn(
+            "cannot have both character and character group", response_body["message"]
+        )
 
     def test_post_stage_direction_rejects_empty_text(self):
         """Test STAGE_DIRECTION with empty/whitespace text returns 400."""

--- a/server/test/utils/show/test_line_type_validator.py
+++ b/server/test/utils/show/test_line_type_validator.py
@@ -187,25 +187,45 @@ class TestStageDirectionValidator:
         assert result.is_valid is False
         assert "must have exactly 1 line part" in result.error_message
 
-    def test_rejects_with_character(self, validator, mock_show):
-        """Test stage direction with character_id is rejected."""
+    def test_allows_with_character(self, validator, mock_show):
+        """Test stage direction with character_id is allowed."""
         line_json = {
             "line_type": 2,
             "line_parts": [{"character_id": 1, "line_text": "Enter stage left"}],
         }
         result = validator.validate(line_json, mock_show)
-        assert result.is_valid is False
-        assert "cannot have characters" in result.error_message
+        assert result.is_valid is True
 
-    def test_rejects_with_character_group(self, validator, mock_show):
-        """Test stage direction with character_group_id is rejected."""
+    def test_allows_with_character_group(self, validator, mock_show):
+        """Test stage direction with character_group_id is allowed."""
         line_json = {
             "line_type": 2,
             "line_parts": [{"character_group_id": 1, "line_text": "Enter stage left"}],
         }
         result = validator.validate(line_json, mock_show)
+        assert result.is_valid is True
+
+    def test_rejects_with_both_character_and_group(self, validator, mock_show):
+        """Test stage direction with both character_id and character_group_id is rejected."""
+        line_json = {
+            "line_type": 2,
+            "line_parts": [
+                {"character_id": 1, "character_group_id": 2, "line_text": "Enter"}
+            ],
+        }
+        result = validator.validate(line_json, mock_show)
         assert result.is_valid is False
-        assert "cannot have character groups" in result.error_message
+        assert "cannot have both character and character group" in result.error_message
+
+    def test_rejects_tagged_with_empty_text(self, validator, mock_show):
+        """Test stage direction tagged to a character but with no text is rejected."""
+        line_json = {
+            "line_type": 2,
+            "line_parts": [{"character_id": 1, "line_text": None}],
+        }
+        result = validator.validate(line_json, mock_show)
+        assert result.is_valid is False
+        assert "must contain text" in result.error_message
 
     def test_rejects_empty_text(self, validator, mock_show):
         """Test stage direction with None text is rejected."""
@@ -350,13 +370,14 @@ class TestLineTypeValidatorRegistry:
             "line_parts": [
                 {
                     "character_id": 1,
+                    "character_group_id": 2,
                     "line_text": "Enter",
-                }  # Invalid: stage direction can't have character
+                }  # Invalid: stage direction can't have both character and group
             ],
         }
         result = registry.validate_line(line_json, mock_show)
         assert result.is_valid is False
-        assert "cannot have characters" in result.error_message
+        assert "cannot have both character and character group" in result.error_message
 
     def test_cue_line_validation_fails_correctly(self, registry, mock_show):
         """Test registry correctly returns validation failure for invalid cue line."""

--- a/server/utils/show/line_type_validator.py
+++ b/server/utils/show/line_type_validator.py
@@ -94,14 +94,12 @@ class StageDirectionValidator(BaseLineTypeValidator):
 
         line_part = line_parts[0]
 
-        if line_part.get("character_id") is not None:
-            return LineTypeValidationResult(
-                is_valid=False, error_message="Stage directions cannot have characters"
-            )
-        if line_part.get("character_group_id") is not None:
+        has_character = line_part.get("character_id") is not None
+        has_group = line_part.get("character_group_id") is not None
+        if has_character and has_group:
             return LineTypeValidationResult(
                 is_valid=False,
-                error_message="Stage directions cannot have character groups",
+                error_message="Stage directions cannot have both character and character group",
             )
 
         line_text = line_part.get("line_text")


### PR DESCRIPTION
## Summary

- Stage directions can now be optionally tagged to a character or character group
- When the character changes from the previous line, a bold character heading appears above the tagged stage direction (matching dialogue heading behaviour) with a 1rem gap before the stage direction text
- In compact live view, the character name appears in the left-hand character column
- Untagged stage directions are completely unaffected

## Backend changes

- `StageDirectionValidator`: relaxed from rejecting any `character_id`/`character_group_id` to allowing one-or-neither (mutual-exclusion check only, matching `DialogueValidator` pattern)
- No schema/migration changes needed — the columns already exist as nullable FKs on `ScriptLinePart` and are already serialised by `ScriptLinePartSchema`
- Tests updated: renamed two tests that previously asserted rejection (now pass), added `test_rejects_with_both_character_and_group`, `test_rejects_tagged_with_empty_text`, and corresponding API-level test

## Frontend changes

- `ScriptLinePart.vue`: character/group dropdowns now shown for stage directions; SD style selector moved onto the same row as character/group (was a separate sibling column in `ScriptLineEditor`)
- `scriptNavigationMixin.ts`: `needsHeadings` lookback skips only *untagged* stage directions (via `checkIsUntaggedStageDirection` helper), so tagged stage directions correctly trigger a new heading
- Config `ScriptLineViewer.vue`: same untagged-only skip in local `needsHeadings`; heading row rendered with `margin-bottom: 1rem` when `isTaggedStageDirection && needsHeadingsAny`
- Live `ScriptLineViewer.vue`: same heading display in both `cue_position_right` and `cue_position_left` branches
- `ScriptLineViewerCompact.vue`: character/group name shown in left column for tagged stage directions

## Test plan

- [ ] Add an untagged stage direction — confirm no character dropdown visible, behaviour unchanged
- [ ] Add a stage direction tagged to a character — confirm character dropdown appears, heading shown when character changes, 1rem gap between heading and content, background box sized to text only
- [ ] Add a stage direction tagged to a character group — same as above
- [ ] Attempt to set both character and character group on a stage direction — confirm rejected (400)
- [ ] Leave a tagged stage direction with empty text — confirm rejected
- [ ] Verify compact live view shows character name in left column for tagged stage directions
- [ ] `pytest test/utils/show/test_line_type_validator.py test/controllers/api/show/script/test_script.py` — all pass
- [ ] `npm run typecheck && npm run lint && npm run test:run` — all pass

Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)