### PR TITLE
Vue 3 migration: Phase 3 — authentication pages

### DIFF
--- a/client-v3/src/App.vue
+++ b/client-v3/src/App.vue
@@ -170,6 +170,7 @@ import type { BModal } from 'bootstrap-vue-next';
 import { useVuelidate } from '@vuelidate/core';
 import { required, minValue } from '@vuelidate/validators';
 import log from 'loglevel';
+import { toast } from '@/js/toast';
 import { useUserStore } from '@/stores/user';
 import { useSystemStore } from '@/stores/system';
 import { useWebSocketStore } from '@/stores/websocket';
@@ -264,12 +265,11 @@ async function stopShowSession(): Promise<void> {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
     });
-    const { useToast } = await import('vue-toast-notification');
     if (response.ok) {
-      useToast().success('Stopped show session');
+      toast.success('Stopped show session');
     } else {
       log.error('Unable to stop show session');
-      useToast().error('Unable to stop show session');
+      toast.error('Unable to stop show session');
     }
   }
   stoppingSession.value = false;
@@ -277,8 +277,7 @@ async function stopShowSession(): Promise<void> {
 
 async function startShowSession(): Promise<void> {
   if (!wsStore.internalUUID) {
-    const { useToast } = await import('vue-toast-notification');
-    useToast().error('Unable to start new show session');
+    toast.error('Unable to start new show session');
     return;
   }
   startingSession.value = true;
@@ -289,12 +288,11 @@ async function startShowSession(): Promise<void> {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ session_id: wsStore.internalUUID }),
     });
-    const { useToast } = await import('vue-toast-notification');
     if (response.ok) {
-      useToast().success('Started new show session');
+      toast.success('Started new show session');
     } else {
       log.error('Unable to start new show session');
-      useToast().error('Unable to start new show session');
+      toast.error('Unable to start new show session');
     }
   }
   startingSession.value = false;

--- a/client-v3/src/composables/useFormValidation.ts
+++ b/client-v3/src/composables/useFormValidation.ts
@@ -1,0 +1,10 @@
+export function useFormValidation() {
+  function validationState(
+    field: { $dirty: boolean; $error: boolean } | undefined
+  ): boolean | null {
+    if (!field) return null;
+    return field.$dirty ? !field.$error : null;
+  }
+
+  return { validationState };
+}

--- a/client-v3/src/composables/usePasswordValidation.ts
+++ b/client-v3/src/composables/usePasswordValidation.ts
@@ -1,0 +1,12 @@
+import { computed } from 'vue';
+import { required, minLength, sameAs } from '@vuelidate/validators';
+
+export function usePasswordValidation() {
+  const passwordRules = { required, minLength: minLength(6) };
+
+  function confirmPasswordRules(getPasswordValue: () => string) {
+    return computed(() => ({ required, sameAsPassword: sameAs(getPasswordValue()) }));
+  }
+
+  return { passwordRules, confirmPasswordRules };
+}

--- a/client-v3/src/composables/useWebSocket.ts
+++ b/client-v3/src/composables/useWebSocket.ts
@@ -1,5 +1,6 @@
 import log from 'loglevel';
 import { debounce } from 'lodash';
+import { toast } from '@/js/toast';
 import { useWebSocketStore } from '@/stores/websocket';
 import { useSystemStore } from '@/stores/system';
 import { useUserStore } from '@/stores/user';
@@ -25,14 +26,10 @@ function sendObj(data: object): void {
   }
 }
 
-const settingsChangedToast = debounce(
-  async () => {
-    const { useToast } = await import('vue-toast-notification');
-    useToast().info('Settings synced from server');
-  },
-  1000,
-  { leading: true, trailing: false }
-);
+const settingsChangedToast = debounce(() => toast.info('Settings synced from server'), 1000, {
+  leading: true,
+  trailing: false,
+});
 
 async function handleMessage(msg: WsMessage): Promise<void> {
   const wsStore = useWebSocketStore();
@@ -156,11 +153,9 @@ function connect(): void {
   ws.onopen = () => {
     wsStore.$patch({ isConnected: true });
     if (errorCount > 0) {
-      import('vue-toast-notification').then(({ useToast }) => {
-        useToast().success(
-          `WebSocket reconnected after ${errorCount} attempt${errorCount > 1 ? 's' : ''}`
-        );
-      });
+      toast.success(
+        `WebSocket reconnected after ${errorCount} attempt${errorCount > 1 ? 's' : ''}`
+      );
     }
     log.info('WebSocket connected');
   };
@@ -184,9 +179,7 @@ function connect(): void {
     log.error('WebSocket error');
     errorCount++;
     if (errorCount === 1) {
-      import('vue-toast-notification').then(({ useToast }) => {
-        useToast().error('WebSocket connection lost');
-      });
+      toast.error('WebSocket connection lost');
     }
   };
 }

--- a/client-v3/src/js/http-interceptor.ts
+++ b/client-v3/src/js/http-interceptor.ts
@@ -1,5 +1,6 @@
 import log from 'loglevel';
 import { makeURL } from '@/js/utils';
+import { toast } from '@/js/toast';
 
 export default function setupHttpInterceptor(): void {
   const originalFetch = window.fetch;
@@ -10,11 +11,11 @@ export default function setupHttpInterceptor(): void {
     if (typeof resource === 'string' && resource.startsWith(makeURL('/api/'))) {
       // Import store inside the override function — Pinia context isn't active at module load time
       const { useUserStore } = await import('@/stores/user');
-      const { useToast } = await import('vue-toast-notification');
       const userStore = useUserStore();
 
       const token = userStore.authToken;
       const isLogoutRequest = resource.endsWith('/api/v1/auth/logout');
+      const isLoginRequest = resource.endsWith('/api/v1/auth/login');
       const isRefreshRequest = resource.endsWith('/api/v1/auth/refresh-token');
 
       const newOptions = {
@@ -38,12 +39,12 @@ export default function setupHttpInterceptor(): void {
       try {
         const response = await originalFetch(resource, newOptions);
 
-        if (response.status === 401 && !isLogoutRequest) {
+        if (response.status === 401 && !isLogoutRequest && !isLoginRequest) {
           log.warn('Received 401 Unauthorized response');
 
           if (isRefreshRequest || isRefreshingToken) {
             log.warn('Token refresh failed with 401 or already refreshing, logging out');
-            useToast().warning('Your session has expired. Please log in again.');
+            toast.warning('Your session has expired. Please log in again.');
             await userStore.logout();
             return response;
           }
@@ -68,13 +69,13 @@ export default function setupHttpInterceptor(): void {
               }
 
               log.warn('Token refresh failed, logging out');
-              useToast().warning('Your session has expired. Please log in again.');
+              toast.warning('Your session has expired. Please log in again.');
               await userStore.logout();
               return response;
             } catch (refreshError) {
               isRefreshingToken = false;
               log.error('Error during token refresh:', refreshError);
-              useToast().error('Authentication error - please log in again');
+              toast.error('Authentication error - please log in again');
               await userStore.logout();
               return response;
             }

--- a/client-v3/src/js/toast.ts
+++ b/client-v3/src/js/toast.ts
@@ -1,0 +1,3 @@
+import { useToast } from 'vue-toast-notification';
+
+export const toast = useToast({ position: 'top-right' });

--- a/client-v3/src/main.ts
+++ b/client-v3/src/main.ts
@@ -1,13 +1,13 @@
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate';
-
 import App from './App.vue';
 import router from './router';
 import setupHttpInterceptor from './js/http-interceptor';
 import { initRemoteLogging } from './js/logger';
 import './assets/styles/dark.scss';
 import 'bootstrap-vue-next/dist/bootstrap-vue-next.css';
+import 'vue-toast-notification/dist/theme-sugar.css';
 
 const app = createApp(App);
 

--- a/client-v3/src/router/index.ts
+++ b/client-v3/src/router/index.ts
@@ -119,8 +119,8 @@ const router = createRouter({
     {
       path: '/force-password-change',
       name: 'force-password-change',
-      component: PlaceholderView,
-      meta: { requiresAuth: true, requiresPasswordChange: true },
+      component: () => import('@/views/user/ForcePasswordChangeView.vue'),
+      meta: { requiresAuth: true },
     },
     {
       path: '/help',
@@ -152,11 +152,10 @@ const router = createRouter({
 router.beforeEach(async (to) => {
   const { useSystemStore } = await import('@/stores/system');
   const { useUserStore } = await import('@/stores/user');
-  const { useToast } = await import('vue-toast-notification');
+  const { toast } = await import('@/js/toast');
 
   const systemStore = useSystemStore();
   const userStore = useUserStore();
-  const toast = useToast();
 
   // Electron: require active connection before any page except server-selector
   if (isElectron() && to.path !== '/electron/server-selector') {

--- a/client-v3/src/stores/user.ts
+++ b/client-v3/src/stores/user.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import log from 'loglevel';
 import { isEmpty } from 'lodash';
 import { makeURL } from '@/js/utils';
+import { toast } from '@/js/toast';
 import type { User, UserSettings, CueColourOverride } from '@/types/api/user';
 import type { StageDirectionStyle } from '@/types/api/script';
 
@@ -10,15 +11,10 @@ const TOKEN_KEY = 'digiscript_auth_token';
 function getToken(): string | null {
   return localStorage.getItem(TOKEN_KEY);
 }
-function setToken(t: string): void {
-  localStorage.setItem(TOKEN_KEY, t);
-}
-function clearToken(): void {
-  localStorage.removeItem(TOKEN_KEY);
-}
 
 export const useUserStore = defineStore('user', {
   state: () => ({
+    authToken: getToken() as string | null,
     currentUser: null as User | null,
     currentRbac: null as Record<string, [number, number][]> | null,
     users: [] as User[],
@@ -28,10 +24,17 @@ export const useUserStore = defineStore('user', {
     cueColourOverrides: [] as CueColourOverride[],
   }),
   getters: {
-    authToken: (): string | null => getToken(),
-    isAuthenticated: (): boolean => getToken() !== null,
+    isAuthenticated: (state): boolean => state.authToken !== null,
   },
   actions: {
+    _setToken(t: string): void {
+      localStorage.setItem(TOKEN_KEY, t);
+      this.authToken = t;
+    },
+    _clearToken(): void {
+      localStorage.removeItem(TOKEN_KEY);
+      this.authToken = null;
+    },
     async login(username: string, password: string): Promise<boolean> {
       const { useWebSocketStore } = await import('@/stores/websocket');
       const wsStore = useWebSocketStore();
@@ -48,7 +51,7 @@ export const useUserStore = defineStore('user', {
 
       if (response.ok) {
         const data = await response.json();
-        if (data.access_token) setToken(data.access_token);
+        if (data.access_token) this._setToken(data.access_token);
 
         const { useSystemStore } = await import('@/stores/system');
         await useSystemStore().getRbacRoles();
@@ -60,15 +63,13 @@ export const useUserStore = defineStore('user', {
         // Trigger WS authentication if the connection is waiting
         wsStore.triggerAuthentication();
 
-        const { useToast } = await import('vue-toast-notification');
-        useToast().success('Successfully logged in!');
+        toast.success('Successfully logged in!');
         return true;
       }
 
       const responseBody = await response.json();
       log.error('Unable to log in');
-      const { useToast } = await import('vue-toast-notification');
-      useToast().error(`Unable to log in! ${responseBody.message}.`);
+      toast.error(`Unable to log in! ${responseBody.message}.`);
       return false;
     },
 
@@ -78,8 +79,8 @@ export const useUserStore = defineStore('user', {
         this.tokenRefreshInterval = null;
       }
 
-      const token = getToken();
-      clearToken();
+      const token = this.authToken;
+      this._clearToken();
       this.currentUser = null;
       this.currentRbac = null;
       this.userSettings = {};
@@ -95,7 +96,7 @@ export const useUserStore = defineStore('user', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
-              Authorization: `Bearer ${token}`,
+              Authorization: `Bearer ${token}`, // use captured value since store is already cleared
             },
             body: JSON.stringify({ session_id: getWsStore().internalUUID }),
           });
@@ -107,8 +108,7 @@ export const useUserStore = defineStore('user', {
         }
       }
 
-      const { useToast } = await import('vue-toast-notification');
-      useToast().success('Successfully logged out!');
+      toast.success('Successfully logged out!');
 
       const { default: router } = await import('@/router');
       if (router.currentRoute.value.path !== '/') {
@@ -117,7 +117,7 @@ export const useUserStore = defineStore('user', {
     },
 
     async refreshToken(): Promise<boolean> {
-      if (!getToken()) return false;
+      if (!this.authToken) return false;
       const response = await fetch(makeURL('/api/v1/auth/refresh-token'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -125,7 +125,7 @@ export const useUserStore = defineStore('user', {
       });
       if (response.ok) {
         const data = await response.json();
-        setToken(data.access_token);
+        this._setToken(data.access_token);
         const { useWebSocketStore } = await import('@/stores/websocket');
         useWebSocketStore().refreshWsToken();
         log.debug('Token refreshed successfully');
@@ -138,7 +138,7 @@ export const useUserStore = defineStore('user', {
     async tokenRefreshFromServer(newToken: string): Promise<void> {
       log.info('Received token refresh from server');
       if (newToken) {
-        setToken(newToken);
+        this._setToken(newToken);
         const { useWebSocketStore } = await import('@/stores/websocket');
         useWebSocketStore().refreshWsToken();
         log.info('Auth token updated from server');
@@ -173,8 +173,7 @@ export const useUserStore = defineStore('user', {
         this.users = data.users;
       } else {
         log.error('Unable to get users');
-        const { useToast } = await import('vue-toast-notification');
-        useToast().error('Unable to fetch users!');
+        toast.error('Unable to fetch users!');
       }
     },
 
@@ -184,14 +183,13 @@ export const useUserStore = defineStore('user', {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(user),
       });
-      const { useToast } = await import('vue-toast-notification');
       if (response.ok) {
         await this.getUsers();
-        useToast().success('User created!');
+        toast.success('User created!');
       } else {
         const body = await response.json();
         log.error('Unable to create user');
-        useToast().error(`Unable to create user: ${body.message || 'Unknown error'}`);
+        toast.error(`Unable to create user: ${body.message || 'Unknown error'}`);
       }
     },
 
@@ -201,15 +199,32 @@ export const useUserStore = defineStore('user', {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id: userId }),
       });
-      const { useToast } = await import('vue-toast-notification');
       if (response.ok) {
         await this.getUsers();
-        useToast().success('User deleted!');
+        toast.success('User deleted!');
       } else {
         const body = await response.json();
         log.error('Unable to delete user');
-        useToast().error(`Unable to delete user: ${body.message || 'Unknown error'}`);
+        toast.error(`Unable to delete user: ${body.message || 'Unknown error'}`);
       }
+    },
+
+    async changePassword(newPassword: string): Promise<boolean> {
+      const response = await fetch(makeURL('/api/v1/auth/change-password'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ new_password: newPassword }),
+      });
+      if (response.ok) {
+        const data = await response.json();
+        if (data.access_token) this._setToken(data.access_token);
+        await this.getCurrentUser();
+        toast.success('Password changed successfully!');
+        return true;
+      }
+      const error = await response.json();
+      toast.error(error.message || 'Failed to change password');
+      return false;
     },
 
     async getUserSettings(): Promise<void> {
@@ -225,7 +240,7 @@ export const useUserStore = defineStore('user', {
       if (this.tokenRefreshInterval) clearInterval(this.tokenRefreshInterval);
       const refreshInterval = setInterval(
         async () => {
-          if (getToken()) {
+          if (this.authToken) {
             await this.refreshToken();
           } else {
             clearInterval(refreshInterval);
@@ -243,13 +258,12 @@ export const useUserStore = defineStore('user', {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({}),
       });
-      const { useToast } = await import('vue-toast-notification');
       if (response.ok) {
-        useToast().success('API token generated successfully!');
+        toast.success('API token generated successfully!');
         return response.json();
       }
       const body = await response.json();
-      useToast().error(`Unable to generate API token: ${body.message || 'Unknown error'}`);
+      toast.error(`Unable to generate API token: ${body.message || 'Unknown error'}`);
       return null;
     },
 
@@ -259,21 +273,19 @@ export const useUserStore = defineStore('user', {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({}),
       });
-      const { useToast } = await import('vue-toast-notification');
       if (response.ok) {
-        useToast().success('API token revoked successfully!');
+        toast.success('API token revoked successfully!');
         return true;
       }
       const body = await response.json();
-      useToast().error(`Unable to revoke API token: ${body.message || 'Unknown error'}`);
+      toast.error(`Unable to revoke API token: ${body.message || 'Unknown error'}`);
       return false;
     },
 
     async getApiToken(): Promise<Record<string, unknown> | null> {
       const response = await fetch(makeURL('/api/v1/auth/api-token'));
       if (response.ok) return response.json();
-      const { useToast } = await import('vue-toast-notification');
-      useToast().error('Unable to get API token!');
+      toast.error('Unable to get API token!');
       return null;
     },
   },

--- a/client-v3/src/stores/websocket.ts
+++ b/client-v3/src/stores/websocket.ts
@@ -16,7 +16,7 @@ export const useWebSocketStore = defineStore('websocket', {
     pick: ['internalUUID'],
   },
   getters: {
-    websocketHealthy: (state) => state.isConnected && state.authenticated,
+    websocketHealthy: (state) => state.isConnected,
   },
   actions: {
     // Called by the useWebSocket composable to register the send function

--- a/client-v3/src/views/user/ForcePasswordChangeView.vue
+++ b/client-v3/src/views/user/ForcePasswordChangeView.vue
@@ -1,0 +1,118 @@
+<template>
+  <div class="force-password-change-container">
+    <BContainer fluid class="h-100 d-flex align-items-center justify-content-center">
+      <BRow class="w-100 justify-content-center">
+        <BCol cols="12" md="6" lg="4">
+          <BCard class="shadow-lg">
+            <template #header>
+              <h4 class="mb-0 text-center">Password Change Required</h4>
+            </template>
+
+            <BAlert :model-value="true" variant="warning" class="mb-4">
+              Your password must be changed before you can continue.
+            </BAlert>
+
+            <BForm @submit.prevent="handlePasswordChange">
+              <BFormGroup
+                id="new-password-input-group"
+                label="New Password"
+                label-for="new-password-input"
+                description="Minimum 6 characters"
+              >
+                <BFormInput
+                  id="new-password-input"
+                  v-model="v$.newPassword.$model"
+                  name="new-password-input"
+                  type="password"
+                  :state="validationState(v$.newPassword)"
+                  aria-describedby="new-password-feedback"
+                  autocomplete="new-password"
+                />
+                <BFormInvalidFeedback id="new-password-feedback">
+                  This is a required field and must be at least 6 characters.
+                </BFormInvalidFeedback>
+              </BFormGroup>
+
+              <BFormGroup
+                id="confirm-password-input-group"
+                label="Confirm New Password"
+                label-for="confirm-password-input"
+              >
+                <BFormInput
+                  id="confirm-password-input"
+                  v-model="v$.confirmPassword.$model"
+                  name="confirm-password-input"
+                  type="password"
+                  :state="validationState(v$.confirmPassword)"
+                  aria-describedby="confirm-password-feedback"
+                  autocomplete="new-password"
+                />
+                <BFormInvalidFeedback id="confirm-password-feedback">
+                  Passwords do not match.
+                </BFormInvalidFeedback>
+              </BFormGroup>
+
+              <div class="d-flex justify-content-between align-items-center mt-4">
+                <BButton variant="outline-secondary" :disabled="loading" @click="handleLogout">
+                  Logout
+                </BButton>
+
+                <BButton type="submit" variant="primary" :disabled="v$.$invalid || loading">
+                  <BSpinner v-if="loading" small class="me-1" />
+                  Change Password
+                </BButton>
+              </div>
+            </BForm>
+          </BCard>
+        </BCol>
+      </BRow>
+    </BContainer>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { useRouter } from 'vue-router';
+import { useVuelidate } from '@vuelidate/core';
+import { required, minLength, sameAs } from '@vuelidate/validators';
+import { useUserStore } from '@/stores/user';
+import { useFormValidation } from '@/composables/useFormValidation';
+
+const router = useRouter();
+const userStore = useUserStore();
+const { validationState } = useFormValidation();
+
+const state = ref({ newPassword: '', confirmPassword: '' });
+const loading = ref(false);
+
+const rules = computed(() => ({
+  newPassword: { required, minLength: minLength(6) },
+  confirmPassword: { required, sameAsPassword: sameAs(state.value.newPassword) },
+}));
+
+const v$ = useVuelidate(rules, state);
+
+async function handlePasswordChange(): Promise<void> {
+  v$.value.$touch();
+  if (v$.value.$invalid) return;
+  loading.value = true;
+  try {
+    const success = await userStore.changePassword(state.value.newPassword);
+    if (success) {
+      router.push('/');
+    }
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function handleLogout(): Promise<void> {
+  await userStore.logout();
+}
+</script>
+
+<style scoped>
+.force-password-change-container {
+  margin-top: 2rem;
+}
+</style>

--- a/client-v3/src/views/user/LoginView.vue
+++ b/client-v3/src/views/user/LoginView.vue
@@ -1,6 +1,81 @@
 <template>
-  <div class="container mt-5">
-    <h2>Login</h2>
-    <p>Full login UI coming in Phase 3.</p>
-  </div>
+  <BContainer class="mx-0" fluid>
+    <BRow style="margin-top: 1rem">
+      <BCol cols="4" offset="4">
+        <h3>Login to DigiScript</h3>
+      </BCol>
+    </BRow>
+    <BRow style="margin-top: 1rem">
+      <BCol cols="4" offset="4">
+        <BForm @submit.prevent="doLogin">
+          <BFormGroup id="username-input-group" label="Username" label-for="username-input">
+            <BFormInput
+              id="username-input"
+              v-model="v$.username.$model"
+              name="username-input"
+              :state="validationState(v$.username)"
+              aria-describedby="username-feedback"
+              @keydown.enter="doLogin"
+            />
+            <BFormInvalidFeedback id="username-feedback">
+              This is a required field.
+            </BFormInvalidFeedback>
+          </BFormGroup>
+          <BFormGroup id="password-input-group" label="Password" label-for="password-input">
+            <BFormInput
+              id="password-input"
+              v-model="v$.password.$model"
+              name="password-input"
+              :state="validationState(v$.password)"
+              aria-describedby="password-feedback"
+              type="password"
+              @keydown.enter="doLogin"
+            />
+            <BFormInvalidFeedback id="password-feedback">
+              This is a required field.
+            </BFormInvalidFeedback>
+          </BFormGroup>
+          <BButton :disabled="v$.$invalid" @click="doLogin"> Login </BButton>
+        </BForm>
+      </BCol>
+    </BRow>
+    <BRow v-if="showLoginFeedback">
+      <BCol>
+        <b style="color: darkred"> Login unsuccessful. </b>
+      </BCol>
+    </BRow>
+  </BContainer>
 </template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useRouter } from 'vue-router';
+import { useVuelidate } from '@vuelidate/core';
+import { required } from '@vuelidate/validators';
+import { useUserStore } from '@/stores/user';
+import { useFormValidation } from '@/composables/useFormValidation';
+
+const router = useRouter();
+const userStore = useUserStore();
+const { validationState } = useFormValidation();
+
+const state = ref({ username: '', password: '' });
+const rules = { username: { required }, password: { required } };
+const v$ = useVuelidate(rules, state);
+
+const showLoginFeedback = ref(false);
+
+async function doLogin(): Promise<void> {
+  v$.value.$touch();
+  if (v$.value.$invalid) return;
+  showLoginFeedback.value = false;
+  const success = await userStore.login(state.value.username, state.value.password);
+  if (success) {
+    router.replace('/');
+  } else {
+    showLoginFeedback.value = true;
+  }
+}
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
## Summary

- Ports `LoginView.vue` (replaces Phase 1 stub) and `ForcePasswordChangeView.vue` (new) to Bootstrap-Vue-Next + `@vuelidate/core` v2
- Adds `useFormValidation` and `usePasswordValidation` composables
- Adds `changePassword()` action to the user store
- Wires `/force-password-change` route to the real component

## Bug fixes found during verification

- **`authToken` reactivity** (`stores/user.ts`): The getter read from `localStorage` directly, so Vue cached `null` on first access and never re-evaluated it. The HTTP interceptor then sent requests without an Authorization header, causing a 401 cascade that immediately logged the user out after a fresh login. Fixed by moving `authToken` to reactive Pinia state with `_setToken`/`_clearToken` actions keeping localStorage in sync.
- **Login endpoint 401 handling** (`http-interceptor.ts`): Wrong credentials returning 401 was triggering the logout cascade. Fixed by excluding the login URL from 401 handling.
- **`websocketHealthy` getter** (`stores/websocket.ts`): Was requiring `authenticated: true`, which meant unauthenticated users saw an infinite loading spinner. Corrected to match Vue 2's `WEBSOCKET_HEALTHY` (connection only).
- **`<BForm>` native submit** (`LoginView.vue`): Missing `@submit.prevent` caused the browser to submit the form natively on Enter, triggering a full page reload instead of the Vue handler.
- **Toast styling and position** (`main.ts`, `js/toast.ts`): `vue-toast-notification` CSS was not imported and `useToast()` was called without `position: 'top-right'` throughout. Added CSS import and a shared `toast.ts` singleton configured with the correct position, replacing all scattered `useToast()` calls.

## Test plan

- [ ] Login form: empty fields show validation feedback, button disabled
- [ ] Login form: wrong credentials shows "Login unsuccessful" (inline) + error toast top-right
- [ ] Login form: correct credentials redirects to `/ui-new/`, admin shown in navbar
- [ ] Sign Out returns to unauthenticated state, "Successfully logged out" toast top-right
- [ ] `/force-password-change` renders with new/confirm password fields + validation
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run ci-lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)