### PR TITLE
Vue 3 migration: Phase 5 — system configuration page (/config)

### DIFF
--- a/client-v3/src/App.vue
+++ b/client-v3/src/App.vue
@@ -133,6 +133,8 @@
     </template>
     <RouterView v-else />
 
+    <ConfirmDialog />
+
     <BModal
       ref="goToPageModal"
       title="Go to Page"
@@ -171,6 +173,8 @@ import { useVuelidate } from '@vuelidate/core';
 import { required, minValue } from '@vuelidate/validators';
 import log from 'loglevel';
 import { toast } from '@/js/toast';
+import { useConfirm } from '@/composables/useConfirm';
+import ConfirmDialog from '@/components/common/ConfirmDialog.vue';
 import { useUserStore } from '@/stores/user';
 import { useSystemStore } from '@/stores/system';
 import { useWebSocketStore } from '@/stores/websocket';
@@ -187,6 +191,7 @@ const { websocketHealthy } = storeToRefs(wsStore);
 const { currentShow, settings } = storeToRefs(systemStore);
 
 const { sendObj, connect } = useWebSocket();
+const { confirm } = useConfirm();
 
 const isElectronEnv = ref(false);
 
@@ -259,7 +264,11 @@ async function awaitWSConnect(): Promise<void> {
 
 async function stopShowSession(): Promise<void> {
   stoppingSession.value = true;
-  const confirmed = window.confirm('Are you sure you want to stop the show?');
+  const confirmed = await confirm('Are you sure you want to stop the show?', {
+    title: 'Stop Show',
+    okVariant: 'danger',
+    okTitle: 'Stop Show',
+  });
   if (confirmed) {
     const response = await fetch(makeURL('/api/v1/show/sessions/stop'), {
       method: 'POST',
@@ -281,7 +290,11 @@ async function startShowSession(): Promise<void> {
     return;
   }
   startingSession.value = true;
-  const confirmed = window.confirm('Are you sure you want to start a show?');
+  const confirmed = await confirm('Are you sure you want to start a show?', {
+    title: 'Start Show',
+    okVariant: 'success',
+    okTitle: 'Start Show',
+  });
   if (confirmed) {
     const response = await fetch(makeURL('/api/v1/show/sessions/start'), {
       method: 'POST',
@@ -299,7 +312,11 @@ async function startShowSession(): Promise<void> {
 }
 
 async function reloadClients(): Promise<void> {
-  const confirmed = window.confirm('Are you sure you want to reload all connected clients?');
+  const confirmed = await confirm('Are you sure you want to reload all connected clients?', {
+    title: 'Reload Clients',
+    okVariant: 'warning',
+    okTitle: 'Reload All',
+  });
   if (confirmed) {
     sendObj({ OP: 'RELOAD_CLIENTS', DATA: {} });
   }

--- a/client-v3/src/components/common/ConfirmDialog.vue
+++ b/client-v3/src/components/common/ConfirmDialog.vue
@@ -1,0 +1,20 @@
+<template>
+  <BModal
+    v-model="visible"
+    :title="currentOptions.title ?? 'Confirm'"
+    :ok-variant="currentOptions.okVariant ?? 'primary'"
+    :ok-title="currentOptions.okTitle ?? 'OK'"
+    :cancel-title="currentOptions.cancelTitle ?? 'Cancel'"
+    :size="currentOptions.size"
+    @ok="_handleOk"
+    @hidden="_handleHidden"
+  >
+    {{ message }}
+  </BModal>
+</template>
+
+<script setup lang="ts">
+import { useConfirm } from '@/composables/useConfirm';
+
+const { visible, message, currentOptions, _handleOk, _handleHidden } = useConfirm();
+</script>

--- a/client-v3/src/components/config/ConfigBackups.vue
+++ b/client-v3/src/components/config/ConfigBackups.vue
@@ -38,7 +38,10 @@ import { ref, onMounted } from 'vue';
 import log from 'loglevel';
 import { makeURL } from '@/js/utils';
 import { toast } from '@/js/toast';
+import { useConfirm } from '@/composables/useConfirm';
 import type { BackupFile, BackupsResponse } from '@/types/api/backup';
+
+const { confirm } = useConfirm();
 
 const loading = ref(true);
 const isDeleting = ref(false);
@@ -70,12 +73,11 @@ async function fetchBackups(): Promise<void> {
 }
 
 async function deleteBackup(backup: BackupFile): Promise<void> {
-  if (
-    !window.confirm(
-      `Are you sure you want to permanently delete "${backup.filename}"? This cannot be undone.`
-    )
-  )
-    return;
+  const confirmed = await confirm(
+    `Are you sure you want to permanently delete "${backup.filename}"? This cannot be undone.`,
+    { title: 'Delete Backup', okVariant: 'danger', okTitle: 'Delete' }
+  );
+  if (!confirmed) return;
 
   isDeleting.value = true;
   try {

--- a/client-v3/src/components/config/ConfigBackups.vue
+++ b/client-v3/src/components/config/ConfigBackups.vue
@@ -1,0 +1,118 @@
+<template>
+  <div v-if="!loading">
+    <div v-if="backups.length > 0">
+      <p class="text-muted mb-3">
+        {{ count }} {{ count === 1 ? 'backup' : 'backups' }} &middot;
+        {{ formatBytes(totalSizeBytes) }} total
+      </p>
+      <BTable :items="backups" :fields="fields" sort-by="created_at" :sort-desc="true">
+        <template #cell(size_bytes)="data">
+          {{ formatBytes(data.item.size_bytes) }}
+        </template>
+        <template #cell(created_at)="data">
+          {{ formatDate(data.item.created_at) }}
+        </template>
+        <template #cell(actions)="data">
+          <BButton
+            variant="danger"
+            size="sm"
+            :disabled="isDeleting"
+            @click="deleteBackup(data.item)"
+          >
+            Delete
+          </BButton>
+        </template>
+      </BTable>
+    </div>
+    <BAlert v-else variant="info" :model-value="true">
+      No backup files found. Backups are created automatically before database migrations.
+    </BAlert>
+  </div>
+  <div v-else class="text-center">
+    <BSpinner style="width: 10rem; height: 10rem" variant="info" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import log from 'loglevel';
+import { makeURL } from '@/js/utils';
+import { toast } from '@/js/toast';
+import type { BackupFile, BackupsResponse } from '@/types/api/backup';
+
+const loading = ref(true);
+const isDeleting = ref(false);
+const backups = ref<BackupFile[]>([]);
+const count = ref(0);
+const totalSizeBytes = ref(0);
+
+const fields = [
+  { key: 'filename', label: 'Filename' },
+  { key: 'size_bytes', label: 'Size', sortable: true },
+  { key: 'created_at', label: 'Date Created', sortable: true },
+  { key: 'actions', label: '' },
+];
+
+async function fetchBackups(): Promise<void> {
+  try {
+    const response = await fetch(makeURL('/api/v1/admin/db-backups'));
+    if (response.ok) {
+      const data: BackupsResponse = await response.json();
+      backups.value = data.backups;
+      count.value = data.count;
+      totalSizeBytes.value = data.total_size_bytes;
+    } else {
+      log.error('Unable to fetch backup files');
+    }
+  } catch (err) {
+    log.error('Error fetching backup files:', err);
+  }
+}
+
+async function deleteBackup(backup: BackupFile): Promise<void> {
+  if (
+    !window.confirm(
+      `Are you sure you want to permanently delete "${backup.filename}"? This cannot be undone.`
+    )
+  )
+    return;
+
+  isDeleting.value = true;
+  try {
+    const response = await fetch(
+      makeURL(`/api/v1/admin/db-backups?timestamp=${backup.created_at}`),
+      { method: 'DELETE' }
+    );
+    if (response.ok) {
+      toast.success('Backup deleted');
+      await fetchBackups();
+    } else {
+      const body = await response.json();
+      toast.error(`Failed to delete backup: ${body.message}`);
+    }
+  } catch (err) {
+    log.error('Error deleting backup:', err);
+    toast.error('Failed to delete backup');
+  } finally {
+    isDeleting.value = false;
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  return `${(bytes / 1024 ** i).toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+function formatDate(unixTimestamp: number): string {
+  const d = new Date(unixTimestamp * 1000);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(d.getDate())}/${pad(d.getMonth() + 1)}/${d.getFullYear()} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+onMounted(async () => {
+  await fetchBackups();
+  loading.value = false;
+});
+</script>

--- a/client-v3/src/components/config/ConfigLogs.vue
+++ b/client-v3/src/components/config/ConfigLogs.vue
@@ -1,0 +1,353 @@
+<template>
+  <div>
+    <!-- Controls bar -->
+    <div class="mb-3 d-flex flex-wrap gap-3 align-items-center">
+      <BFormGroup label="Source:" label-cols="auto" class="mb-0">
+        <BFormRadioGroup
+          v-model="source"
+          :options="sourceOptions"
+          buttons
+          button-variant="outline-secondary"
+          size="sm"
+        />
+      </BFormGroup>
+
+      <BFormGroup label="Level:" label-cols="auto" class="mb-0">
+        <BFormSelect v-model="levelFilter" :options="levelOptions" size="sm" style="width: 120px" />
+      </BFormGroup>
+
+      <BFormGroup label="Search:" label-cols="auto" class="mb-0">
+        <BFormInput
+          v-model="searchInput"
+          placeholder="Filter messages…"
+          size="sm"
+          style="width: 200px"
+          type="text"
+        />
+      </BFormGroup>
+
+      <BFormGroup v-if="source === 'client'" label="User:" label-cols="auto" class="mb-0">
+        <BFormInput
+          v-model="usernameInput"
+          placeholder="Filter by username…"
+          size="sm"
+          style="width: 160px"
+          type="text"
+        />
+      </BFormGroup>
+
+      <BFormGroup label="Max lines:" label-cols="auto" class="mb-0">
+        <BFormInput
+          v-model.number="limit"
+          min="10"
+          max="1000"
+          size="sm"
+          style="width: 80px"
+          type="number"
+        />
+      </BFormGroup>
+
+      <BFormGroup label="Live:" label-cols="auto" class="mb-0">
+        <BFormCheckbox v-model="liveRefresh" switch />
+      </BFormGroup>
+
+      <BButton :disabled="loading || liveRefresh" size="sm" variant="secondary" @click="fetchLogs">
+        <BSpinner v-if="loading" small />
+        <span v-else>Refresh</span>
+      </BButton>
+    </div>
+
+    <!-- Status line -->
+    <div class="mb-1 text-muted" style="font-size: 0.8rem">
+      <span v-if="error" class="text-danger">{{ error }}</span>
+      <span v-else-if="liveRefresh" class="text-success">&#9679; Live</span>
+      <span v-else>Showing {{ entries.length }} of {{ totalEntries }} entries</span>
+    </div>
+
+    <!-- Console -->
+    <div
+      ref="consoleRef"
+      class="log-console"
+      style="
+        background: #1e1e1e;
+        color: #d4d4d4;
+        font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+        font-size: 0.78rem;
+        line-height: 1.45;
+        padding: 8px 12px;
+        height: 520px;
+        overflow-y: auto;
+        border-radius: 4px;
+        white-space: pre-wrap;
+        word-break: break-all;
+        text-align: left;
+      "
+      @scroll="onScroll"
+    >
+      <div v-if="entries.length === 0" class="text-muted" style="padding-top: 4px">
+        No log entries to display.
+      </div>
+      <div v-for="(entry, idx) in entries" :key="idx">
+        <span :class="levelClass(entry.level)">{{ formatEntry(entry) }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, onMounted, onBeforeUnmount, nextTick } from 'vue';
+import { makeURL } from '@/js/utils';
+
+interface LogEntry {
+  ts: string;
+  level: string;
+  filename: string;
+  lineno: number;
+  message: string;
+}
+
+const consoleRef = ref<HTMLElement | null>(null);
+
+const entries = ref<LogEntry[]>([]);
+const totalEntries = ref(0);
+const source = ref('server');
+const levelFilter = ref('');
+const searchInput = ref('');
+const usernameInput = ref('');
+const limit = ref(500);
+const liveRefresh = ref(false);
+const loading = ref(false);
+const error = ref<string | null>(null);
+const autoScroll = ref(true);
+
+let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+let usernameDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+let streamReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+let streamAborted = false;
+
+const sourceOptions = [
+  { text: 'Server', value: 'server' },
+  { text: 'Client', value: 'client' },
+];
+
+const levelOptions = [
+  { text: 'All Levels', value: '' },
+  { text: 'TRACE+', value: 'TRACE' },
+  { text: 'DEBUG+', value: 'DEBUG' },
+  { text: 'INFO+', value: 'INFO' },
+  { text: 'WARN+', value: 'WARN' },
+  { text: 'ERROR+', value: 'ERROR' },
+];
+
+watch(source, () => {
+  usernameInput.value = '';
+  if (liveRefresh.value) restartStream();
+  else fetchLogs();
+});
+
+watch(levelFilter, () => {
+  if (liveRefresh.value) restartStream();
+  else fetchLogs();
+});
+
+watch(searchInput, () => {
+  clearTimeout(searchDebounceTimer ?? undefined);
+  searchDebounceTimer = setTimeout(() => {
+    if (liveRefresh.value) restartStream();
+    else fetchLogs();
+  }, 400);
+});
+
+watch(usernameInput, () => {
+  clearTimeout(usernameDebounceTimer ?? undefined);
+  usernameDebounceTimer = setTimeout(() => {
+    if (liveRefresh.value) restartStream();
+    else fetchLogs();
+  }, 400);
+});
+
+watch(liveRefresh, (val) => {
+  if (val) startStream();
+  else stopStream();
+});
+
+async function fetchLogs(): Promise<void> {
+  loading.value = true;
+  error.value = null;
+  try {
+    const params = new URLSearchParams({
+      source: source.value,
+      level: levelFilter.value,
+      search: searchInput.value,
+      limit: String(limit.value),
+      offset: '0',
+    });
+    if (source.value === 'client' && usernameInput.value)
+      params.set('username', usernameInput.value);
+
+    const response = await fetch(`${makeURL('/api/v1/logs/view')}?${params}`);
+    if (!response.ok) {
+      error.value = `Server returned ${response.status}`;
+      return;
+    }
+
+    const data = await response.json();
+    const wasAtBottom = autoScroll.value;
+    entries.value = data.entries;
+    totalEntries.value = data.total;
+    if (wasAtBottom) nextTick(scrollToBottom);
+  } catch (err: any) {
+    error.value = err.message || 'Failed to fetch logs';
+  } finally {
+    loading.value = false;
+  }
+}
+
+function buildStreamUrl(): string {
+  const params = new URLSearchParams({
+    source: source.value,
+    level: levelFilter.value,
+    search: searchInput.value,
+  });
+  if (source.value === 'client' && usernameInput.value) params.set('username', usernameInput.value);
+  return `${makeURL('/api/v1/logs/stream')}?${params}`;
+}
+
+async function startStream(): Promise<void> {
+  stopStream();
+  streamAborted = false;
+  error.value = null;
+
+  let response: Response;
+  try {
+    response = await fetch(buildStreamUrl());
+  } catch (err: any) {
+    error.value = err.message || 'Failed to connect to log stream';
+    return;
+  }
+
+  if (!response.ok) {
+    error.value = `Log stream returned ${response.status}`;
+    return;
+  }
+
+  entries.value = [];
+  totalEntries.value = 0;
+
+  const reader = response.body!.getReader();
+  streamReader = reader;
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const events = buffer.split('\n\n');
+      buffer = events.pop()!;
+
+      for (const event of events) {
+        if (event.startsWith('data: ')) {
+          try {
+            const entry = JSON.parse(event.slice(6));
+            const wasAtBottom = autoScroll.value;
+            entries.value.push(entry);
+            totalEntries.value++;
+            if (entries.value.length > limit.value) entries.value.shift();
+            if (wasAtBottom) nextTick(scrollToBottom);
+          } catch {
+            // ignore malformed SSE JSON
+          }
+        }
+      }
+    }
+  } catch {
+    if (!streamAborted) {
+      error.value = 'Log stream disconnected';
+      liveRefresh.value = false;
+    }
+  } finally {
+    streamReader = null;
+  }
+}
+
+function stopStream(): void {
+  if (streamReader) {
+    streamAborted = true;
+    streamReader.cancel();
+    streamReader = null;
+  }
+}
+
+function restartStream(): void {
+  stopStream();
+  startStream();
+}
+
+function formatEntry(entry: LogEntry): string {
+  const dt = new Date(entry.ts);
+  const yy = String(dt.getUTCFullYear()).slice(2);
+  const mo = String(dt.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(dt.getUTCDate()).padStart(2, '0');
+  const hh = String(dt.getUTCHours()).padStart(2, '0');
+  const mm = String(dt.getUTCMinutes()).padStart(2, '0');
+  const ss = String(dt.getUTCSeconds()).padStart(2, '0');
+  const ms = String(dt.getUTCMilliseconds()).padStart(3, '0');
+  const letter = levelLetter(entry.level);
+  return `[${letter} ${yy}-${mo}-${dd} ${hh}:${mm}:${ss}.${ms} ${entry.filename}:${entry.lineno}] ${entry.message}`;
+}
+
+function levelClass(level: string): string {
+  switch (level) {
+    case 'TRACE':
+      return 'text-secondary';
+    case 'DEBUG':
+      return 'text-info';
+    case 'INFO':
+      return 'text-success';
+    case 'WARNING':
+    case 'WARN':
+      return 'text-warning';
+    case 'ERROR':
+      return 'text-danger';
+    case 'CRITICAL':
+      return 'text-danger fw-bold';
+    default:
+      return 'text-light';
+  }
+}
+
+function levelLetter(level: string): string {
+  const map: Record<string, string> = {
+    TRACE: 'T',
+    DEBUG: 'D',
+    INFO: 'I',
+    WARNING: 'W',
+    WARN: 'W',
+    ERROR: 'E',
+    CRITICAL: 'C',
+  };
+  return map[level] || level[0];
+}
+
+function onScroll(): void {
+  const el = consoleRef.value;
+  if (!el) return;
+  autoScroll.value = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+}
+
+function scrollToBottom(): void {
+  const el = consoleRef.value;
+  if (el) el.scrollTop = el.scrollHeight;
+}
+
+onMounted(() => fetchLogs());
+
+onBeforeUnmount(() => {
+  stopStream();
+  clearTimeout(searchDebounceTimer ?? undefined);
+  clearTimeout(usernameDebounceTimer ?? undefined);
+});
+</script>

--- a/client-v3/src/components/config/ConfigSettings.vue
+++ b/client-v3/src/components/config/ConfigSettings.vue
@@ -25,10 +25,13 @@
                       {{ dirtyByCategory[String(category)] }}
                     </BBadge>
                   </span>
-                  <span>{{ expandedCategories.includes(String(category)) ? '▲' : '▼' }}</span>
+                  <span>{{ expandedState[String(category)] ? '▲' : '▼' }}</span>
                 </div>
               </BCardHeader>
-              <BCollapse :visible="expandedCategories.includes(String(category))">
+              <BCollapse
+                :model-value="expandedState[String(category)]"
+                @update:model-value="(val) => (expandedState[String(category)] = val)"
+              >
                 <BCardBody>
                   <BFormGroup
                     v-for="(setting, key) in settings"
@@ -110,7 +113,7 @@ const { rawSettings, settingsCategories } = storeToRefs(systemStore);
 
 const loaded = ref(false);
 const editSettings = ref<Record<string, unknown>>({});
-const expandedCategories = ref<string[]>(['General']);
+const expandedState = ref<Record<string, boolean>>({ General: true });
 
 const visibleSettings = computed(() => {
   const result: Record<string, any> = {};
@@ -178,9 +181,7 @@ function getChoiceOptions(setting: any): Array<{ value: unknown; text: string }>
 }
 
 function toggleCategory(category: string): void {
-  const idx = expandedCategories.value.indexOf(category);
-  if (idx >= 0) expandedCategories.value.splice(idx, 1);
-  else expandedCategories.value.push(category);
+  expandedState.value[category] = !expandedState.value[category];
 }
 
 function resetEditSettings(): void {

--- a/client-v3/src/components/config/ConfigSettings.vue
+++ b/client-v3/src/components/config/ConfigSettings.vue
@@ -39,7 +39,6 @@
                     :key="key"
                     :label-for="`${key}-input`"
                     label-cols="4"
-                    style="margin-bottom: 0"
                   >
                     <template #label>
                       <span>

--- a/client-v3/src/components/config/ConfigSettings.vue
+++ b/client-v3/src/components/config/ConfigSettings.vue
@@ -1,0 +1,235 @@
+<template>
+  <BContainer fluid class="mx-0">
+    <BRow>
+      <BCol>
+        <template v-if="loaded">
+          <BForm @submit.prevent="handleSubmit" @reset.prevent="resetForm">
+            <BCard
+              v-for="(settings, category) in settingsByCategory"
+              :key="`settings-${category}`"
+              no-body
+              class="mt-2"
+            >
+              <BCardHeader class="cursor-pointer" @click="toggleCategory(String(category))">
+                <div class="d-flex justify-content-between align-items-center">
+                  <span>
+                    {{ category }}
+                    <BBadge variant="success" class="ms-1">
+                      {{ Object.keys(settings).length - (dirtyByCategory[String(category)] ?? 0) }}
+                    </BBadge>
+                    <BBadge
+                      v-if="(dirtyByCategory[String(category)] ?? 0) > 0"
+                      variant="warning"
+                      class="ms-1"
+                    >
+                      {{ dirtyByCategory[String(category)] }}
+                    </BBadge>
+                  </span>
+                  <span>{{ expandedCategories.includes(String(category)) ? '▲' : '▼' }}</span>
+                </div>
+              </BCardHeader>
+              <BCollapse :visible="expandedCategories.includes(String(category))">
+                <BCardBody>
+                  <BFormGroup
+                    v-for="(setting, key) in settings"
+                    :id="`${key}-input-group`"
+                    :key="key"
+                    :label-for="`${key}-input`"
+                    label-cols="4"
+                    style="margin-bottom: 0"
+                  >
+                    <template #label>
+                      <span>
+                        {{ setting.display_name !== '' ? setting.display_name : key }}
+                        <span
+                          v-if="setting.help_text !== ''"
+                          :id="`${key}-help-icon`"
+                          class="text-muted ms-1"
+                          style="cursor: help"
+                          :title="setting.help_text"
+                          >?</span
+                        >
+                      </span>
+                    </template>
+                    <BFormSelect
+                      v-if="setting.choice_options != null"
+                      :id="`${key}-input`"
+                      v-model="editSettings[String(key)]"
+                      :name="`${key}-input`"
+                      :options="getChoiceOptions(setting)"
+                      :state="fieldState(String(key))"
+                      :disabled="!setting.can_edit"
+                    />
+                    <BFormInput
+                      v-else-if="setting.type !== 'bool'"
+                      :id="`${key}-input`"
+                      v-model="editSettings[String(key)]"
+                      :name="`${key}-input`"
+                      :type="inputType(setting.type)"
+                      :state="fieldState(String(key))"
+                      :readonly="!setting.can_edit"
+                    />
+                    <BFormCheckbox
+                      v-else
+                      :id="`${key}-input`"
+                      v-model="editSettings[String(key)]"
+                      :name="`${key}-input`"
+                      :disabled="!setting.can_edit"
+                      switch
+                    />
+                  </BFormGroup>
+                </BCardBody>
+              </BCollapse>
+            </BCard>
+            <BButtonGroup size="md" style="float: right; padding-top: 1rem; padding-bottom: 0.5rem">
+              <BButton type="reset" variant="danger" :disabled="!hasChanges">Reset</BButton>
+              <BButton type="submit" variant="primary" :disabled="!hasChanges">Submit</BButton>
+            </BButtonGroup>
+          </BForm>
+        </template>
+        <div v-else class="text-center">
+          <BSpinner style="width: 10rem; height: 10rem" variant="info" />
+        </div>
+      </BCol>
+    </BRow>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue';
+import { useVuelidate } from '@vuelidate/core';
+import { required, integer } from '@vuelidate/validators';
+import { storeToRefs } from 'pinia';
+import log from 'loglevel';
+import { makeURL } from '@/js/utils';
+import { useSystemStore } from '@/stores/system';
+import { toast } from '@/js/toast';
+
+const systemStore = useSystemStore();
+const { rawSettings, settingsCategories } = storeToRefs(systemStore);
+
+const loaded = ref(false);
+const editSettings = ref<Record<string, unknown>>({});
+const expandedCategories = ref<string[]>(['General']);
+
+const visibleSettings = computed(() => {
+  const result: Record<string, any> = {};
+  for (const [key, setting] of Object.entries(rawSettings.value)) {
+    if (!(setting as any).hide_from_ui) result[key] = setting;
+  }
+  return result;
+});
+
+const settingsByCategory = computed(() => {
+  const result: Record<string, Record<string, any>> = {};
+  for (const [category, keys] of Object.entries(settingsCategories.value)) {
+    result[category] = {};
+    for (const key of keys as string[]) {
+      if (key in visibleSettings.value) result[category][key] = visibleSettings.value[key];
+    }
+  }
+  return result;
+});
+
+const hasChanges = computed(() =>
+  Object.keys(editSettings.value).some(
+    (key) => editSettings.value[key] !== (rawSettings.value[key] as any)?.value
+  )
+);
+
+const rules = computed(() => {
+  const r: Record<string, any> = {};
+  for (const key of Object.keys(editSettings.value)) {
+    r[key] = (rawSettings.value[key] as any)?.type === 'int' ? { required, integer } : {};
+  }
+  return { editSettings: r };
+});
+
+const v$ = useVuelidate(rules, { editSettings });
+
+const dirtyByCategory = computed(() => {
+  const dirty: Record<string, number> = {};
+  for (const [category, keys] of Object.entries(settingsCategories.value)) {
+    dirty[category] = 0;
+    for (const key of keys as string[]) {
+      if (key in visibleSettings.value && v$.value.editSettings?.[key]?.$dirty) {
+        dirty[category]++;
+      }
+    }
+  }
+  return dirty;
+});
+
+function fieldState(key: string): boolean | null {
+  const field = v$.value.editSettings?.[key];
+  if (!field) return null;
+  return field.$dirty ? !field.$error : null;
+}
+
+function inputType(fieldType: string): string {
+  return fieldType === 'int' ? 'number' : 'text';
+}
+
+function getChoiceOptions(setting: any): Array<{ value: unknown; text: string }> {
+  const options: Array<{ value: unknown; text: string }> = [];
+  if (setting._nullable) options.push({ value: null, text: 'N/A' });
+  setting.choice_options.forEach((opt: unknown) => options.push({ value: opt, text: String(opt) }));
+  return options;
+}
+
+function toggleCategory(category: string): void {
+  const idx = expandedCategories.value.indexOf(category);
+  if (idx >= 0) expandedCategories.value.splice(idx, 1);
+  else expandedCategories.value.push(category);
+}
+
+function resetEditSettings(): void {
+  for (const [key, setting] of Object.entries(visibleSettings.value)) {
+    editSettings.value[key] = (setting as any).value;
+  }
+}
+
+function resetForm(): void {
+  loaded.value = false;
+  resetEditSettings();
+  v$.value.$reset();
+  loaded.value = true;
+}
+
+watch(rawSettings, () => {
+  loaded.value = false;
+  resetEditSettings();
+  v$.value.$reset();
+  loaded.value = true;
+});
+
+onMounted(async () => {
+  await systemStore.getSettingsCategories();
+  resetEditSettings();
+  loaded.value = true;
+});
+
+async function handleSubmit(): Promise<void> {
+  const valid = await v$.value.$validate();
+  if (!valid) return;
+
+  const response = await fetch(makeURL('/api/v1/settings'), {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(editSettings.value),
+  });
+  if (response.ok) {
+    toast.success('Saved settings');
+    v$.value.$reset();
+  } else {
+    log.error('Unable to save settings');
+    toast.error('Unable to save settings');
+  }
+}
+</script>
+
+<style scoped>
+.cursor-pointer {
+  cursor: pointer;
+}
+</style>

--- a/client-v3/src/components/config/ConfigShows.vue
+++ b/client-v3/src/components/config/ConfigShows.vue
@@ -1,0 +1,254 @@
+<template>
+  <BContainer fluid class="mx-0">
+    <template v-if="loaded">
+      <BRow>
+        <BCol>
+          <BTable
+            id="shows-table"
+            :items="availableShows"
+            :fields="showFields"
+            :per-page="rowsPerPage"
+            :current-page="currentPage"
+          >
+            <template #head(btn)>
+              <BButton variant="success" @click="newShowModal?.show()">Setup New Show</BButton>
+            </template>
+            <template #cell(btn)="data">
+              <BButton
+                variant="primary"
+                :disabled="
+                  isSubmittingLoad || (currentShow != null && currentShow.id === data.item.id)
+                "
+                @click="loadShow(data.item)"
+              >
+                {{
+                  currentShow != null && currentShow.id === data.item.id ? 'Loaded' : 'Load Show'
+                }}
+              </BButton>
+            </template>
+          </BTable>
+          <BPagination
+            v-show="availableShows.length > rowsPerPage"
+            v-model="currentPage"
+            :total-rows="availableShows.length"
+            :per-page="rowsPerPage"
+            aria-controls="shows-table"
+            class="justify-content-center"
+          />
+        </BCol>
+      </BRow>
+    </template>
+    <BRow v-else>
+      <BCol class="text-center">
+        <BSpinner label="Loading shows..." variant="primary" />
+      </BCol>
+    </BRow>
+
+    <BModal ref="newShowModal" title="Setup New Show" @show="resetForm">
+      <BForm @submit.stop.prevent>
+        <BFormGroup label="Name" label-for="show-name-input" label-cols="4">
+          <BFormInput
+            id="show-name-input"
+            v-model="formState.name"
+            name="show-name-input"
+            :state="fieldState('name')"
+          />
+          <BFormInvalidFeedback>Required, max 100 characters.</BFormInvalidFeedback>
+        </BFormGroup>
+
+        <BFormGroup label="Start Date" label-for="show-start-input" label-cols="4">
+          <BFormInput
+            id="show-start-input"
+            v-model="formState.start_date"
+            name="show-start-input"
+            type="date"
+            :state="fieldState('start_date')"
+          />
+          <BFormInvalidFeedback>Required, must be before or same as end date.</BFormInvalidFeedback>
+        </BFormGroup>
+
+        <BFormGroup label="End Date" label-for="show-end-input" label-cols="4">
+          <BFormInput
+            id="show-end-input"
+            v-model="formState.end_date"
+            name="show-end-input"
+            type="date"
+            :state="fieldState('end_date')"
+          />
+          <BFormInvalidFeedback
+            >Required, must be after or same as start date.</BFormInvalidFeedback
+          >
+        </BFormGroup>
+
+        <hr />
+
+        <BFormGroup label="Script Mode" label-for="show-script-mode-input" label-cols="4">
+          <BAlert variant="secondary" :model-value="true">
+            Change the type of script for this show.
+          </BAlert>
+          <BFormSelect
+            id="show-script-mode-input"
+            v-model="formState.script_mode"
+            :options="scriptModes"
+            :state="fieldState('script_mode')"
+          />
+        </BFormGroup>
+      </BForm>
+
+      <template #footer="{ cancel }">
+        <BButton @click="cancel()">Cancel</BButton>
+        <BButton variant="success" :disabled="isSubmittingShow" @click="submit(false)">
+          Save
+        </BButton>
+        <BButton variant="primary" :disabled="isSubmittingShow" @click="submit(true)">
+          Save and Load
+        </BButton>
+      </template>
+    </BModal>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useVuelidate } from '@vuelidate/core';
+import { required, maxLength, helpers } from '@vuelidate/validators';
+import { storeToRefs } from 'pinia';
+import { BModal } from 'bootstrap-vue-next';
+import log from 'loglevel';
+import { makeURL } from '@/js/utils';
+import { useSystemStore } from '@/stores/system';
+import { toast } from '@/js/toast';
+import type { Show } from '@/types/api/show';
+
+const systemStore = useSystemStore();
+const { availableShows, scriptModes, currentShow } = storeToRefs(systemStore);
+
+const loaded = ref(false);
+const newShowModal = ref<InstanceType<typeof BModal>>();
+const isSubmittingLoad = ref(false);
+const isSubmittingShow = ref(false);
+const currentPage = ref(1);
+const rowsPerPage = 15;
+
+const showFields = [
+  { key: 'id', label: 'ID' },
+  'name',
+  'start_date',
+  'end_date',
+  'created_at',
+  { key: 'btn', label: '' },
+];
+
+interface ShowForm {
+  name: string;
+  start_date: string;
+  end_date: string;
+  script_mode: number | null;
+}
+
+const defaultForm = (): ShowForm => ({
+  name: '',
+  start_date: '',
+  end_date: '',
+  script_mode: scriptModes.value[0]?.value ?? null,
+});
+
+const formState = ref<ShowForm>(defaultForm());
+
+const beforeEnd = helpers.withMessage(
+  'Start date must be before end date',
+  () =>
+    !formState.value.start_date ||
+    !formState.value.end_date ||
+    new Date(formState.value.start_date) <= new Date(formState.value.end_date)
+);
+
+const afterStart = helpers.withMessage(
+  'End date must be after start date',
+  () =>
+    !formState.value.start_date ||
+    !formState.value.end_date ||
+    new Date(formState.value.end_date) >= new Date(formState.value.start_date)
+);
+
+const rules = {
+  name: { required, maxLength: maxLength(100) },
+  start_date: { required, beforeEnd },
+  end_date: { required, afterStart },
+  script_mode: { required },
+};
+
+const v$ = useVuelidate(rules, formState);
+
+function fieldState(key: keyof ShowForm): boolean | null {
+  const field = v$.value[key];
+  if (!field) return null;
+  return field.$dirty ? !field.$error : null;
+}
+
+function resetForm(): void {
+  formState.value = defaultForm();
+  if (scriptModes.value.length > 0) formState.value.script_mode = scriptModes.value[0].value;
+  isSubmittingShow.value = false;
+  v$.value.$reset();
+}
+
+async function submit(load: boolean): Promise<void> {
+  const valid = await v$.value.$validate();
+  if (!valid) return;
+  if (isSubmittingShow.value) return;
+
+  isSubmittingShow.value = true;
+  try {
+    const params = new URLSearchParams({ load: String(load) });
+    const response = await fetch(`${makeURL('/api/v1/show')}?${params}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(formState.value),
+    });
+    if (response.ok) {
+      await systemStore.getAvailableShows();
+      toast.success('Created new show!');
+      newShowModal.value?.hide();
+      resetForm();
+    } else {
+      log.error('Unable to create show');
+      toast.error('Unable to save show');
+    }
+  } catch (err) {
+    log.error('Error creating show:', err);
+    toast.error('Unable to save show');
+  } finally {
+    isSubmittingShow.value = false;
+  }
+}
+
+async function loadShow(show: Show): Promise<void> {
+  if (isSubmittingLoad.value) return;
+  isSubmittingLoad.value = true;
+  try {
+    const response = await fetch(makeURL('/api/v1/settings'), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ current_show: show.id }),
+    });
+    if (response.ok) {
+      toast.success('Loaded show!');
+      await systemStore.getAvailableShows();
+    } else {
+      log.error('Unable to load show');
+      toast.error('Unable to load show');
+    }
+  } catch (err) {
+    log.error('Error loading show:', err);
+    toast.error('Unable to load show');
+  } finally {
+    isSubmittingLoad.value = false;
+  }
+}
+
+onMounted(async () => {
+  await Promise.all([systemStore.getAvailableShows(), systemStore.getScriptModes()]);
+  loaded.value = true;
+});
+</script>

--- a/client-v3/src/components/config/ConfigSystem.vue
+++ b/client-v3/src/components/config/ConfigSystem.vue
@@ -1,0 +1,148 @@
+<template>
+  <div v-if="!loading">
+    <BTableSimple>
+      <BTbody>
+        <BTr>
+          <BTd><strong>Version</strong></BTd>
+          <BTd>
+            {{ versionStatus?.current_version ?? 'Unknown' }}
+            <BBadge :variant="versionBadgeVariant" pill>{{ versionBadgeText }}</BBadge>
+            <template v-if="versionStatus?.update_available && versionStatus.latest_version">
+              <br />
+              <small class="text-muted">
+                Latest: {{ versionStatus.latest_version }}
+                <a
+                  v-if="versionStatus.release_url"
+                  :href="versionStatus.release_url"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  (Release Notes)
+                </a>
+              </small>
+            </template>
+            <template v-if="versionStatus?.check_error">
+              <br />
+              <small class="text-danger">{{ versionStatus.check_error }}</small>
+            </template>
+          </BTd>
+          <BTd>
+            <BButton
+              variant="outline-success"
+              :disabled="isCheckingVersion"
+              @click="checkForUpdates"
+            >
+              <BSpinner v-if="isCheckingVersion" small class="me-1" />
+              Check Now
+            </BButton>
+          </BTd>
+        </BTr>
+        <BTr>
+          <BTd><strong>Connected Clients</strong></BTd>
+          <BTd>{{ connectedSessions.length }}</BTd>
+          <BTd>
+            <BButton variant="outline-success" @click="clientsModal?.show()">
+              View Clients
+            </BButton>
+          </BTd>
+        </BTr>
+      </BTbody>
+    </BTableSimple>
+
+    <BModal ref="clientsModal" title="Connected Clients" size="lg">
+      <BTable
+        id="connected-clients-table"
+        :items="connectedSessions"
+        :fields="clientFields"
+        :per-page="perPage"
+        :current-page="currentPage"
+        small
+      />
+      <BPagination
+        v-model="currentPage"
+        :total-rows="connectedSessions.length"
+        :per-page="perPage"
+        aria-controls="connected-clients-table"
+        class="justify-content-center"
+      />
+    </BModal>
+  </div>
+  <div v-else class="text-center">
+    <BSpinner style="width: 10rem; height: 10rem" variant="info" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
+import { storeToRefs } from 'pinia';
+import { BModal } from 'bootstrap-vue-next';
+import { useSystemStore } from '@/stores/system';
+import { toast } from '@/js/toast';
+
+const systemStore = useSystemStore();
+const { connectedSessions, versionStatus } = storeToRefs(systemStore);
+
+const loading = ref(true);
+const isCheckingVersion = ref(false);
+const currentPage = ref(1);
+const perPage = 5;
+const clientsModal = ref<InstanceType<typeof BModal>>();
+
+const clientFields = [
+  { key: 'internal_id', label: 'UUID' },
+  { key: 'remote_ip', label: 'IP' },
+  { key: 'is_editor', label: 'Editing Script' },
+  'last_ping',
+  'last_pong',
+];
+
+const versionBadgeVariant = computed(() => {
+  if (!versionStatus.value?.current_version) return 'secondary';
+  if (versionStatus.value.check_error) return 'danger';
+  if (versionStatus.value.update_available) return 'warning';
+  return 'success';
+});
+
+const versionBadgeText = computed(() => {
+  if (!versionStatus.value?.current_version) return 'Loading...';
+  if (versionStatus.value.check_error) return 'Unable to check';
+  if (versionStatus.value.update_available) return 'Update Available';
+  return 'Up to date';
+});
+
+async function checkForUpdates(): Promise<void> {
+  if (isCheckingVersion.value) return;
+  isCheckingVersion.value = true;
+  try {
+    await systemStore.checkForUpdates();
+    if (versionStatus.value?.update_available) {
+      toast.info(`Update available: ${versionStatus.value.latest_version}`);
+    } else if (!versionStatus.value?.check_error) {
+      toast.success('You are running the latest version');
+    }
+  } catch {
+    toast.error('Unable to check for updates');
+  } finally {
+    isCheckingVersion.value = false;
+  }
+}
+
+let sessionTimer: ReturnType<typeof setTimeout> | null = null;
+
+function scheduleSessionPoll(): void {
+  sessionTimer = setTimeout(async () => {
+    await systemStore.getConnectedSessions();
+    scheduleSessionPoll();
+  }, 1000);
+}
+
+onMounted(async () => {
+  await Promise.all([systemStore.getVersionStatus(), systemStore.getConnectedSessions()]);
+  loading.value = false;
+  scheduleSessionPoll();
+});
+
+onBeforeUnmount(() => {
+  if (sessionTimer) clearTimeout(sessionTimer);
+});
+</script>

--- a/client-v3/src/components/config/ConfigUsers.vue
+++ b/client-v3/src/components/config/ConfigUsers.vue
@@ -1,0 +1,151 @@
+<template>
+  <BContainer fluid class="mx-0">
+    <BRow>
+      <BCol>
+        <BTable id="users-table" :items="users" :fields="userFields" show-empty>
+          <template #head(btn)>
+            <BButtonGroup>
+              <BButton variant="outline-success" @click="newUserModal?.show()">New User</BButton>
+              <BButton variant="outline-success" @click="newAdminModal?.show()">New Admin</BButton>
+            </BButtonGroup>
+          </template>
+          <template #head(is_admin)>User Type</template>
+          <template #cell(last_login)="data">
+            {{ data.item.last_login ?? 'Never' }}
+          </template>
+          <template #cell(last_seen)="data">
+            {{ data.item.last_seen ?? 'Never' }}
+          </template>
+          <template #cell(is_admin)="data">
+            <BBadge v-if="data.item.is_admin" variant="primary">Admin</BBadge>
+            <BBadge v-else variant="secondary">User</BBadge>
+          </template>
+          <template #cell(btn)="data">
+            <BButtonGroup>
+              <BButton
+                variant="warning"
+                :disabled="data.item.is_admin"
+                @click.stop="openRbac(data.item.id)"
+              >
+                RBAC
+              </BButton>
+              <BButton
+                variant="info"
+                :disabled="data.item.id === currentUser?.id"
+                @click.stop="openResetPassword(data.item)"
+              >
+                Reset Password
+              </BButton>
+              <BButton
+                variant="danger"
+                :disabled="
+                  (adminUsers.length === 1 && data.item.is_admin) ||
+                  data.item.id === currentUser?.id
+                "
+                @click.stop="deleteUser(data.item)"
+              >
+                Delete
+              </BButton>
+            </BButtonGroup>
+          </template>
+        </BTable>
+      </BCol>
+    </BRow>
+
+    <BModal ref="newUserModal" title="Add New User" size="md" hide-footer>
+      <CreateUser :is-first-admin="false" @created_user="handleUserCreated(newUserModal)" />
+    </BModal>
+
+    <BModal ref="newAdminModal" title="Add New Admin" size="md" hide-footer>
+      <CreateUser
+        :is-first-admin="false"
+        :is-admin="true"
+        @created_user="handleUserCreated(newAdminModal)"
+      />
+    </BModal>
+
+    <BModal ref="rbacModal" title="User RBAC Config" size="xl" hide-footer>
+      <ConfigRbac v-if="selectedUserId != null" :user-id="selectedUserId" />
+    </BModal>
+
+    <BModal ref="resetPasswordModal" title="Reset User Password" size="md" hide-footer>
+      <ResetPassword
+        v-if="selectedUser"
+        :user-id="selectedUser.id"
+        :username="selectedUser.username"
+        @cancel="resetPasswordModal?.hide()"
+        @password-reset="userStore.getUsers()"
+        @done="resetPasswordModal?.hide()"
+      />
+    </BModal>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
+import { storeToRefs } from 'pinia';
+import { BModal } from 'bootstrap-vue-next';
+import { useUserStore } from '@/stores/user';
+import CreateUser from '@/components/user/CreateUser.vue';
+import ConfigRbac from '@/components/user/ConfigRbac.vue';
+import ResetPassword from '@/components/user/ResetPassword.vue';
+
+const userStore = useUserStore();
+const { users, currentUser } = storeToRefs(userStore);
+
+const newUserModal = ref<InstanceType<typeof BModal>>();
+const newAdminModal = ref<InstanceType<typeof BModal>>();
+const rbacModal = ref<InstanceType<typeof BModal>>();
+const resetPasswordModal = ref<InstanceType<typeof BModal>>();
+
+const selectedUserId = ref<number | null>(null);
+const selectedUser = ref<{ id: number; username: string } | null>(null);
+
+const userFields = [
+  'username',
+  'last_login',
+  'last_seen',
+  { key: 'is_admin', label: 'User Type' },
+  { key: 'btn', label: '' },
+];
+
+const adminUsers = computed(() => users.value.filter((u) => u.is_admin));
+
+function handleUserCreated(modal: typeof newUserModal): void {
+  modal.value?.hide();
+  userStore.getUsers();
+}
+
+function openRbac(userId: number): void {
+  selectedUserId.value = userId;
+  rbacModal.value?.show();
+}
+
+function openResetPassword(user: { id: number; username: string }): void {
+  selectedUser.value = user;
+  resetPasswordModal.value?.show();
+}
+
+async function deleteUser(item: { id: number; username: string }): Promise<void> {
+  if (!window.confirm(`Are you sure you want to delete ${item.username}?`)) return;
+  await userStore.deleteUser(item.id);
+}
+
+let pollTimer: ReturnType<typeof setTimeout> | null = null;
+
+function schedulePolling(): void {
+  pollTimer = setTimeout(async () => {
+    await userStore.getUsers();
+    schedulePolling();
+  }, 5000);
+}
+
+onMounted(async () => {
+  await userStore.getUsers();
+  schedulePolling();
+});
+
+onBeforeUnmount(() => {
+  if (pollTimer) clearTimeout(pollTimer);
+});
+</script>

--- a/client-v3/src/components/config/ConfigUsers.vue
+++ b/client-v3/src/components/config/ConfigUsers.vue
@@ -86,11 +86,13 @@ import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
 import { storeToRefs } from 'pinia';
 import { BModal } from 'bootstrap-vue-next';
 import { useUserStore } from '@/stores/user';
+import { useConfirm } from '@/composables/useConfirm';
 import CreateUser from '@/components/user/CreateUser.vue';
 import ConfigRbac from '@/components/user/ConfigRbac.vue';
 import ResetPassword from '@/components/user/ResetPassword.vue';
 
 const userStore = useUserStore();
+const { confirm } = useConfirm();
 const { users, currentUser } = storeToRefs(userStore);
 
 const newUserModal = ref<InstanceType<typeof BModal>>();
@@ -127,7 +129,12 @@ function openResetPassword(user: { id: number; username: string }): void {
 }
 
 async function deleteUser(item: { id: number; username: string }): Promise<void> {
-  if (!window.confirm(`Are you sure you want to delete ${item.username}?`)) return;
+  const confirmed = await confirm(`Are you sure you want to delete ${item.username}?`, {
+    title: 'Delete User',
+    okVariant: 'danger',
+    okTitle: 'Delete',
+  });
+  if (!confirmed) return;
   await userStore.deleteUser(item.id);
 }
 

--- a/client-v3/src/components/user/ConfigRbac.vue
+++ b/client-v3/src/components/user/ConfigRbac.vue
@@ -1,0 +1,58 @@
+<template>
+  <div v-if="!loaded" class="text-center">
+    <BSpinner style="width: 10rem; height: 10rem" variant="info" />
+  </div>
+  <div v-else-if="error">
+    <strong>Unable to load RBAC config, please try again!</strong>
+  </div>
+  <BContainer v-else fluid class="mx-0">
+    <BRow>
+      <BCol>
+        <BTabs content-class="mt-3">
+          <BTab
+            v-for="(resource, index) in rbacResources"
+            :key="`rbac_resource_${index}`"
+            :active="index === 0"
+            :title="capitalize(resource)"
+          >
+            <RbacResource :resource="resource" :user-id="userId" />
+          </BTab>
+        </BTabs>
+      </BCol>
+    </BRow>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { makeURL } from '@/js/utils';
+import { toast } from '@/js/toast';
+import RbacResource from '@/components/user/RbacResource.vue';
+
+const props = defineProps<{ userId: number }>();
+
+const loaded = ref(false);
+const error = ref(false);
+const rbacResources = ref<string[]>([]);
+
+function capitalize(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+onMounted(async () => {
+  try {
+    const response = await fetch(makeURL('/api/v1/rbac/user/resources'));
+    if (response.ok) {
+      const data = await response.json();
+      rbacResources.value = data.resources;
+    } else {
+      toast.error('Unable to fetch RBAC configuration');
+      error.value = true;
+    }
+  } catch {
+    toast.error('Unable to fetch RBAC configuration');
+    error.value = true;
+  }
+  loaded.value = true;
+});
+</script>

--- a/client-v3/src/components/user/CreateUser.vue
+++ b/client-v3/src/components/user/CreateUser.vue
@@ -1,0 +1,104 @@
+<template>
+  <BForm @submit.prevent="createUser">
+    <BFormGroup label="Username" label-for="username-input" label-cols="4">
+      <BFormInput
+        id="username-input"
+        v-model="state.username"
+        name="username-input"
+        :state="fieldState('username')"
+        :disabled="isFirstAdmin"
+      />
+      <BFormInvalidFeedback>Required and must be a unique username.</BFormInvalidFeedback>
+    </BFormGroup>
+
+    <BFormGroup label="Password" label-for="password-input" label-cols="4">
+      <BFormInput
+        id="password-input"
+        v-model="state.password"
+        name="password-input"
+        type="password"
+        :state="fieldState('password')"
+      />
+      <BFormInvalidFeedback>Required, at least 6 characters.</BFormInvalidFeedback>
+    </BFormGroup>
+
+    <BFormGroup label="Confirm Password" label-for="confirm-password-input" label-cols="4">
+      <BFormInput
+        id="confirm-password-input"
+        v-model="state.confirmPassword"
+        name="confirm-password-input"
+        type="password"
+        :state="fieldState('confirmPassword')"
+      />
+      <BFormInvalidFeedback>Passwords do not match.</BFormInvalidFeedback>
+    </BFormGroup>
+
+    <BButtonGroup>
+      <BButton variant="success" :disabled="v$.$invalid" @click.stop.prevent="createUser">
+        Save
+      </BButton>
+    </BButtonGroup>
+  </BForm>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { useVuelidate } from '@vuelidate/core';
+import { required, minLength, sameAs, helpers } from '@vuelidate/validators';
+import { storeToRefs } from 'pinia';
+import { useUserStore } from '@/stores/user';
+
+const props = withDefaults(
+  defineProps<{
+    isFirstAdmin?: boolean;
+    isAdmin?: boolean;
+  }>(),
+  { isFirstAdmin: false, isAdmin: false }
+);
+
+const emit = defineEmits<{ (e: 'created_user'): void }>();
+
+const userStore = useUserStore();
+const { users } = storeToRefs(userStore);
+
+const state = ref({
+  username: props.isFirstAdmin ? 'admin' : '',
+  password: '',
+  confirmPassword: '',
+  is_admin: props.isFirstAdmin || props.isAdmin,
+});
+
+const isUsernameUnique = helpers.withMessage(
+  'Username already taken',
+  (val: string) =>
+    val === '' || !users.value.some((u) => u.username.toLowerCase() === val.toLowerCase())
+);
+
+const passwordRef = computed(() => state.value.password);
+
+const rules = {
+  username: { required, isUsernameUnique },
+  password: { required, minLength: minLength(6) },
+  confirmPassword: { required, sameAs: sameAs(passwordRef) },
+};
+
+const v$ = useVuelidate(rules, state);
+
+function fieldState(key: 'username' | 'password' | 'confirmPassword'): boolean | null {
+  const field = v$.value[key];
+  return field.$dirty ? !field.$error : null;
+}
+
+async function createUser(): Promise<void> {
+  const valid = await v$.value.$validate();
+  if (!valid) return;
+
+  await userStore.createUser({
+    username: state.value.username,
+    password: state.value.password,
+    is_admin: state.value.is_admin,
+  });
+
+  emit('created_user');
+}
+</script>

--- a/client-v3/src/components/user/RbacResource.vue
+++ b/client-v3/src/components/user/RbacResource.vue
@@ -1,0 +1,148 @@
+<template>
+  <div v-if="!loaded" class="text-center">
+    <BSpinner style="width: 10rem; height: 10rem" variant="info" />
+  </div>
+  <div v-else-if="error">
+    <strong>Unable to load RBAC config, please try again!</strong>
+  </div>
+  <BContainer v-else fluid class="mx-0">
+    <BRow>
+      <BCol>
+        <BTable
+          :id="`rbac-table-${resource}`"
+          :items="rbacObjects.map((x) => x[0])"
+          :fields="[...displayFields, ...rbacRoles]"
+          show-empty
+        >
+          <template v-for="role in rbacRoles" #[getCellSlot(role)]="data" :key="role">
+            <BButton
+              v-if="(rbacObjects[data.index][1] & rbacRolesDict[role]) === 0"
+              variant="primary"
+              :disabled="processing"
+              @click.stop="giveRole(data.item, rbacRolesDict[role])"
+            >
+              Grant Role
+            </BButton>
+            <BButton
+              v-else
+              variant="danger"
+              :disabled="processing"
+              @click.stop="revokeRole(data.item, rbacRolesDict[role])"
+            >
+              Revoke Role
+            </BButton>
+          </template>
+        </BTable>
+      </BCol>
+    </BRow>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { makeURL } from '@/js/utils';
+import { toast } from '@/js/toast';
+
+interface RbacRole {
+  key: string;
+  value: number;
+}
+
+const props = defineProps<{
+  resource: string;
+  userId: number;
+}>();
+
+const loaded = ref(false);
+const error = ref(false);
+const rbacObjects = ref<Array<[unknown, number]>>([]);
+const displayFields = ref<string[]>([]);
+const roles = ref<RbacRole[]>([]);
+const processing = ref(false);
+
+const rbacRoles = computed(() => roles.value.map((r) => r.key));
+const rbacRolesDict = computed(() => {
+  const dict: Record<string, number> = {};
+  roles.value.forEach((r) => {
+    dict[r.key] = r.value;
+  });
+  return dict;
+});
+
+function getCellSlot(role: string): string {
+  return `cell(${role})`;
+}
+
+async function getRoles(): Promise<void> {
+  try {
+    const response = await fetch(makeURL('/api/v1/rbac/roles'));
+    if (response.ok) {
+      const data = await response.json();
+      roles.value = data.roles;
+    } else {
+      toast.error('Unable to fetch RBAC roles');
+      error.value = true;
+    }
+  } catch {
+    toast.error('Unable to fetch RBAC roles');
+    error.value = true;
+  }
+}
+
+async function getObjects(): Promise<void> {
+  const params = new URLSearchParams({ resource: props.resource, user: String(props.userId) });
+  try {
+    const response = await fetch(`${makeURL('/api/v1/rbac/user/objects')}?${params}`);
+    if (response.ok) {
+      const data = await response.json();
+      rbacObjects.value = data.objects;
+      displayFields.value = data.display_fields;
+    } else {
+      toast.error('Unable to fetch RBAC objects for resource');
+      error.value = true;
+    }
+  } catch {
+    toast.error('Unable to fetch RBAC objects for resource');
+    error.value = true;
+  }
+}
+
+async function giveRole(object: unknown, role: number): Promise<void> {
+  processing.value = true;
+  try {
+    const response = await fetch(makeURL('/api/v1/rbac/user/roles/grant'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ resource: props.resource, user: props.userId, object, role }),
+    });
+    if (response.ok) toast.success('Granted role to user');
+    else toast.error('Unable to grant role to user');
+  } catch {
+    toast.error('Unable to grant role to user');
+  }
+  await getObjects();
+  processing.value = false;
+}
+
+async function revokeRole(object: unknown, role: number): Promise<void> {
+  processing.value = true;
+  try {
+    const response = await fetch(makeURL('/api/v1/rbac/user/roles/revoke'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ resource: props.resource, user: props.userId, object, role }),
+    });
+    if (response.ok) toast.success('Revoked role from user');
+    else toast.error('Unable to revoke role from user');
+  } catch {
+    toast.error('Unable to revoke role from user');
+  }
+  await getObjects();
+  processing.value = false;
+}
+
+onMounted(async () => {
+  await Promise.all([getObjects(), getRoles()]);
+  loaded.value = true;
+});
+</script>

--- a/client-v3/src/components/user/ResetPassword.vue
+++ b/client-v3/src/components/user/ResetPassword.vue
@@ -1,0 +1,103 @@
+<template>
+  <div>
+    <BAlert v-if="!temporaryPassword" variant="warning" :model-value="true">
+      This will reset <strong>{{ username }}</strong
+      >'s password to a randomly generated temporary password. The user will be forced to change it
+      on their next login.
+    </BAlert>
+
+    <BAlert v-if="temporaryPassword" variant="success" :model-value="true">
+      <h5 class="alert-heading">Password Reset Successfully</h5>
+      <p class="mb-3">
+        The temporary password for <strong>{{ username }}</strong> is:
+      </p>
+      <BFormGroup>
+        <BInputGroup>
+          <BFormInput
+            :value="temporaryPassword"
+            readonly
+            :type="showPassword ? 'text' : 'password'"
+          />
+          <BButton variant="outline-secondary" @click="showPassword = !showPassword">
+            {{ showPassword ? 'Hide' : 'Show' }}
+          </BButton>
+          <BButton variant="outline-secondary" @click="copyToClipboard">Copy</BButton>
+        </BInputGroup>
+      </BFormGroup>
+      <p class="mb-0 small">
+        Make sure to share this password with the user securely. They will need to change it on
+        their next login.
+      </p>
+    </BAlert>
+
+    <div class="d-flex justify-content-end mt-3">
+      <BButton
+        v-if="!temporaryPassword"
+        variant="outline-secondary"
+        class="me-2"
+        @click="emit('cancel')"
+      >
+        Cancel
+      </BButton>
+      <BButton v-if="!temporaryPassword" variant="danger" :disabled="loading" @click="handleReset">
+        <BSpinner v-if="loading" small class="me-1" />
+        Reset Password
+      </BButton>
+      <BButton v-if="temporaryPassword" variant="primary" @click="emit('done')">Done</BButton>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { makeURL } from '@/js/utils';
+import { toast } from '@/js/toast';
+
+const props = defineProps<{
+  userId: number;
+  username: string;
+}>();
+
+const emit = defineEmits<{
+  (e: 'cancel'): void;
+  (e: 'password-reset'): void;
+  (e: 'done'): void;
+}>();
+
+const loading = ref(false);
+const temporaryPassword = ref<string | null>(null);
+const showPassword = ref(false);
+
+async function handleReset(): Promise<void> {
+  loading.value = true;
+  try {
+    const response = await fetch(makeURL('/api/v1/auth/reset-password'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id: props.userId }),
+    });
+    if (response.ok) {
+      const data = await response.json();
+      temporaryPassword.value = data.temporary_password;
+      toast.success(`Password reset for ${props.username}`);
+      emit('password-reset');
+    } else {
+      const error = await response.json();
+      toast.error(error.message || 'Failed to reset password');
+    }
+  } catch {
+    toast.error('An error occurred while resetting password');
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function copyToClipboard(): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(temporaryPassword.value!);
+    toast.success('Password copied to clipboard');
+  } catch {
+    toast.error('Failed to copy to clipboard');
+  }
+}
+</script>

--- a/client-v3/src/composables/useConfirm.ts
+++ b/client-v3/src/composables/useConfirm.ts
@@ -1,0 +1,42 @@
+import { ref } from 'vue';
+
+export interface ConfirmOptions {
+  title?: string;
+  okVariant?: string;
+  okTitle?: string;
+  cancelTitle?: string;
+  size?: 'sm' | 'md' | 'lg' | 'xl';
+}
+
+// Module-level singleton state shared across all callers
+const visible = ref(false);
+const message = ref('');
+const currentOptions = ref<ConfirmOptions>({});
+let resolveCallback: ((value: boolean) => void) | null = null;
+let resolved = false;
+
+export function useConfirm() {
+  function confirm(msg: string, opts: ConfirmOptions = {}): Promise<boolean> {
+    message.value = msg;
+    currentOptions.value = opts;
+    resolved = false;
+    visible.value = true;
+    return new Promise((resolve) => {
+      resolveCallback = resolve;
+    });
+  }
+
+  function _handleOk(): void {
+    if (resolved) return;
+    resolved = true;
+    resolveCallback?.(true);
+  }
+
+  function _handleHidden(): void {
+    if (resolved) return;
+    resolved = true;
+    resolveCallback?.(false);
+  }
+
+  return { confirm, visible, message, currentOptions, _handleOk, _handleHidden };
+}

--- a/client-v3/src/router/index.ts
+++ b/client-v3/src/router/index.ts
@@ -34,7 +34,7 @@ const router = createRouter({
     {
       path: '/config',
       name: 'config',
-      component: PlaceholderView,
+      component: () => import('@/views/config/ConfigView.vue'),
       meta: { requiresAuth: true, requiresAdmin: true },
     },
     {

--- a/client-v3/src/stores/system.ts
+++ b/client-v3/src/stores/system.ts
@@ -5,6 +5,29 @@ import type { Show } from '@/types/api/show';
 import type { SystemSettings } from '@/types/api/settings';
 import { useUserStore } from '@/stores/user';
 
+// ScriptMode moves to stores/show.ts in Phase 6
+interface ScriptMode {
+  value: number;
+  text: string;
+}
+
+interface ConnectedSession {
+  internal_id: string;
+  remote_ip: string;
+  is_editor: boolean;
+  last_ping: string | null;
+  last_pong: string | null;
+}
+
+interface VersionStatus {
+  current_version: string | null;
+  latest_version: string | null;
+  update_available: boolean;
+  release_url: string | null;
+  last_checked: string | null;
+  check_error: string | null;
+}
+
 interface RbacRole {
   key: string;
   value: number;
@@ -28,6 +51,9 @@ export const useSystemStore = defineStore('system', {
     rbacRoles: [] as RbacRole[],
     settingsCategories: {} as Record<string, unknown>,
     currentShow: null as Show | null,
+    scriptModes: [] as ScriptMode[],
+    connectedSessions: [] as ConnectedSession[],
+    versionStatus: null as VersionStatus | null,
   }),
   getters: {
     isAdminUser(): boolean {
@@ -178,6 +204,43 @@ export const useSystemStore = defineStore('system', {
         this.settingsCategories = data.categories;
       } else {
         log.error('Unable to fetch settings categories');
+      }
+    },
+    async getScriptModes() {
+      const response = await fetch(makeURL('/api/v1/show/script_modes'));
+      if (response.ok) {
+        const data = await response.json();
+        this.scriptModes = data.script_modes ?? [];
+      } else {
+        log.error('Unable to fetch script modes');
+      }
+    },
+    async getConnectedSessions() {
+      const response = await fetch(makeURL('/api/v1/ws/sessions'));
+      if (response.ok) {
+        const data = await response.json();
+        this.connectedSessions = data.sessions ?? [];
+      } else {
+        log.error('Unable to fetch connected sessions');
+      }
+    },
+    async getVersionStatus() {
+      const response = await fetch(makeURL('/api/v1/version/status'));
+      if (response.ok) {
+        this.versionStatus = await response.json();
+      } else {
+        log.error('Unable to fetch version status');
+      }
+    },
+    async checkForUpdates() {
+      const response = await fetch(makeURL('/api/v1/version/check'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (response.ok) {
+        this.versionStatus = await response.json();
+      } else {
+        log.error('Unable to check for updates');
       }
     },
   },

--- a/client-v3/src/views/config/ConfigView.vue
+++ b/client-v3/src/views/config/ConfigView.vue
@@ -1,0 +1,22 @@
+<template>
+  <BContainer fluid class="mx-0">
+    <h1>System Configuration</h1>
+    <BTabs pills vertical content-class="flex-fill text-start">
+      <BTab active title="Shows"><ConfigShows /></BTab>
+      <BTab title="System"><ConfigSystem /></BTab>
+      <BTab title="Settings"><ConfigSettings /></BTab>
+      <BTab title="Users"><ConfigUsers /></BTab>
+      <BTab title="Logs"><ConfigLogs /></BTab>
+      <BTab title="Backups"><ConfigBackups /></BTab>
+    </BTabs>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import ConfigShows from '@/components/config/ConfigShows.vue';
+import ConfigSystem from '@/components/config/ConfigSystem.vue';
+import ConfigSettings from '@/components/config/ConfigSettings.vue';
+import ConfigUsers from '@/components/config/ConfigUsers.vue';
+import ConfigLogs from '@/components/config/ConfigLogs.vue';
+import ConfigBackups from '@/components/config/ConfigBackups.vue';
+</script>

--- a/client-v3/src/views/config/ConfigView.vue
+++ b/client-v3/src/views/config/ConfigView.vue
@@ -1,14 +1,18 @@
 <template>
   <BContainer fluid class="mx-0">
-    <h1>System Configuration</h1>
-    <BTabs pills vertical content-class="flex-fill text-start">
-      <BTab active title="Shows"><ConfigShows /></BTab>
-      <BTab title="System"><ConfigSystem /></BTab>
-      <BTab title="Settings"><ConfigSettings /></BTab>
-      <BTab title="Users"><ConfigUsers /></BTab>
-      <BTab title="Logs"><ConfigLogs /></BTab>
-      <BTab title="Backups"><ConfigBackups /></BTab>
-    </BTabs>
+    <BRow>
+      <BCol>
+        <h1>DigiScript Config</h1>
+        <BTabs content-class="mt-3" lazy>
+          <BTab active title="Shows"><ConfigShows /></BTab>
+          <BTab title="System"><ConfigSystem /></BTab>
+          <BTab title="Settings"><ConfigSettings /></BTab>
+          <BTab title="Users"><ConfigUsers /></BTab>
+          <BTab title="Logs"><ConfigLogs /></BTab>
+          <BTab title="Backups"><ConfigBackups /></BTab>
+        </BTabs>
+      </BCol>
+    </BRow>
   </BContainer>
 </template>
 


### PR DESCRIPTION
## Summary

- Ports the admin `/config` section (6-tab interface) from Vue 2 to Vue 3
- Implements `ConfigView`, `ConfigSettings`, `ConfigShows`, `ConfigSystem`, `ConfigUsers`, `ConfigBackups`, `ConfigLogs` components
- Implements user management child components: `CreateUser`, `ResetPassword`, `ConfigRbac`, `RbacResource`
- Adds `ConfirmDialog` composable + component to replace `window.confirm` with a styled BModal dialog, reusable across the whole V3 frontend
- Extends `stores/system.ts` with `scriptModes`, `connectedSessions`, `versionStatus` state and `getScriptModes`, `getConnectedSessions`, `getVersionStatus`, `checkForUpdates` actions
- Wires `/config` router entry to the real view (was `PlaceholderView`)

## Notable implementation details

- `BTabs` uses `lazy` prop to defer tab component mount — prevents all 6 tabs' polling timers starting simultaneously on page load
- `BCollapse` accordion uses `:model-value`/`@update:model-value` (not `:visible`) to preserve the slide transition animation — BVN's `useShowHide` disables animation when the `visible` prop is used directly
- `ConfigLogs` streams live log output via the Web Streams API (`response.body.getReader()`) with 400ms debounce on search inputs and auto-scroll when near the bottom
- `ConfigSystem` and `ConfigUsers` use `setTimeout`-based recursive polling (1s and 5s respectively) cleaned up in `onBeforeUnmount`

## Test plan

- [ ] Navigate to `/ui-new/config` as admin — 6 tabs render (Shows, System, Settings, Users, Logs, Backups)
- [ ] **Shows**: table lists shows; "Setup New Show" modal opens, date validation works, Save/Save and Load create show; Load button switches active show
- [ ] **System**: version badge shown; Connected Clients modal opens; Check for Updates posts correctly
- [ ] **Settings**: categories expand/collapse with slide animation; settings editable; dirty badge counts update; Save patches `/api/v1/settings`
- [ ] **Users**: user list shown; New User/New Admin modals open with username uniqueness validation; RBAC modal shows per-resource tabs with Grant/Revoke; Reset Password displays temp password; Delete user shows confirm dialog
- [ ] **Logs**: static mode loads logs with filters; Live mode streams via SSE; auto-scroll works
- [ ] **Backups**: list shown with size/date; Delete shows confirm dialog and removes entry
- [ ] Non-admin user is redirected away from `/config`
- [ ] `ConfirmDialog` (BModal) appears for all destructive actions — no `window.confirm` dialogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)