### PR TITLE
Vue 3 migration: Phase 6 — show configuration foundation

### DIFF
--- a/client-v3/src/components/config/ConfigShows.vue
+++ b/client-v3/src/components/config/ConfigShows.vue
@@ -117,11 +117,14 @@ import { BModal } from 'bootstrap-vue-next';
 import log from 'loglevel';
 import { makeURL } from '@/js/utils';
 import { useSystemStore } from '@/stores/system';
+import { useShowStore } from '@/stores/show';
 import { toast } from '@/js/toast';
 import type { Show } from '@/types/api/show';
 
 const systemStore = useSystemStore();
-const { availableShows, scriptModes, currentShow } = storeToRefs(systemStore);
+const showStore = useShowStore();
+const { availableShows, currentShow } = storeToRefs(systemStore);
+const { scriptModes } = storeToRefs(showStore);
 
 const loaded = ref(false);
 const newShowModal = ref<InstanceType<typeof BModal>>();
@@ -248,7 +251,7 @@ async function loadShow(show: Show): Promise<void> {
 }
 
 onMounted(async () => {
-  await Promise.all([systemStore.getAvailableShows(), systemStore.getScriptModes()]);
+  await Promise.all([systemStore.getAvailableShows(), showStore.getScriptModes()]);
   loaded.value = true;
 });
 </script>

--- a/client-v3/src/composables/useWebSocket.ts
+++ b/client-v3/src/composables/useWebSocket.ts
@@ -116,7 +116,20 @@ async function dispatchAction(action: string, data: Record<string, unknown>): Pr
       window.location.reload();
     },
     GET_CAST_LIST: async () => {
-      /* handled in show store — Phase 6 */
+      const { useShowStore } = await import('@/stores/show');
+      await useShowStore().getCastList();
+    },
+    ELECTED_LEADER: async () => {
+      const { useShowStore } = await import('@/stores/show');
+      await useShowStore().electedLeader();
+    },
+    NO_LEADER: async () => {
+      const { useShowStore } = await import('@/stores/show');
+      await useShowStore().noLeader();
+    },
+    SCRIPT_SCROLL: async (d: Record<string, unknown>) => {
+      const { useShowStore } = await import('@/stores/show');
+      useShowStore().scriptScroll(d);
     },
   };
 

--- a/client-v3/src/js/micConflictUtils.ts
+++ b/client-v3/src/js/micConflictUtils.ts
@@ -1,0 +1,283 @@
+import type { Act, Character, Scene, Show } from '@/types/api/show';
+
+export interface SceneGraphNode {
+  sceneId: number;
+  actId: number;
+  sceneName: string;
+  actName: string;
+  globalPosition: number;
+  scenePositionInAct: number;
+  previousSceneInAct: number | null;
+  nextSceneInAct: number | null;
+  previousSceneInShow: number | null;
+  nextSceneInShow: number | null;
+}
+
+export interface AdjacentScenes {
+  sameActPrev: number | null;
+  sameActNext: number | null;
+  crossActPrev: number | null;
+  crossActNext: number | null;
+}
+
+export interface MicConflict {
+  micId: number;
+  sceneId: number;
+  sceneName: string;
+  actName: string;
+  characterId: number;
+  characterName: string;
+  adjacentSceneId: number;
+  adjacentSceneName: string;
+  adjacentActName: string;
+  adjacentCharacterId: number;
+  adjacentCharacterName: string;
+  severity: 'WARNING' | 'INFO';
+  message: string;
+}
+
+export interface MicConflictResult {
+  conflicts: MicConflict[];
+  conflictsByScene: Record<number, MicConflict[]>;
+  conflictsByMic: Record<number, MicConflict[]>;
+}
+
+// Nested dict: { micId: { sceneId: characterId | null } }
+type MicAllocations = Record<string, Record<string, number | null> | null>;
+
+export function buildSceneGraph(
+  scenes: Scene[],
+  acts: Act[],
+  currentShow: Pick<Show, 'first_act_id'> | null
+): SceneGraphNode[] {
+  if (!currentShow?.first_act_id || !scenes?.length || !acts?.length) {
+    return [];
+  }
+
+  const sceneById: Record<number, Scene> = {};
+  scenes.forEach((scene) => {
+    sceneById[scene.id] = scene;
+  });
+
+  const actById: Record<number, Act> = {};
+  acts.forEach((act) => {
+    actById[act.id] = act;
+  });
+
+  const graph: SceneGraphNode[] = [];
+  const graphById: Record<number, SceneGraphNode> = {};
+  let globalPosition = 0;
+
+  let currentAct: Act | null = actById[currentShow.first_act_id];
+  let previousActLastSceneId: number | null = null;
+
+  while (currentAct != null) {
+    let scenePosition = 0;
+    let previousSceneId: number | null = null;
+
+    let currentScene = currentAct.first_scene ? sceneById[currentAct.first_scene] : null;
+
+    while (currentScene != null) {
+      const node: SceneGraphNode = {
+        sceneId: currentScene.id,
+        actId: currentScene.act!,
+        sceneName: currentScene.name!,
+        actName: currentAct.name!,
+        globalPosition,
+        scenePositionInAct: scenePosition,
+        previousSceneInAct: previousSceneId,
+        nextSceneInAct: null,
+        previousSceneInShow: null,
+        nextSceneInShow: null,
+      };
+
+      if (previousSceneId) {
+        const prevNode = graphById[previousSceneId];
+        if (prevNode) {
+          prevNode.nextSceneInAct = currentScene.id;
+          prevNode.nextSceneInShow = currentScene.id;
+          node.previousSceneInShow = previousSceneId;
+        }
+      }
+
+      if (scenePosition === 0 && previousActLastSceneId) {
+        const prevActLastNode = graphById[previousActLastSceneId];
+        if (prevActLastNode) {
+          prevActLastNode.nextSceneInShow = currentScene.id;
+          node.previousSceneInShow = previousActLastSceneId;
+        }
+      }
+
+      graph.push(node);
+      graphById[currentScene.id] = node;
+
+      previousSceneId = currentScene.id;
+      currentScene = currentScene.next_scene ? sceneById[currentScene.next_scene] : null;
+      scenePosition++;
+      globalPosition++;
+    }
+
+    previousActLastSceneId = previousSceneId;
+    currentAct = currentAct.next_act ? actById[currentAct.next_act] : null;
+  }
+
+  return graph;
+}
+
+export function getAdjacentScenes(sceneId: number, sceneGraph: SceneGraphNode[]): AdjacentScenes {
+  const node = sceneGraph.find((n) => n.sceneId === sceneId);
+
+  if (!node) {
+    return { sameActPrev: null, sameActNext: null, crossActPrev: null, crossActNext: null };
+  }
+
+  const prevNode = node.previousSceneInShow
+    ? sceneGraph.find((n) => n.sceneId === node.previousSceneInShow)
+    : null;
+  const nextNode = node.nextSceneInShow
+    ? sceneGraph.find((n) => n.sceneId === node.nextSceneInShow)
+    : null;
+
+  return {
+    sameActPrev: prevNode && prevNode.actId === node.actId ? prevNode.sceneId : null,
+    sameActNext: nextNode && nextNode.actId === node.actId ? nextNode.sceneId : null,
+    crossActPrev: prevNode && prevNode.actId !== node.actId ? prevNode.sceneId : null,
+    crossActNext: nextNode && nextNode.actId !== node.actId ? nextNode.sceneId : null,
+  };
+}
+
+export function areScenesInSameAct(
+  sceneId1: number,
+  sceneId2: number,
+  sceneGraph: SceneGraphNode[]
+): boolean {
+  const node1 = sceneGraph.find((n) => n.sceneId === sceneId1);
+  const node2 = sceneGraph.find((n) => n.sceneId === sceneId2);
+  if (!node1 || !node2) return false;
+  return node1.actId === node2.actId;
+}
+
+export function isSameCastMember(
+  characterId1: number,
+  characterId2: number,
+  characters: Character[],
+  castList: unknown[]
+): boolean {
+  if (characterId1 === characterId2) return true;
+
+  const char1 = characters.find((c) => c.id === characterId1);
+  const char2 = characters.find((c) => c.id === characterId2);
+  if (!char1 || !char2) return false;
+
+  const castId1 = char1.cast_member?.id;
+  const castId2 = char2.cast_member?.id;
+  if (castId1 == null || castId2 == null) return false;
+
+  return castId1 === castId2;
+}
+
+export function getConflictSeverity(
+  sceneId1: number,
+  sceneId2: number,
+  sceneGraph: SceneGraphNode[]
+): 'WARNING' | 'INFO' {
+  return areScenesInSameAct(sceneId1, sceneId2, sceneGraph) ? 'WARNING' : 'INFO';
+}
+
+export function detectMicConflicts(
+  allocations: MicAllocations,
+  scenes: Scene[],
+  acts: Act[],
+  currentShow: Pick<Show, 'first_act_id'> | null,
+  characters: Character[],
+  castList: unknown[]
+): MicConflictResult {
+  if (!allocations || !scenes?.length || !acts?.length || !currentShow) {
+    return { conflicts: [], conflictsByScene: {}, conflictsByMic: {} };
+  }
+
+  const sceneGraph = buildSceneGraph(scenes, acts, currentShow);
+
+  if (sceneGraph.length === 0) {
+    return { conflicts: [], conflictsByScene: {}, conflictsByMic: {} };
+  }
+
+  const conflicts: MicConflict[] = [];
+
+  Object.keys(allocations).forEach((micId) => {
+    const micAllocations = allocations[micId];
+    if (!micAllocations || typeof micAllocations !== 'object') return;
+
+    Object.keys(micAllocations).forEach((sceneId) => {
+      const characterId = micAllocations[sceneId];
+      if (characterId == null) return;
+
+      const sceneIdNum = parseInt(sceneId, 10);
+      const adjacentScenes = getAdjacentScenes(sceneIdNum, sceneGraph);
+
+      const adjacentSceneIds = [
+        adjacentScenes.sameActPrev,
+        adjacentScenes.sameActNext,
+        adjacentScenes.crossActPrev,
+        adjacentScenes.crossActNext,
+      ].filter((id): id is number => id != null);
+
+      adjacentSceneIds.forEach((adjacentSceneId) => {
+        const adjacentCharacterId = micAllocations[adjacentSceneId];
+        if (adjacentCharacterId == null) return;
+        if (adjacentCharacterId === characterId) return;
+        if (isSameCastMember(characterId, adjacentCharacterId, characters, castList)) return;
+
+        const severity = getConflictSeverity(sceneIdNum, adjacentSceneId, sceneGraph);
+        const currentSceneNode = sceneGraph.find((n) => n.sceneId === sceneIdNum);
+        const adjacentSceneNode = sceneGraph.find((n) => n.sceneId === adjacentSceneId);
+        const char1 = characters.find((c) => c.id === characterId);
+        const char2 = characters.find((c) => c.id === adjacentCharacterId);
+
+        let message = `Quick-change from "${currentSceneNode?.sceneName || 'Unknown'}"`;
+        if (char1 && char2) message += ` (${char1.name} → ${char2.name})`;
+        message +=
+          severity === 'WARNING'
+            ? ' - Tight changeover required'
+            : ' - Interval provides changeover time';
+
+        const isDuplicate = conflicts.some(
+          (c) =>
+            c.micId === parseInt(micId, 10) &&
+            c.sceneId === adjacentSceneId &&
+            c.adjacentSceneId === sceneIdNum
+        );
+
+        if (!isDuplicate) {
+          conflicts.push({
+            micId: parseInt(micId, 10),
+            sceneId: sceneIdNum,
+            sceneName: currentSceneNode?.sceneName || 'Unknown',
+            actName: currentSceneNode?.actName || 'Unknown',
+            characterId,
+            characterName: char1?.name || 'Unknown',
+            adjacentSceneId,
+            adjacentSceneName: adjacentSceneNode?.sceneName || 'Unknown',
+            adjacentActName: adjacentSceneNode?.actName || 'Unknown',
+            adjacentCharacterId,
+            adjacentCharacterName: char2?.name || 'Unknown',
+            severity,
+            message,
+          });
+        }
+      });
+    });
+  });
+
+  const conflictsByScene: Record<number, MicConflict[]> = {};
+  const conflictsByMic: Record<number, MicConflict[]> = {};
+
+  conflicts.forEach((conflict) => {
+    if (!conflictsByScene[conflict.sceneId]) conflictsByScene[conflict.sceneId] = [];
+    conflictsByScene[conflict.sceneId].push(conflict);
+    if (!conflictsByMic[conflict.micId]) conflictsByMic[conflict.micId] = [];
+    conflictsByMic[conflict.micId].push(conflict);
+  });
+
+  return { conflicts, conflictsByScene, conflictsByMic };
+}

--- a/client-v3/src/router/index.ts
+++ b/client-v3/src/router/index.ts
@@ -39,7 +39,7 @@ const router = createRouter({
     },
     {
       path: '/show-config',
-      component: PlaceholderView,
+      component: () => import('@/views/show/ShowConfigView.vue'),
       meta: { requiresAuth: true, requiresShowAccess: true },
       children: [
         {

--- a/client-v3/src/stores/show.ts
+++ b/client-v3/src/stores/show.ts
@@ -1,0 +1,732 @@
+import { defineStore } from 'pinia';
+import log from 'loglevel';
+import { makeURL } from '@/js/utils';
+import { toast } from '@/js/toast';
+import { detectMicConflicts } from '@/js/micConflictUtils';
+import type { MicConflict, MicConflictResult } from '@/js/micConflictUtils';
+import type { Cast, Character, CharacterGroup, Act, Scene } from '@/types/api/show';
+import type { CueType } from '@/types/api/cues';
+import type { ShowSession, Interval, SessionTag } from '@/types/api/session';
+import type { Microphone } from '@/types/api/microphones';
+import { useSystemStore } from '@/stores/system';
+
+interface ScriptMode {
+  key: string;
+  value: number;
+}
+
+export const useShowStore = defineStore('show', {
+  state: () => ({
+    castList: [] as Cast[],
+    characterList: [] as Character[],
+    characterGroupList: [] as CharacterGroup[],
+    actList: [] as Act[],
+    sceneList: [] as Scene[],
+    cueTypes: [] as CueType[],
+    sessions: [] as ShowSession[],
+    currentSession: null as ShowSession | null,
+    currentInterval: null as Interval | null,
+    sessionFollowData: {} as Record<string, unknown>,
+    microphones: [] as Microphone[],
+    // API returns a dict keyed by mic ID (not a flat array)
+    micAllocations: {} as Record<string, { scene_id: number; character_id: number }[]>,
+    scriptModes: [] as ScriptMode[],
+    sessionTags: [] as SessionTag[],
+    stageManagerMode: false,
+  }),
+
+  persist: {
+    pick: ['stageManagerMode'],
+  },
+
+  getters: {
+    castDict: (state): Record<number, Cast> =>
+      Object.fromEntries(state.castList.map((c) => [c.id, c])),
+    castById:
+      (state): ((id: number | null) => Cast | null) =>
+      (id) => {
+        const dict: Record<number, Cast> = Object.fromEntries(state.castList.map((c) => [c.id, c]));
+        return id != null ? (dict[id] ?? null) : null;
+      },
+
+    characterDict: (state): Record<number, Character> =>
+      Object.fromEntries(state.characterList.map((c) => [c.id, c])),
+    characterById:
+      (state): ((id: number | null) => Character | null) =>
+      (id) => {
+        const dict: Record<number, Character> = Object.fromEntries(
+          state.characterList.map((c) => [c.id, c])
+        );
+        return id != null ? (dict[id] ?? null) : null;
+      },
+
+    actDict: (state): Record<number, Act> =>
+      Object.fromEntries(state.actList.map((a) => [a.id, a])),
+    actById:
+      (state): ((id: number | null) => Act | null) =>
+      (id) => {
+        const dict: Record<number, Act> = Object.fromEntries(state.actList.map((a) => [a.id, a]));
+        return id != null ? (dict[id] ?? null) : null;
+      },
+
+    sceneDict: (state): Record<number, Scene> =>
+      Object.fromEntries(state.sceneList.map((s) => [s.id, s])),
+    sceneById:
+      (state): ((id: number | null) => Scene | null) =>
+      (id) => {
+        const dict: Record<number, Scene> = Object.fromEntries(
+          state.sceneList.map((s) => [s.id, s])
+        );
+        return id != null ? (dict[id] ?? null) : null;
+      },
+
+    cueTypesDict: (state): Record<number, CueType> =>
+      Object.fromEntries(state.cueTypes.map((ct) => [ct.id, ct])),
+    cueTypeById:
+      (state): ((id: number | null) => CueType | null) =>
+      (id) => {
+        const dict: Record<number, CueType> = Object.fromEntries(
+          state.cueTypes.map((ct) => [ct.id, ct])
+        );
+        return id != null ? (dict[id] ?? null) : null;
+      },
+
+    microphoneDict: (state): Record<number, Microphone> =>
+      Object.fromEntries(state.microphones.map((m) => [m.id, m])),
+    microphoneById:
+      (state): ((id: number | null) => Microphone | null) =>
+      (id) => {
+        const dict: Record<number, Microphone> = Object.fromEntries(
+          state.microphones.map((m) => [m.id, m])
+        );
+        return id != null ? (dict[id] ?? null) : null;
+      },
+
+    sessionTagsDict: (state): Record<number, SessionTag> =>
+      Object.fromEntries(state.sessionTags.map((t) => [t.id, t])),
+    sessionTagById:
+      (state): ((id: number | null) => SessionTag | null) =>
+      (id) => {
+        const dict: Record<number, SessionTag> = Object.fromEntries(
+          state.sessionTags.map((t) => [t.id, t])
+        );
+        return id != null ? (dict[id] ?? null) : null;
+      },
+
+    orderedScenes(state): Scene[] {
+      const currentShow = useSystemStore().currentShow;
+      if (!currentShow?.first_act_id || !state.sceneList.length || !state.actList.length) {
+        return [];
+      }
+      const actById: Record<number, Act> = Object.fromEntries(state.actList.map((a) => [a.id, a]));
+      const sceneById: Record<number, Scene> = Object.fromEntries(
+        state.sceneList.map((s) => [s.id, s])
+      );
+      const scenes: Scene[] = [];
+      let currentAct: Act | null = actById[currentShow.first_act_id] ?? null;
+      while (currentAct != null) {
+        let currentScene: Scene | null =
+          currentAct.first_scene != null ? (sceneById[currentAct.first_scene] ?? null) : null;
+        while (currentScene != null) {
+          scenes.push(currentScene);
+          currentScene =
+            currentScene.next_scene != null ? (sceneById[currentScene.next_scene] ?? null) : null;
+        }
+        currentAct = currentAct.next_act != null ? (actById[currentAct.next_act] ?? null) : null;
+      }
+      return scenes;
+    },
+
+    micConflicts(state): MicConflictResult {
+      const allocationsObj: Record<string, Record<string, number | null>> = {};
+      Object.keys(state.micAllocations).forEach((micId) => {
+        const allocs = state.micAllocations[micId];
+        const sceneData: Record<string, number | null> = {};
+        if (Array.isArray(allocs)) {
+          allocs.forEach((alloc) => {
+            sceneData[String(alloc.scene_id)] = alloc.character_id;
+          });
+        }
+        allocationsObj[micId] = sceneData;
+      });
+      return detectMicConflicts(
+        allocationsObj,
+        state.sceneList,
+        state.actList,
+        useSystemStore().currentShow,
+        state.characterList,
+        state.castList
+      );
+    },
+
+    conflictsByScene(): Record<number, MicConflict[]> {
+      return this.micConflicts.conflictsByScene;
+    },
+    conflictsByMic(): Record<number, MicConflict[]> {
+      return this.micConflicts.conflictsByMic;
+    },
+    micTimelineData(state): {
+      scenes: Scene[];
+      allocations: Record<string, { scene_id: number; character_id: number }[]>;
+      conflicts: MicConflict[];
+      microphones: Microphone[];
+      characters: Character[];
+    } {
+      return {
+        scenes: this.orderedScenes,
+        allocations: state.micAllocations,
+        conflicts: this.micConflicts.conflicts,
+        microphones: state.microphones,
+        characters: state.characterList,
+      };
+    },
+  },
+
+  actions: {
+    // Cast
+    async getCastList(): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/cast'));
+      if (response.ok) {
+        const data = await response.json();
+        this.castList = data.cast;
+      } else {
+        log.error('Unable to get cast list');
+      }
+    },
+    async addCastMember(member: Partial<Cast>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/cast'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(member),
+      });
+      if (response.ok) {
+        await this.getCastList();
+        toast.success('Added new cast member!');
+      } else {
+        log.error('Unable to add new cast member');
+        toast.error('Unable to add new cast member');
+      }
+    },
+    async updateCastMember(member: Partial<Cast>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/cast'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(member),
+      });
+      if (response.ok) {
+        await this.getCastList();
+        toast.success('Updated cast member!');
+      } else {
+        log.error('Unable to edit cast member');
+        toast.error('Unable to edit cast member');
+      }
+    },
+    async deleteCastMember(id: number): Promise<void> {
+      const params = new URLSearchParams({ id: String(id) });
+      const response = await fetch(`${makeURL('/api/v1/show/cast')}?${params}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (response.ok) {
+        await this.getCastList();
+        toast.success('Deleted cast member!');
+      } else {
+        log.error('Unable to delete cast member');
+        toast.error('Unable to delete cast member');
+      }
+    },
+
+    // Characters
+    async getCharacterList(): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/character'));
+      if (response.ok) {
+        const data = await response.json();
+        this.characterList = data.characters;
+      } else {
+        log.error('Unable to get characters list');
+      }
+    },
+    async addCharacter(character: Partial<Character>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/character'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(character),
+      });
+      if (response.ok) {
+        await this.getCharacterList();
+        toast.success('Added new character!');
+      } else {
+        log.error('Unable to add new character');
+        toast.error('Unable to add new character');
+      }
+    },
+    async updateCharacter(character: Partial<Character>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/character'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(character),
+      });
+      if (response.ok) {
+        await this.getCharacterList();
+        toast.success('Updated character!');
+      } else {
+        log.error('Unable to edit character');
+        toast.error('Unable to edit character');
+      }
+    },
+    async deleteCharacter(id: number): Promise<void> {
+      const params = new URLSearchParams({ id: String(id) });
+      const response = await fetch(`${makeURL('/api/v1/show/character')}?${params}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (response.ok) {
+        await this.getCharacterList();
+        toast.success('Deleted character!');
+      } else {
+        log.error('Unable to delete character');
+        toast.error('Unable to delete character');
+      }
+    },
+
+    // Character Groups
+    async getCharacterGroupList(): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/character/group'));
+      if (response.ok) {
+        const data = await response.json();
+        this.characterGroupList = data.character_groups;
+        await this.getCharacterList();
+      } else {
+        log.error('Unable to get character groups list');
+      }
+    },
+    async addCharacterGroup(group: Partial<CharacterGroup>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/character/group'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(group),
+      });
+      if (response.ok) {
+        await this.getCharacterGroupList();
+        toast.success('Added new character group!');
+      } else {
+        log.error('Unable to add new character group');
+        toast.error('Unable to add new character group');
+      }
+    },
+    async updateCharacterGroup(group: Partial<CharacterGroup>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/character/group'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(group),
+      });
+      if (response.ok) {
+        await this.getCharacterGroupList();
+        toast.success('Updated character group!');
+      } else {
+        log.error('Unable to edit character group');
+        toast.error('Unable to edit character group');
+      }
+    },
+    async deleteCharacterGroup(id: number): Promise<void> {
+      const params = new URLSearchParams({ id: String(id) });
+      const response = await fetch(`${makeURL('/api/v1/show/character/group')}?${params}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (response.ok) {
+        await this.getCharacterGroupList();
+        toast.success('Deleted character group!');
+      } else {
+        log.error('Unable to delete character group');
+        toast.error('Unable to delete character group');
+      }
+    },
+
+    // Acts
+    async getActList(): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/act'));
+      if (response.ok) {
+        const data = await response.json();
+        this.actList = data.acts;
+      } else {
+        log.error('Unable to get acts list');
+      }
+    },
+    async addAct(act: Partial<Act>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/act'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(act),
+      });
+      if (response.ok) {
+        await this.getActList();
+        toast.success('Added new act!');
+      } else {
+        log.error('Unable to add new act');
+        toast.error('Unable to add new act');
+      }
+    },
+    async updateAct(act: Partial<Act>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/act'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(act),
+      });
+      if (response.ok) {
+        await this.getActList();
+        toast.success('Updated act!');
+      } else {
+        log.error('Unable to edit act');
+        toast.error('Unable to edit act');
+      }
+    },
+    async deleteAct(id: number): Promise<void> {
+      const params = new URLSearchParams({ id: String(id) });
+      const response = await fetch(`${makeURL('/api/v1/show/act')}?${params}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (response.ok) {
+        await this.getActList();
+        toast.success('Deleted act!');
+      } else {
+        log.error('Unable to delete act');
+        toast.error('Unable to delete act');
+      }
+    },
+    async setActFirstScene(act: Partial<Act>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/act/first_scene'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(act),
+      });
+      if (response.ok) {
+        await this.getActList();
+        toast.success('Updated act!');
+      } else {
+        log.error('Unable to edit act');
+        toast.error('Unable to edit act');
+      }
+    },
+
+    // Scenes
+    async getSceneList(): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/scene'));
+      if (response.ok) {
+        const data = await response.json();
+        this.sceneList = data.scenes;
+      } else {
+        log.error('Unable to get scenes list');
+      }
+    },
+    async addScene(scene: Partial<Scene>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/scene'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(scene),
+      });
+      if (response.ok) {
+        await this.getSceneList();
+        await this.getActList();
+        toast.success('Added new scene!');
+      } else {
+        log.error('Unable to add new scene');
+        toast.error('Unable to add new scene');
+      }
+    },
+    async updateScene(scene: Partial<Scene>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/scene'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(scene),
+      });
+      if (response.ok) {
+        await this.getSceneList();
+        await this.getActList();
+        toast.success('Updated scene!');
+      } else {
+        log.error('Unable to edit scene');
+        toast.error('Unable to edit scene');
+      }
+    },
+    async deleteScene(id: number): Promise<void> {
+      const params = new URLSearchParams({ id: String(id) });
+      const response = await fetch(`${makeURL('/api/v1/show/scene')}?${params}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (response.ok) {
+        await this.getSceneList();
+        await this.getActList();
+        toast.success('Deleted scene!');
+      } else {
+        log.error('Unable to delete scene');
+        toast.error('Unable to delete scene');
+      }
+    },
+
+    // Cue Types
+    async getCueTypes(): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/cues/types'));
+      if (response.ok) {
+        const data = await response.json();
+        this.cueTypes = data.cue_types;
+      } else {
+        log.error('Unable to get cue types');
+      }
+    },
+    async addCueType(cueType: Partial<CueType>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/cues/types'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(cueType),
+      });
+      if (response.ok) {
+        await this.getCueTypes();
+        toast.success('Added new cue type!');
+      } else {
+        log.error('Unable to add new cue type');
+        toast.error('Unable to add new cue type');
+      }
+    },
+    async updateCueType(cueType: Partial<CueType>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/cues/types'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(cueType),
+      });
+      if (response.ok) {
+        await this.getCueTypes();
+        toast.success('Updated cue type!');
+      } else {
+        log.error('Unable to edit cue type');
+        toast.error('Unable to edit cue type');
+      }
+    },
+    async deleteCueType(id: number): Promise<void> {
+      const params = new URLSearchParams({ id: String(id) });
+      const response = await fetch(`${makeURL('/api/v1/show/cues/types')}?${params}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (response.ok) {
+        await this.getCueTypes();
+        toast.success('Deleted cue type!');
+      } else {
+        log.error('Unable to delete cue type');
+        toast.error('Unable to delete cue type');
+      }
+    },
+    async getImportableCueTypes(): Promise<unknown> {
+      const response = await fetch(makeURL('/api/v1/show/cues/types/import'));
+      if (!response.ok) {
+        log.error('Unable to fetch importable cue types');
+        throw new Error('Failed to fetch importable cue types');
+      }
+      return response.json();
+    },
+
+    // Sessions
+    async getShowSessionData(): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/sessions'));
+      if (response.ok) {
+        const data = await response.json();
+        this.sessions = data.sessions;
+        this.currentSession = data.current_session;
+        this.currentInterval = data.current_interval;
+      } else {
+        log.error('Unable to get show sessions');
+      }
+    },
+
+    // Microphones
+    async getMicrophoneList(): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/microphones'));
+      if (response.ok) {
+        const data = await response.json();
+        this.microphones = data.microphones;
+      } else {
+        log.error('Unable to get microphone list');
+      }
+    },
+    async addMicrophone(microphone: Partial<Microphone>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/microphones'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(microphone),
+      });
+      if (response.ok) {
+        await this.getMicrophoneList();
+        toast.success('Added new microphone!');
+      } else {
+        log.error('Unable to add new microphone');
+        toast.error('Unable to add new microphone');
+      }
+    },
+    async updateMicrophone(microphone: Partial<Microphone>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/microphones'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(microphone),
+      });
+      if (response.ok) {
+        await this.getMicrophoneList();
+        toast.success('Updated microphone!');
+      } else {
+        log.error('Unable to edit microphone');
+        toast.error('Unable to edit microphone');
+      }
+    },
+    async deleteMicrophone(id: number): Promise<void> {
+      const params = new URLSearchParams({ id: String(id) });
+      const response = await fetch(`${makeURL('/api/v1/show/microphones')}?${params}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (response.ok) {
+        await this.getMicrophoneList();
+        toast.success('Deleted microphone!');
+      } else {
+        log.error('Unable to delete microphone');
+        toast.error('Unable to delete microphone');
+      }
+    },
+    async getMicAllocations(): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/microphones/allocations'));
+      if (response.ok) {
+        const data = await response.json();
+        this.micAllocations = data.allocations;
+      } else {
+        log.error('Unable to get microphone allocations');
+      }
+    },
+    async updateMicAllocations(allocations: unknown): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/microphones/allocations'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(allocations),
+      });
+      if (response.ok) {
+        await this.getMicAllocations();
+        toast.success('Updated microphone allocations!');
+      } else {
+        log.error('Unable to edit microphone allocations');
+        toast.error('Unable to edit microphone allocations');
+      }
+    },
+
+    // Script Modes
+    async getScriptModes(): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/script_modes'));
+      if (response.ok) {
+        const data = await response.json();
+        this.scriptModes = data.script_modes ?? [];
+      } else {
+        log.error('Unable to fetch script modes');
+      }
+    },
+
+    // Session Tags
+    async getSessionTags(): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/session/tags'));
+      if (response.ok) {
+        const data = await response.json();
+        this.sessionTags = data.tags;
+      } else {
+        log.error('Unable to get session tags');
+      }
+    },
+    async addSessionTag(tag: Partial<SessionTag>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/session/tags'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(tag),
+      });
+      if (response.ok) {
+        await this.getSessionTags();
+        toast.success('Added new session tag!');
+      } else {
+        log.error('Unable to add session tag');
+        toast.error('Unable to add session tag');
+      }
+    },
+    async updateSessionTag(tag: Partial<SessionTag>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/session/tags'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(tag),
+      });
+      if (response.ok) {
+        await this.getSessionTags();
+        toast.success('Updated session tag!');
+      } else {
+        log.error('Unable to edit session tag');
+        toast.error('Unable to edit session tag');
+      }
+    },
+    async deleteSessionTag(id: number): Promise<void> {
+      const response = await fetch(`${makeURL('/api/v1/show/session/tags')}?id=${id}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (response.ok) {
+        await this.getSessionTags();
+        toast.success('Deleted session tag!');
+      } else {
+        log.error('Unable to delete session tag');
+        toast.error('Unable to delete session tag');
+      }
+    },
+    async getImportableSessionTags(): Promise<unknown> {
+      const response = await fetch(makeURL('/api/v1/show/session/tags/import'));
+      if (!response.ok) {
+        log.error('Unable to fetch importable session tags');
+        throw new Error('Failed to fetch importable session tags');
+      }
+      return response.json();
+    },
+    async updateSessionTags({
+      sessionId,
+      tagIds,
+    }: {
+      sessionId: number;
+      tagIds: number[];
+    }): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/sessions/assign-tags'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ session_id: sessionId, tag_ids: tagIds }),
+      });
+      if (response.ok) {
+        await this.getShowSessionData();
+        toast.success('Updated session tags!');
+      } else {
+        const errorData: { message?: string } = await response.json().catch(() => ({}));
+        log.error('Unable to update session tags:', errorData);
+        toast.error(errorData.message || 'Unable to update session tags');
+        throw new Error('Failed to update session tags');
+      }
+    },
+
+    clearCurrentShow(): void {
+      this.castList = [];
+      this.characterList = [];
+      this.actList = [];
+      this.sceneList = [];
+      this.sessionTags = [];
+    },
+
+    // WS-triggered actions
+    async electedLeader(): Promise<void> {
+      toast.info('You are now leader of the script - other clients will follow your view');
+    },
+    async noLeader(): Promise<void> {
+      await this.getShowSessionData();
+      toast.warning('There is no script leader. Please scroll your own script!');
+    },
+    scriptScroll(data: Record<string, unknown>): void {
+      this.sessionFollowData = data;
+    },
+  },
+});

--- a/client-v3/src/stores/system.ts
+++ b/client-v3/src/stores/system.ts
@@ -5,12 +5,6 @@ import type { Show } from '@/types/api/show';
 import type { SystemSettings } from '@/types/api/settings';
 import { useUserStore } from '@/stores/user';
 
-// ScriptMode moves to stores/show.ts in Phase 6
-interface ScriptMode {
-  value: number;
-  text: string;
-}
-
 interface ConnectedSession {
   internal_id: string;
   remote_ip: string;
@@ -51,7 +45,6 @@ export const useSystemStore = defineStore('system', {
     rbacRoles: [] as RbacRole[],
     settingsCategories: {} as Record<string, unknown>,
     currentShow: null as Show | null,
-    scriptModes: [] as ScriptMode[],
     connectedSessions: [] as ConnectedSession[],
     versionStatus: null as VersionStatus | null,
   }),
@@ -204,15 +197,6 @@ export const useSystemStore = defineStore('system', {
         this.settingsCategories = data.categories;
       } else {
         log.error('Unable to fetch settings categories');
-      }
-    },
-    async getScriptModes() {
-      const response = await fetch(makeURL('/api/v1/show/script_modes'));
-      if (response.ok) {
-        const data = await response.json();
-        this.scriptModes = data.script_modes ?? [];
-      } else {
-        log.error('Unable to fetch script modes');
       }
     },
     async getConnectedSessions() {

--- a/client-v3/src/views/show/ShowConfigView.vue
+++ b/client-v3/src/views/show/ShowConfigView.vue
@@ -1,0 +1,185 @@
+<template>
+  <div class="show">
+    <h1>{{ systemStore.currentShow?.name }}</h1>
+    <BContainer fluid class="mx-0 show-config-container">
+      <BRow>
+        <BCol cols="1">
+          <BButtonGroup vertical class="sticky-nav" :style="{ top: navbarHeight + 'px' }">
+            <BButton
+              :disabled="!shouldViewShowConfig"
+              replace
+              :to="{ name: 'show-config' }"
+              variant="outline-info"
+              exact-active-class="active"
+            >
+              Show
+            </BButton>
+            <BButton
+              :disabled="!shouldViewShowConfig"
+              replace
+              :to="{ name: 'show-config-stage' }"
+              variant="outline-info"
+              active-class="active"
+            >
+              Staging
+            </BButton>
+            <BButton
+              :disabled="!shouldViewShowConfig"
+              replace
+              :to="{ name: 'show-config-cast' }"
+              variant="outline-info"
+              active-class="active"
+            >
+              Cast
+            </BButton>
+            <BButton
+              :disabled="!shouldViewShowConfig"
+              replace
+              :to="{ name: 'show-config-characters' }"
+              variant="outline-info"
+              active-class="active"
+            >
+              Characters
+            </BButton>
+            <BButton
+              :disabled="!shouldViewShowConfig"
+              replace
+              :to="{ name: 'show-config-acts-scenes' }"
+              variant="outline-info"
+              active-class="active"
+            >
+              Acts & Scenes
+            </BButton>
+            <BButton
+              :disabled="!shouldShowScriptConfig"
+              replace
+              :to="{ name: 'show-config-script-revisions' }"
+              variant="outline-info"
+              active-class="active"
+            >
+              Revisions
+            </BButton>
+            <BButton
+              :disabled="!shouldShowScriptConfig"
+              replace
+              :to="{ name: 'show-config-script' }"
+              variant="outline-info"
+              active-class="active"
+            >
+              Script
+            </BButton>
+            <BButton
+              :disabled="!shouldShowCueConfig"
+              replace
+              :to="{ name: 'show-config-cues' }"
+              variant="outline-info"
+              active-class="active"
+            >
+              Cues
+            </BButton>
+            <BButton
+              :disabled="!shouldViewShowConfig"
+              replace
+              :to="{ name: 'show-config-mics' }"
+              variant="outline-info"
+              active-class="active"
+            >
+              Mics
+            </BButton>
+            <BButton
+              :disabled="!shouldShowSessionConfig"
+              replace
+              :to="{ name: 'show-sessions' }"
+              variant="outline-info"
+              active-class="active"
+            >
+              Sessions
+            </BButton>
+          </BButtonGroup>
+        </BCol>
+        <BCol cols="11">
+          <RouterView />
+        </BCol>
+      </BRow>
+    </BContainer>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onBeforeMount, onBeforeUnmount } from 'vue';
+import { useRouter } from 'vue-router';
+import { useSystemStore } from '@/stores/system';
+import { toast } from '@/js/toast';
+
+const router = useRouter();
+const systemStore = useSystemStore();
+
+const navbarHeight = ref(0);
+
+const shouldViewShowConfig = computed(() => systemStore.isShowEditor || systemStore.isShowReader);
+const shouldShowCueConfig = computed(
+  () => shouldViewShowConfig.value || systemStore.isCueEditor || systemStore.isCueReader
+);
+const shouldShowScriptConfig = computed(
+  () => shouldViewShowConfig.value || systemStore.isScriptEditor || systemStore.isScriptReader
+);
+const shouldShowSessionConfig = computed(
+  () => shouldViewShowConfig.value || systemStore.isShowExecutor
+);
+const requiresRedirect = computed(
+  () =>
+    !shouldViewShowConfig.value &&
+    !shouldShowCueConfig.value &&
+    !shouldShowScriptConfig.value &&
+    !shouldShowSessionConfig.value
+);
+
+onBeforeMount(() => {
+  if (!shouldViewShowConfig.value) {
+    if (shouldShowCueConfig.value) {
+      router.replace({ name: 'show-config-cues' });
+    } else if (shouldShowScriptConfig.value) {
+      // Fix V2 double-redirect bug — redirect to revisions only
+      router.replace({ name: 'show-config-script-revisions' });
+    } else if (shouldShowSessionConfig.value) {
+      router.replace({ name: 'show-sessions' });
+    } else {
+      toast.warning('Something went wrong viewing show config page');
+      router.replace('/');
+    }
+  }
+});
+
+watch(requiresRedirect, (val) => {
+  if (val) {
+    toast.warning('Something went wrong viewing show config page');
+    router.replace('/');
+  }
+});
+
+function calculateNavbarHeight(): void {
+  const navbar = document.querySelector('.navbar');
+  navbarHeight.value = navbar ? (navbar as HTMLElement).offsetHeight : 56;
+}
+
+onMounted(() => {
+  calculateNavbarHeight();
+  window.addEventListener('resize', calculateNavbarHeight);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', calculateNavbarHeight);
+});
+</script>
+
+<style scoped>
+.show-config-container {
+  position: relative;
+}
+
+.sticky-nav {
+  position: sticky;
+  padding: 10px 0;
+  background: var(--bs-body-bg);
+}
+</style>


### PR DESCRIPTION
## Summary

- **`stores/show.ts`** — full Pinia port of V2's 850-line Vuex show module: cast, characters, character groups, acts, scenes, cue types, sessions, microphones, mic allocations, script modes, session tags; `stageManagerMode` persisted via `pinia-plugin-persistedstate`
- **`js/micConflictUtils.ts`** — mic conflict detection utilities (verbatim copy from V2 `client/src/js/micConflictUtils.ts`)
- **`views/show/ShowConfigView.vue`** — sticky vertical `<BButtonGroup>` nav sidebar (col-1) + `<RouterView>` (col-11); permission-based button disabling; redirect logic for role-restricted users (fixes V2 double-redirect bug by redirecting only to `show-config-script-revisions`)
- **`router/index.ts`** — wire `/show-config` parent route to `ShowConfigView.vue` (was `PlaceholderView`)
- **`stores/system.ts`** — remove `scriptModes` state/action (moved to `show.ts`)
- **`components/config/ConfigShows.vue`** — update `scriptModes` source to `useShowStore()`
- **`composables/useWebSocket.ts`** — fill in `GET_CAST_LIST`, `ELECTED_LEADER`, `NO_LEADER`, `SCRIPT_SCROLL` WS action handlers

All child routes under `/show-config` remain as `PlaceholderView` — individual config sections are implemented in Phases 7–11.

## Test plan

- [ ] `npm run build` — no errors
- [ ] `npm run typecheck` — passes
- [ ] `npm run ci-lint` — passes
- [ ] Navigate to `/ui-new/show-config` as admin with a show loaded → sticky sidebar renders with 10 buttons; active route highlighted; content area shows PlaceholderView
- [ ] Admin without show loaded → redirected to `/` with toast
- [ ] User with cue-only access → redirected to cues section
- [ ] Admin config → Shows tab still creates shows correctly (scriptModes now from show store)
- [ ] Resize window → sticky sidebar `top` value updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)