### PR TITLE
Vue 3 migration: Phase 7 — show configuration basic tabs

### DIFF
--- a/client-v3/src/components/show/config/acts_and_scenes/ConfigActs.vue
+++ b/client-v3/src/components/show/config/acts_and_scenes/ConfigActs.vue
@@ -1,0 +1,346 @@
+<template>
+  <div v-if="!loading">
+    <BTable
+      id="acts-table"
+      :items="actTableItems"
+      :fields="actFields"
+      :per-page="rowsPerPage"
+      :current-page="currentPage"
+      show-empty
+    >
+      <template #head(btn)>
+        <BButton v-if="systemStore.isShowEditor" v-b-modal.new-act variant="outline-success">
+          New Act
+        </BButton>
+      </template>
+      <template #cell(interval_after)="data">
+        <BBadge :variant="data.item.interval_after ? 'success' : 'danger'">
+          {{ data.item.interval_after ? 'Yes' : 'No' }}
+        </BBadge>
+      </template>
+      <template #cell(next_act)="data">
+        <span v-if="data.item.next_act">{{ showStore.actById(data.item.next_act)?.name }}</span>
+        <span v-else>N/A</span>
+      </template>
+      <template #cell(previous_act)="data">
+        <span v-if="data.item.previous_act">{{
+          showStore.actById(data.item.previous_act)?.name
+        }}</span>
+        <span v-else>N/A</span>
+      </template>
+      <template #cell(btn)="data">
+        <BButtonGroup v-if="systemStore.isShowEditor">
+          <BButton
+            variant="warning"
+            :disabled="submittingEditAct || deletingAct"
+            @click="openEditForm(data.item)"
+          >
+            Edit
+          </BButton>
+          <BButton
+            variant="danger"
+            :disabled="submittingEditAct || deletingAct"
+            @click="deleteAct(data.item)"
+          >
+            Delete
+          </BButton>
+        </BButtonGroup>
+      </template>
+    </BTable>
+    <BPagination
+      v-show="actTableItems.length > rowsPerPage"
+      v-model="currentPage"
+      :total-rows="actTableItems.length"
+      :per-page="rowsPerPage"
+      aria-controls="acts-table"
+      class="justify-content-center"
+    />
+
+    <BModal
+      id="new-act"
+      ref="newActModal"
+      title="Add New Act"
+      size="md"
+      :ok-disabled="newV$.newFormState.$invalid || submittingNewAct"
+      @show="resetNewForm"
+      @hide="resetNewForm"
+      @ok="onSubmitNew"
+    >
+      <BForm @submit.stop.prevent="onSubmitNew">
+        <BFormGroup label="Name" label-for="new-name-input" label-cols="4">
+          <BFormInput
+            id="new-name-input"
+            v-model="newFormState.name"
+            :state="newFieldState('name')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Interval After" label-for="new-interval-input" label-cols="4">
+          <BFormCheckbox id="new-interval-input" v-model="newFormState.interval_after" />
+        </BFormGroup>
+        <BFormGroup label="Previous Act" label-for="new-previous-act-input" label-cols="4">
+          <BFormSelect
+            id="new-previous-act-input"
+            v-model="newFormState.previous_act_id"
+            :options="previousActOptions"
+          />
+        </BFormGroup>
+      </BForm>
+    </BModal>
+
+    <BModal
+      id="edit-act"
+      ref="editActModal"
+      title="Edit Act"
+      size="md"
+      :ok-disabled="editV$.editFormState.$invalid || submittingEditAct"
+      @hide="resetEditForm"
+      @ok="onSubmitEdit"
+    >
+      <BForm @submit.stop.prevent="onSubmitEdit">
+        <BFormGroup label="Name" label-for="edit-name-input" label-cols="4">
+          <BFormInput
+            id="edit-name-input"
+            v-model="editFormState.name"
+            :state="editFieldState('name')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Interval After" label-for="edit-interval-input" label-cols="4">
+          <BFormCheckbox id="edit-interval-input" v-model="editFormState.interval_after" />
+        </BFormGroup>
+        <BFormGroup label="Previous Act" label-for="edit-previous-act-input" label-cols="4">
+          <BFormSelect
+            id="edit-previous-act-input"
+            v-model="editFormState.previous_act_id"
+            :options="editFormActOptions"
+            :state="editFieldState('previous_act_id')"
+          />
+          <BFormInvalidFeedback
+            >This cannot form a circular dependency between acts.</BFormInvalidFeedback
+          >
+        </BFormGroup>
+      </BForm>
+    </BModal>
+  </div>
+  <div v-else class="text-center py-5">
+    <BSpinner label="Loading" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { useVuelidate } from '@vuelidate/core';
+import { required, helpers } from '@vuelidate/validators';
+import { BModal } from 'bootstrap-vue-next';
+import log from 'loglevel';
+import { useSystemStore } from '@/stores/system';
+import { useShowStore } from '@/stores/show';
+import { useConfirm } from '@/composables/useConfirm';
+import type { Act } from '@/types/api/show';
+
+const systemStore = useSystemStore();
+const showStore = useShowStore();
+const { confirm } = useConfirm();
+
+const loading = ref(true);
+const rowsPerPage = 15;
+const currentPage = ref(1);
+const submittingNewAct = ref(false);
+const submittingEditAct = ref(false);
+const deletingAct = ref(false);
+
+const newActModal = ref<InstanceType<typeof BModal>>();
+const editActModal = ref<InstanceType<typeof BModal>>();
+
+const actFields = [
+  'name',
+  { key: 'interval_after', label: 'Interval After' },
+  { key: 'previous_act', label: 'Previous Act' },
+  { key: 'next_act', label: 'Next Act' },
+  { key: 'btn', label: '' },
+];
+
+interface NewActForm {
+  name: string;
+  interval_after: boolean;
+  previous_act_id: number | null;
+}
+
+interface EditActForm {
+  id: number | null;
+  showID: number | null;
+  name: string;
+  interval_after: boolean;
+  previous_act_id: number | null;
+}
+
+const newFormState = ref<NewActForm>({ name: '', interval_after: false, previous_act_id: null });
+const editFormState = ref<EditActForm>({
+  id: null,
+  showID: null,
+  name: '',
+  interval_after: false,
+  previous_act_id: null,
+});
+
+const noActLoops = helpers.withMessage(
+  'This cannot form a circular dependency between acts',
+  (value: number | null) => {
+    if (value == null) return true;
+    const visited = new Set<number>();
+    visited.add(editFormState.value.id ?? -1);
+    let current = showStore.actById(value);
+    while (current != null && current.previous_act != null) {
+      if (visited.has(current.previous_act)) return false;
+      current = showStore.actById(current.previous_act);
+    }
+    return true;
+  }
+);
+
+const newRules = { newFormState: { name: { required } } };
+const editRules = {
+  editFormState: {
+    name: { required },
+    previous_act_id: { noActLoops },
+  },
+};
+
+const newV$ = useVuelidate(newRules, { newFormState });
+const editV$ = useVuelidate(editRules, { editFormState });
+
+const actTableItems = computed((): Act[] => {
+  const ret: Act[] = [];
+  const show = systemStore.currentShow;
+  if (show?.first_act_id != null && showStore.actList.length > 0) {
+    let act = showStore.actById(show.first_act_id);
+    while (act != null) {
+      ret.push(act);
+      act = showStore.actById(act.next_act);
+    }
+  }
+  const linkedIds = new Set(ret.map((a) => a.id));
+  for (const act of showStore.actList) {
+    if (!linkedIds.has(act.id)) ret.push(act);
+  }
+  return ret;
+});
+
+const previousActOptions = computed(() => [
+  { value: null, text: 'None', disabled: false },
+  ...showStore.actList
+    .filter((act) => act.next_act == null)
+    .map((act) => ({ value: act.id, text: act.name })),
+]);
+
+const editFormActOptions = computed(() => {
+  const base = previousActOptions.value.filter((opt) => opt.value !== editFormState.value.id);
+  if (
+    editFormState.value.previous_act_id != null &&
+    !base.find((o) => o.value === editFormState.value.previous_act_id)
+  ) {
+    const act = showStore.actById(editFormState.value.previous_act_id);
+    if (act) base.push({ value: act.id, text: act.name, disabled: false } as (typeof base)[0]);
+  }
+  return base;
+});
+
+function newFieldState(key: keyof NewActForm): boolean | null {
+  const field = newV$.value.newFormState[key];
+  if (!field) return null;
+  return field.$dirty ? !field.$error : null;
+}
+
+function editFieldState(key: keyof EditActForm): boolean | null {
+  const field = editV$.value.editFormState[key];
+  if (!field) return null;
+  return field.$dirty ? !field.$error : null;
+}
+
+function resetNewForm(): void {
+  newFormState.value = { name: '', interval_after: false, previous_act_id: null };
+  submittingNewAct.value = false;
+  newV$.value.$reset();
+}
+
+function resetEditForm(): void {
+  editFormState.value = {
+    id: null,
+    showID: null,
+    name: '',
+    interval_after: false,
+    previous_act_id: null,
+  };
+  submittingEditAct.value = false;
+  deletingAct.value = false;
+  editV$.value.$reset();
+}
+
+function openEditForm(act: Act): void {
+  editFormState.value.id = act.id;
+  editFormState.value.showID = act.show_id;
+  editFormState.value.name = act.name ?? '';
+  editFormState.value.interval_after = act.interval_after ?? false;
+  editFormState.value.previous_act_id = act.previous_act ?? null;
+  editActModal.value?.show();
+}
+
+async function onSubmitNew(event: Event): Promise<void> {
+  newV$.value.newFormState.$touch();
+  if (newV$.value.newFormState.$invalid || submittingNewAct.value) {
+    event.preventDefault();
+    return;
+  }
+  submittingNewAct.value = true;
+  try {
+    await showStore.addAct(newFormState.value);
+    newActModal.value?.hide();
+    resetNewForm();
+  } catch (error) {
+    log.error('Error submitting new act:', error);
+    event.preventDefault();
+  } finally {
+    submittingNewAct.value = false;
+  }
+}
+
+async function onSubmitEdit(event: Event): Promise<void> {
+  editV$.value.editFormState.$touch();
+  if (editV$.value.editFormState.$invalid || submittingEditAct.value) {
+    event.preventDefault();
+    return;
+  }
+  submittingEditAct.value = true;
+  try {
+    await showStore.updateAct(editFormState.value);
+    editActModal.value?.hide();
+    resetEditForm();
+  } catch (error) {
+    log.error('Error submitting edit act:', error);
+    event.preventDefault();
+  } finally {
+    submittingEditAct.value = false;
+  }
+}
+
+async function deleteAct(act: Act): Promise<void> {
+  if (deletingAct.value) return;
+  const ok = await confirm(`Are you sure you want to delete ${act.name}?`);
+  if (ok) {
+    deletingAct.value = true;
+    try {
+      await showStore.deleteAct(act.id);
+    } catch (error) {
+      log.error('Error deleting act:', error);
+    } finally {
+      deletingAct.value = false;
+    }
+  }
+}
+
+onMounted(async () => {
+  await showStore.getActList();
+  loading.value = false;
+});
+</script>

--- a/client-v3/src/components/show/config/acts_and_scenes/ConfigScenes.vue
+++ b/client-v3/src/components/show/config/acts_and_scenes/ConfigScenes.vue
@@ -1,0 +1,530 @@
+<template>
+  <BContainer v-if="!loading" class="mx-0" fluid>
+    <BRow>
+      <BCol cols="8">
+        <BTable
+          id="scene-table"
+          :items="sceneTableItems"
+          :fields="sceneFields"
+          :per-page="rowsPerPage"
+          :current-page="currentPage"
+          show-empty
+        >
+          <template #head(btn)>
+            <BButton v-if="systemStore.isShowEditor" v-b-modal.new-scene variant="outline-success">
+              New Scene
+            </BButton>
+          </template>
+          <template #cell(act)="data">
+            {{ showStore.actById(data.item.act)?.name }}
+          </template>
+          <template #cell(next_scene)="data">
+            <span v-if="data.item.next_scene">{{
+              showStore.sceneById(data.item.next_scene)?.name
+            }}</span>
+            <span v-else>N/A</span>
+          </template>
+          <template #cell(previous_scene)="data">
+            <span v-if="data.item.previous_scene">{{
+              showStore.sceneById(data.item.previous_scene)?.name
+            }}</span>
+            <span v-else>N/A</span>
+          </template>
+          <template #cell(btn)="data">
+            <BButtonGroup v-if="systemStore.isShowEditor">
+              <BButton
+                variant="warning"
+                :disabled="submittingEditScene || deletingScene"
+                @click="openEditForm(data.item)"
+              >
+                Edit
+              </BButton>
+              <BButton
+                variant="danger"
+                :disabled="submittingEditScene || deletingScene"
+                @click="deleteScene(data.item)"
+              >
+                Delete
+              </BButton>
+            </BButtonGroup>
+          </template>
+        </BTable>
+        <BPagination
+          v-show="sceneTableItems.length > rowsPerPage"
+          v-model="currentPage"
+          :total-rows="sceneTableItems.length"
+          :per-page="rowsPerPage"
+          aria-controls="scene-table"
+          class="justify-content-center"
+        />
+      </BCol>
+      <BCol cols="4">
+        <BTable
+          id="first-scenes-table"
+          :items="showStore.actList"
+          :fields="firstSceneFields"
+          show-empty
+        >
+          <template #cell(first_scene)="data">
+            <span v-if="data.item.first_scene">{{
+              showStore.sceneById(data.item.first_scene)?.name
+            }}</span>
+            <span v-else>N/A</span>
+          </template>
+          <template #cell(btn)="data">
+            <BButtonGroup v-if="systemStore.isShowEditor">
+              <BButton
+                variant="success"
+                :disabled="submittingFirstScene"
+                @click="openFirstSceneEdit(data.item)"
+              >
+                Set
+              </BButton>
+            </BButtonGroup>
+          </template>
+        </BTable>
+      </BCol>
+    </BRow>
+
+    <BModal
+      id="new-scene"
+      ref="newSceneModal"
+      title="Add New Scene"
+      size="md"
+      :ok-disabled="newV$.newFormState.$invalid || submittingNewScene"
+      @show="resetNewForm"
+      @hide="resetNewForm"
+      @ok="onSubmitNew"
+    >
+      <BForm @submit.stop.prevent="onSubmitNew">
+        <BFormGroup label="Name" label-for="new-name-input" label-cols="4">
+          <BFormInput
+            id="new-name-input"
+            v-model="newFormState.name"
+            :state="newFieldState('name')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Act" label-for="new-act-input" label-cols="4">
+          <BFormSelect
+            id="new-act-input"
+            v-model="newFormState.act_id"
+            :options="actOptions"
+            :state="newFieldState('act_id')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Previous Scene" label-for="new-previous-scene-input" label-cols="4">
+          <BFormSelect
+            id="new-previous-scene-input"
+            v-model="newFormState.previous_scene_id"
+            :options="previousSceneOptions[newFormState.act_id ?? 'null']"
+          />
+        </BFormGroup>
+      </BForm>
+    </BModal>
+
+    <BModal
+      id="edit-scene"
+      ref="editSceneModal"
+      title="Edit Scene"
+      size="md"
+      :ok-disabled="editV$.editFormState.$invalid || submittingEditScene"
+      @hide="resetEditForm"
+      @ok="onSubmitEdit"
+    >
+      <BForm @submit.stop.prevent="onSubmitEdit">
+        <BFormGroup label="Name" label-for="edit-name-input" label-cols="4">
+          <BFormInput
+            id="edit-name-input"
+            v-model="editFormState.name"
+            :state="editFieldState('name')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Act" label-for="edit-act-input" label-cols="4">
+          <BFormSelect
+            id="edit-act-input"
+            v-model="editFormState.act_id"
+            :options="actOptions"
+            :state="editFieldState('act_id')"
+            @update:model-value="editActChanged"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Previous Scene" label-for="edit-previous-scene-input" label-cols="4">
+          <BFormSelect
+            id="edit-previous-scene-input"
+            v-model="editFormState.previous_scene_id"
+            :options="editFormPrevScenes"
+            :state="editFieldState('previous_scene_id')"
+          />
+          <BFormInvalidFeedback
+            >This cannot form a circular dependency between scenes.</BFormInvalidFeedback
+          >
+        </BFormGroup>
+      </BForm>
+    </BModal>
+
+    <BModal
+      id="set-first-scene"
+      ref="firstSceneModal"
+      title="Set First Scene"
+      size="md"
+      :ok-disabled="submittingFirstScene"
+      @hide="resetFirstSceneForm"
+      @ok="onSubmitFirstScene"
+    >
+      <BForm @submit.stop.prevent="onSubmitFirstScene">
+        <BFormGroup :label="firstSceneModalLabel" label-for="first-scene-input" label-cols="4">
+          <BFormSelect
+            id="first-scene-input"
+            v-model="firstSceneFormState.scene_id"
+            :options="firstSceneOptions[firstSceneFormState.act_id ?? -1]"
+          />
+        </BFormGroup>
+      </BForm>
+    </BModal>
+  </BContainer>
+  <div v-else class="text-center py-5">
+    <BSpinner label="Loading" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { useVuelidate } from '@vuelidate/core';
+import { required, helpers } from '@vuelidate/validators';
+import { BModal } from 'bootstrap-vue-next';
+import log from 'loglevel';
+import { useSystemStore } from '@/stores/system';
+import { useShowStore } from '@/stores/show';
+import { useConfirm } from '@/composables/useConfirm';
+import type { Scene } from '@/types/api/show';
+
+const systemStore = useSystemStore();
+const showStore = useShowStore();
+const { confirm } = useConfirm();
+
+const loading = ref(true);
+const rowsPerPage = 15;
+const currentPage = ref(1);
+const submittingNewScene = ref(false);
+const submittingEditScene = ref(false);
+const submittingFirstScene = ref(false);
+const deletingScene = ref(false);
+const editSceneOriginalId = ref<number | null>(null);
+
+const newSceneModal = ref<InstanceType<typeof BModal>>();
+const editSceneModal = ref<InstanceType<typeof BModal>>();
+const firstSceneModal = ref<InstanceType<typeof BModal>>();
+
+const sceneFields = [
+  'name',
+  'act',
+  { key: 'previous_scene', label: 'Previous Scene' },
+  { key: 'next_scene', label: 'Next Scene' },
+  { key: 'btn', label: '' },
+];
+const firstSceneFields = [
+  { key: 'name', label: 'Act' },
+  { key: 'first_scene', label: 'First Scene' },
+  { key: 'btn', label: '' },
+];
+
+interface NewSceneForm {
+  name: string;
+  act_id: number | null;
+  previous_scene_id: number | null;
+}
+
+interface EditSceneForm {
+  scene_id: number | null;
+  name: string;
+  act_id: number | null;
+  previous_scene_id: number | null;
+}
+
+interface FirstSceneForm {
+  act_id: number | null;
+  scene_id: number | null;
+}
+
+const newFormState = ref<NewSceneForm>({ name: '', act_id: null, previous_scene_id: null });
+const editFormState = ref<EditSceneForm>({
+  scene_id: null,
+  name: '',
+  act_id: null,
+  previous_scene_id: null,
+});
+const firstSceneFormState = ref<FirstSceneForm>({ act_id: null, scene_id: null });
+
+const notNullAndGreaterThanZero = helpers.withMessage(
+  'This is a required field',
+  (val: number | null) => val != null && val > 0
+);
+
+const noSceneLoops = helpers.withMessage(
+  'This cannot form a circular dependency between scenes',
+  (value: number | null) => {
+    if (value == null) return true;
+    const visited = new Set<number>();
+    visited.add(editFormState.value.scene_id ?? -1);
+    let current = showStore.sceneById(value);
+    while (current != null && current.previous_scene != null) {
+      if (visited.has(current.previous_scene)) return false;
+      current = showStore.sceneById(current.previous_scene);
+    }
+    return true;
+  }
+);
+
+const newRules = {
+  newFormState: {
+    name: { required },
+    act_id: { notNullAndGreaterThanZero },
+  },
+};
+const editRules = {
+  editFormState: {
+    name: { required },
+    act_id: { notNullAndGreaterThanZero },
+    previous_scene_id: { noSceneLoops },
+  },
+};
+
+const newV$ = useVuelidate(newRules, { newFormState });
+const editV$ = useVuelidate(editRules, { editFormState });
+
+const sceneTableItems = computed((): Scene[] => {
+  const show = systemStore.currentShow;
+  const actOrder: number[] = [];
+  if (show?.first_act_id != null && showStore.actList.length > 0) {
+    let act = showStore.actById(show.first_act_id);
+    while (act != null) {
+      actOrder.push(act.id);
+      act = showStore.actById(act.next_act);
+    }
+  }
+  for (const act of showStore.actList) {
+    if (!actOrder.includes(act.id)) actOrder.push(act.id);
+  }
+
+  const ret: Scene[] = [];
+  for (const actId of actOrder) {
+    const act = showStore.actById(actId);
+    if (act?.first_scene != null) {
+      let scene = showStore.sceneById(act.first_scene);
+      while (scene != null) {
+        ret.push(scene);
+        scene = showStore.sceneById(scene.next_scene);
+      }
+    }
+    const linked = new Set(ret.map((s) => s.id));
+    for (const scene of showStore.sceneList.filter((s) => s.act === actId)) {
+      if (!linked.has(scene.id)) ret.push(scene);
+    }
+  }
+  return ret;
+});
+
+const actOptions = computed(() => [
+  { value: null, text: 'Please select an option', disabled: true },
+  ...showStore.actList.map((act) => ({ value: act.id, text: act.name })),
+]);
+
+const previousSceneOptions = computed(
+  (): Record<string | number, { value: number | null; text: string }[]> => {
+    const ret: Record<string | number, { value: number | null; text: string }[]> = {
+      null: [{ value: null, text: 'None' }],
+    };
+    for (const act of showStore.actList) {
+      ret[act.id] = [
+        { value: null, text: 'None' },
+        ...showStore.sceneList
+          .filter((scene) => scene.act === act.id && scene.next_scene == null)
+          .map((scene) => ({
+            value: scene.id,
+            text: `${showStore.actById(scene.act)?.name ?? ''}: ${scene.name ?? ''}`,
+          })),
+      ];
+    }
+    return ret;
+  }
+);
+
+const editFormPrevScenes = computed(() => {
+  const actId = editFormState.value.act_id;
+  const base = (
+    previousSceneOptions.value[actId ?? 'null'] ?? [{ value: null, text: 'None' }]
+  ).filter((opt) => opt.value !== editFormState.value.scene_id);
+  if (
+    editFormState.value.previous_scene_id != null &&
+    !base.find((o) => o.value === editFormState.value.previous_scene_id)
+  ) {
+    const scene = showStore.sceneById(editFormState.value.previous_scene_id);
+    if (scene) {
+      base.push({
+        value: scene.id,
+        text: `${showStore.actById(scene.act)?.name ?? ''}: ${scene.name ?? ''}`,
+      });
+    }
+  }
+  return base;
+});
+
+const firstSceneOptions = computed((): Record<number, { value: number | null; text: string }[]> => {
+  const ret: Record<number, { value: number | null; text: string }[]> = {};
+  for (const act of showStore.actList) {
+    ret[act.id] = [
+      { value: null, text: 'None' },
+      ...showStore.sceneList
+        .filter((scene) => scene.act === act.id && scene.previous_scene == null)
+        .map((scene) => ({
+          value: scene.id,
+          text: `${act.name ?? ''}: ${scene.name ?? ''}`,
+        })),
+    ];
+  }
+  return ret;
+});
+
+const firstSceneModalLabel = computed(() => {
+  if (firstSceneFormState.value.act_id == null) return '';
+  const act = showStore.actById(firstSceneFormState.value.act_id);
+  return `${act?.name ?? ''} First Scene`;
+});
+
+function newFieldState(key: keyof NewSceneForm): boolean | null {
+  const field = newV$.value.newFormState[key];
+  if (!field) return null;
+  return field.$dirty ? !field.$error : null;
+}
+
+function editFieldState(key: keyof EditSceneForm): boolean | null {
+  const field = editV$.value.editFormState[key];
+  if (!field) return null;
+  return field.$dirty ? !field.$error : null;
+}
+
+function resetNewForm(): void {
+  newFormState.value = { name: '', act_id: null, previous_scene_id: null };
+  submittingNewScene.value = false;
+  newV$.value.$reset();
+}
+
+function resetEditForm(): void {
+  editSceneOriginalId.value = null;
+  editFormState.value = { scene_id: null, name: '', act_id: null, previous_scene_id: null };
+  submittingEditScene.value = false;
+  deletingScene.value = false;
+  editV$.value.$reset();
+}
+
+function resetFirstSceneForm(): void {
+  firstSceneFormState.value = { act_id: null, scene_id: null };
+  submittingFirstScene.value = false;
+}
+
+function openEditForm(scene: Scene): void {
+  editSceneOriginalId.value = scene.id;
+  editFormState.value.scene_id = scene.id;
+  editFormState.value.name = scene.name ?? '';
+  editFormState.value.act_id = scene.act;
+  editFormState.value.previous_scene_id = scene.previous_scene ?? null;
+  editSceneModal.value?.show();
+}
+
+function openFirstSceneEdit(act: { id: number; first_scene: number | null }): void {
+  firstSceneFormState.value.act_id = act.id;
+  firstSceneFormState.value.scene_id = act.first_scene ?? null;
+  firstSceneModal.value?.show();
+}
+
+function editActChanged(newActId: number | null): void {
+  const originalScene =
+    editSceneOriginalId.value != null ? showStore.sceneById(editSceneOriginalId.value) : null;
+  if (newActId !== originalScene?.act) {
+    editFormState.value.previous_scene_id = null;
+  } else {
+    editFormState.value.previous_scene_id = originalScene?.previous_scene ?? null;
+  }
+}
+
+async function onSubmitNew(event: Event): Promise<void> {
+  newV$.value.newFormState.$touch();
+  if (newV$.value.newFormState.$invalid || submittingNewScene.value) {
+    event.preventDefault();
+    return;
+  }
+  submittingNewScene.value = true;
+  try {
+    await showStore.addScene(newFormState.value);
+    newSceneModal.value?.hide();
+    resetNewForm();
+  } catch (error) {
+    log.error('Error submitting new scene:', error);
+    event.preventDefault();
+  } finally {
+    submittingNewScene.value = false;
+  }
+}
+
+async function onSubmitEdit(event: Event): Promise<void> {
+  editV$.value.editFormState.$touch();
+  if (editV$.value.editFormState.$invalid || submittingEditScene.value) {
+    event.preventDefault();
+    return;
+  }
+  submittingEditScene.value = true;
+  try {
+    await showStore.updateScene(editFormState.value);
+    editSceneModal.value?.hide();
+    resetEditForm();
+  } catch (error) {
+    log.error('Error submitting edit scene:', error);
+    event.preventDefault();
+  } finally {
+    submittingEditScene.value = false;
+  }
+}
+
+async function onSubmitFirstScene(event: Event): Promise<void> {
+  if (submittingFirstScene.value) {
+    event.preventDefault();
+    return;
+  }
+  submittingFirstScene.value = true;
+  try {
+    await showStore.setActFirstScene(firstSceneFormState.value);
+    firstSceneModal.value?.hide();
+    resetFirstSceneForm();
+  } catch (error) {
+    log.error('Error submitting first scene:', error);
+    event.preventDefault();
+  } finally {
+    submittingFirstScene.value = false;
+  }
+}
+
+async function deleteScene(scene: Scene): Promise<void> {
+  if (deletingScene.value) return;
+  const ok = await confirm(`Are you sure you want to delete ${scene.name}?`);
+  if (ok) {
+    deletingScene.value = true;
+    try {
+      await showStore.deleteScene(scene.id);
+    } catch (error) {
+      log.error('Error deleting scene:', error);
+    } finally {
+      deletingScene.value = false;
+    }
+  }
+}
+
+onMounted(async () => {
+  await showStore.getSceneList();
+  await showStore.getActList();
+  loading.value = false;
+});
+</script>

--- a/client-v3/src/components/show/config/cast/CastLineStats.vue
+++ b/client-v3/src/components/show/config/cast/CastLineStats.vue
@@ -1,0 +1,100 @@
+<template>
+  <BContainer class="mx-0 px-0" fluid>
+    <BRow>
+      <BCol>
+        <div v-if="!loaded" class="text-center center-spinner">
+          <BSpinner style="width: 10rem; height: 10rem" variant="info" />
+        </div>
+        <template v-else-if="sortedScenes.length > 0">
+          <BTable
+            :items="tableData"
+            :fields="tableFields"
+            responsive
+            show-empty
+            sticky-header="65vh"
+          >
+            <template #thead-top>
+              <BTr>
+                <BTh colspan="1">
+                  <span class="visually-hidden">Cast</span>
+                </BTh>
+                <template v-for="act in sortedActs" :key="act.id">
+                  <BTh
+                    v-if="numScenesPerAct(act.id) > 0"
+                    variant="primary"
+                    :colspan="numScenesPerAct(act.id)"
+                    class="act-header"
+                  >
+                    {{ act.name }}
+                  </BTh>
+                </template>
+              </BTr>
+            </template>
+            <template v-for="scene in sortedScenes" :key="scene.id" #[getHeaderName(scene.id)]>
+              {{ scene.name }}
+            </template>
+            <template #cell(Cast)="data">
+              {{ showStore.castById(data.item.Cast)?.first_name }}
+              {{ showStore.castById(data.item.Cast)?.last_name }}
+            </template>
+            <template v-for="scene in sortedScenes" :key="scene.id" #[getCellName(scene.id)]="data">
+              <template v-if="getLineCountForCast(data.item.Cast, scene.act, scene.id) > 0">
+                {{ getLineCountForCast(data.item.Cast, scene.act, scene.id) }}
+              </template>
+            </template>
+          </BTable>
+        </template>
+        <b v-else>Unable to get line counts. Ensure act and scene ordering is set.</b>
+      </BCol>
+    </BRow>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import log from 'loglevel';
+import { makeURL } from '@/js/utils';
+import { useShowStore } from '@/stores/show';
+import { useStatsTable } from '@/composables/useStatsTable';
+
+const showStore = useShowStore();
+const { sortedActs, sortedScenes, numScenesPerAct, getHeaderName, getCellName } = useStatsTable();
+
+const loaded = ref(false);
+const castStats = ref<Record<string, unknown>>({});
+
+const tableData = computed(() => {
+  if (!loaded.value) return [];
+  return showStore.castList.map((cast) => ({ Cast: cast.id }));
+});
+
+const tableFields = computed(() => [
+  'Cast',
+  ...sortedScenes.value.map((scene) => scene.id.toString()),
+]);
+
+async function getStats(): Promise<void> {
+  const response = await fetch(makeURL('/api/v1/show/cast/stats'));
+  if (response.ok) {
+    castStats.value = await response.json();
+  } else {
+    log.error('Unable to get cast stats!');
+  }
+}
+
+function getLineCountForCast(castId: number, actId: number | null, sceneId: number): number {
+  const lineCounts = (castStats.value as Record<string, unknown>).line_counts as
+    | Record<string, Record<string, Record<string, number>>>
+    | undefined;
+  if (!lineCounts) return 0;
+  return lineCounts[castId]?.[actId ?? '']?.[sceneId] ?? 0;
+}
+
+onMounted(async () => {
+  await showStore.getActList();
+  await showStore.getSceneList();
+  await showStore.getCastList();
+  await getStats();
+  loaded.value = true;
+});
+</script>

--- a/client-v3/src/components/show/config/characters/CharacterGroups.vue
+++ b/client-v3/src/components/show/config/characters/CharacterGroups.vue
@@ -1,0 +1,289 @@
+<template>
+  <span v-if="!loading">
+    <BTable
+      id="character-group-table"
+      :items="showStore.characterGroupList"
+      :fields="characterGroupFields"
+      :per-page="rowsPerPage"
+      :current-page="currentPage"
+      show-empty
+    >
+      <template #head(btn)>
+        <BButton
+          v-if="systemStore.isShowEditor"
+          v-b-modal.new-character-group
+          variant="outline-success"
+        >
+          New Character Group
+        </BButton>
+      </template>
+      <template #cell(characters)="data">
+        <div style="overflow-wrap: break-word">
+          <p>
+            {{
+              showStore.characterList
+                .filter((c) => data.item.characters.includes(c.id))
+                .map((c) => c.name)
+                .join(', ')
+            }}
+          </p>
+        </div>
+      </template>
+      <template #cell(btn)="data">
+        <BButtonGroup v-if="systemStore.isShowEditor">
+          <BButton
+            variant="warning"
+            :disabled="submittingEditGroup || deletingGroup"
+            @click="openEditForm(data.item)"
+          >
+            Edit
+          </BButton>
+          <BButton
+            variant="danger"
+            :disabled="submittingEditGroup || deletingGroup"
+            @click="deleteCharacterGroup(data.item)"
+          >
+            Delete
+          </BButton>
+        </BButtonGroup>
+      </template>
+    </BTable>
+    <BPagination
+      v-show="showStore.characterGroupList.length > rowsPerPage"
+      v-model="currentPage"
+      :total-rows="showStore.characterGroupList.length"
+      :per-page="rowsPerPage"
+      aria-controls="character-group-table"
+      class="justify-content-center"
+    />
+
+    <BModal
+      id="new-character-group"
+      ref="newGroupModal"
+      title="Add New Character Group"
+      size="md"
+      :ok-disabled="newV$.newFormState.$invalid || submittingNewGroup"
+      @show="resetNewForm"
+      @hide="resetNewForm"
+      @ok="onSubmitNew"
+    >
+      <BForm @submit.stop.prevent="onSubmitNew">
+        <BFormGroup label="Name" label-for="new-name-input" label-cols="4">
+          <BFormInput
+            id="new-name-input"
+            v-model="newFormState.name"
+            :state="newFieldState('name')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Description" label-for="new-description-input" label-cols="4">
+          <BFormInput id="new-description-input" v-model="newFormState.description" />
+        </BFormGroup>
+        <BFormGroup label="Characters" label-for="new-characters-input" label-cols="4">
+          <VueMultiselect
+            v-model="newCharacterObjects"
+            :multiple="true"
+            :options="showStore.characterList"
+            track-by="id"
+            label="name"
+          />
+        </BFormGroup>
+      </BForm>
+    </BModal>
+
+    <BModal
+      id="edit-character-group"
+      ref="editGroupModal"
+      title="Edit Character Group"
+      size="md"
+      :ok-disabled="editV$.editFormState.$invalid || submittingEditGroup"
+      @hide="resetEditForm"
+      @ok="onSubmitEdit"
+    >
+      <BForm @submit.stop.prevent="onSubmitEdit">
+        <BFormGroup label="Name" label-for="edit-name-input" label-cols="4">
+          <BFormInput
+            id="edit-name-input"
+            v-model="editFormState.name"
+            :state="editFieldState('name')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Description" label-for="edit-description-input" label-cols="4">
+          <BFormInput id="edit-description-input" v-model="editFormState.description" />
+        </BFormGroup>
+        <BFormGroup label="Characters" label-for="edit-characters-input" label-cols="4">
+          <VueMultiselect
+            v-model="editCharacterObjects"
+            :multiple="true"
+            :options="showStore.characterList"
+            track-by="id"
+            label="name"
+          />
+        </BFormGroup>
+      </BForm>
+    </BModal>
+  </span>
+  <div v-else class="text-center py-5">
+    <BSpinner label="Loading" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useVuelidate } from '@vuelidate/core';
+import { required } from '@vuelidate/validators';
+import { BModal } from 'bootstrap-vue-next';
+import VueMultiselect from 'vue-multiselect';
+import 'vue-multiselect/dist/vue-multiselect.css';
+import log from 'loglevel';
+import { useSystemStore } from '@/stores/system';
+import { useShowStore } from '@/stores/show';
+import { useConfirm } from '@/composables/useConfirm';
+import type { Character, CharacterGroup } from '@/types/api/show';
+
+const systemStore = useSystemStore();
+const showStore = useShowStore();
+const { confirm } = useConfirm();
+
+const loading = ref(true);
+const rowsPerPage = 15;
+const currentPage = ref(1);
+const submittingNewGroup = ref(false);
+const submittingEditGroup = ref(false);
+const deletingGroup = ref(false);
+
+const newGroupModal = ref<InstanceType<typeof BModal>>();
+const editGroupModal = ref<InstanceType<typeof BModal>>();
+
+const characterGroupFields = ['name', 'description', 'characters', { key: 'btn', label: '' }];
+
+interface NewGroupForm {
+  name: string;
+  description: string;
+  characters: number[];
+}
+
+interface EditGroupForm {
+  id: number | null;
+  name: string;
+  description: string;
+  characters: number[];
+}
+
+const newFormState = ref<NewGroupForm>({ name: '', description: '', characters: [] });
+const editFormState = ref<EditGroupForm>({ id: null, name: '', description: '', characters: [] });
+
+const newCharacterObjects = ref<Character[]>([]);
+const editCharacterObjects = ref<Character[]>([]);
+
+const newRules = { newFormState: { name: { required } } };
+const editRules = { editFormState: { name: { required } } };
+
+const newV$ = useVuelidate(newRules, { newFormState });
+const editV$ = useVuelidate(editRules, { editFormState });
+
+function newFieldState(key: keyof NewGroupForm): boolean | null {
+  const field = newV$.value.newFormState[key];
+  if (!field) return null;
+  return field.$dirty ? !field.$error : null;
+}
+
+function editFieldState(key: keyof EditGroupForm): boolean | null {
+  const field = editV$.value.editFormState[key];
+  if (!field) return null;
+  return field.$dirty ? !field.$error : null;
+}
+
+function resetNewForm(): void {
+  newCharacterObjects.value = [];
+  newFormState.value = { name: '', description: '', characters: [] };
+  submittingNewGroup.value = false;
+  newV$.value.$reset();
+}
+
+function resetEditForm(): void {
+  editCharacterObjects.value = [];
+  editFormState.value = { id: null, name: '', description: '', characters: [] };
+  submittingEditGroup.value = false;
+  deletingGroup.value = false;
+  editV$.value.$reset();
+}
+
+function openEditForm(group: CharacterGroup): void {
+  editFormState.value.id = group.id;
+  editFormState.value.name = group.name ?? '';
+  editFormState.value.description = group.description ?? '';
+  editFormState.value.characters = group.characters;
+  editCharacterObjects.value = showStore.characterList.filter((c) =>
+    group.characters.includes(c.id)
+  );
+  editGroupModal.value?.show();
+}
+
+async function onSubmitNew(event: Event): Promise<void> {
+  newV$.value.newFormState.$touch();
+  if (newV$.value.newFormState.$invalid || submittingNewGroup.value) {
+    event.preventDefault();
+    return;
+  }
+  submittingNewGroup.value = true;
+  try {
+    const payload = {
+      ...newFormState.value,
+      characters: newCharacterObjects.value.map((c) => c.id),
+    };
+    await showStore.addCharacterGroup(payload);
+    newGroupModal.value?.hide();
+    resetNewForm();
+  } catch (error) {
+    log.error('Error submitting new character group:', error);
+    event.preventDefault();
+  } finally {
+    submittingNewGroup.value = false;
+  }
+}
+
+async function onSubmitEdit(event: Event): Promise<void> {
+  editV$.value.editFormState.$touch();
+  if (editV$.value.editFormState.$invalid || submittingEditGroup.value) {
+    event.preventDefault();
+    return;
+  }
+  submittingEditGroup.value = true;
+  try {
+    const payload = {
+      ...editFormState.value,
+      characters: editCharacterObjects.value.map((c) => c.id),
+    };
+    await showStore.updateCharacterGroup(payload);
+    editGroupModal.value?.hide();
+    resetEditForm();
+  } catch (error) {
+    log.error('Error submitting edit character group:', error);
+    event.preventDefault();
+  } finally {
+    submittingEditGroup.value = false;
+  }
+}
+
+async function deleteCharacterGroup(group: CharacterGroup): Promise<void> {
+  if (deletingGroup.value) return;
+  const ok = await confirm(`Are you sure you want to delete ${group.name}?`);
+  if (ok) {
+    deletingGroup.value = true;
+    try {
+      await showStore.deleteCharacterGroup(group.id);
+    } catch (error) {
+      log.error('Error deleting character group:', error);
+    } finally {
+      deletingGroup.value = false;
+    }
+  }
+}
+
+onMounted(async () => {
+  await Promise.all([showStore.getCharacterList(), showStore.getCharacterGroupList()]);
+  loading.value = false;
+});
+</script>

--- a/client-v3/src/components/show/config/characters/CharacterLineStats.vue
+++ b/client-v3/src/components/show/config/characters/CharacterLineStats.vue
@@ -1,0 +1,105 @@
+<template>
+  <BContainer class="mx-0 px-0" fluid>
+    <BRow>
+      <BCol>
+        <div v-if="!loaded" class="text-center center-spinner">
+          <BSpinner style="width: 10rem; height: 10rem" variant="info" />
+        </div>
+        <template v-else-if="sortedScenes.length > 0">
+          <BTable
+            :items="tableData"
+            :fields="tableFields"
+            responsive
+            show-empty
+            sticky-header="65vh"
+          >
+            <template #thead-top>
+              <BTr>
+                <BTh colspan="1">
+                  <span class="visually-hidden">Character</span>
+                </BTh>
+                <template v-for="act in sortedActs" :key="act.id">
+                  <BTh
+                    v-if="numScenesPerAct(act.id) > 0"
+                    variant="primary"
+                    :colspan="numScenesPerAct(act.id)"
+                    class="act-header"
+                  >
+                    {{ act.name }}
+                  </BTh>
+                </template>
+              </BTr>
+            </template>
+            <template v-for="scene in sortedScenes" :key="scene.id" #[getHeaderName(scene.id)]>
+              {{ scene.name }}
+            </template>
+            <template #cell(Character)="data">
+              {{ showStore.characterById(data.item.Character)?.name }}
+            </template>
+            <template v-for="scene in sortedScenes" :key="scene.id" #[getCellName(scene.id)]="data">
+              <template
+                v-if="getLineCountForCharacter(data.item.Character, scene.act, scene.id) > 0"
+              >
+                {{ getLineCountForCharacter(data.item.Character, scene.act, scene.id) }}
+              </template>
+            </template>
+          </BTable>
+        </template>
+        <b v-else>Unable to get line counts. Ensure act and scene ordering is set.</b>
+      </BCol>
+    </BRow>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import log from 'loglevel';
+import { makeURL } from '@/js/utils';
+import { useShowStore } from '@/stores/show';
+import { useStatsTable } from '@/composables/useStatsTable';
+
+const showStore = useShowStore();
+const { sortedActs, sortedScenes, numScenesPerAct, getHeaderName, getCellName } = useStatsTable();
+
+const loaded = ref(false);
+const characterStats = ref<Record<string, unknown>>({});
+
+const tableData = computed(() => {
+  if (!loaded.value) return [];
+  return showStore.characterList.map((character) => ({ Character: character.id }));
+});
+
+const tableFields = computed(() => [
+  'Character',
+  ...sortedScenes.value.map((scene) => scene.id.toString()),
+]);
+
+async function getStats(): Promise<void> {
+  const response = await fetch(makeURL('/api/v1/show/character/stats'));
+  if (response.ok) {
+    characterStats.value = await response.json();
+  } else {
+    log.error('Unable to get character stats!');
+  }
+}
+
+function getLineCountForCharacter(
+  characterId: number,
+  actId: number | null,
+  sceneId: number
+): number {
+  const lineCounts = (characterStats.value as Record<string, unknown>).line_counts as
+    | Record<string, Record<string, Record<string, number>>>
+    | undefined;
+  if (!lineCounts) return 0;
+  return lineCounts[characterId]?.[actId ?? '']?.[sceneId] ?? 0;
+}
+
+onMounted(async () => {
+  await showStore.getActList();
+  await showStore.getSceneList();
+  await showStore.getCharacterList();
+  await getStats();
+  loaded.value = true;
+});
+</script>

--- a/client-v3/src/composables/useStatsTable.ts
+++ b/client-v3/src/composables/useStatsTable.ts
@@ -1,0 +1,52 @@
+import { computed } from 'vue';
+import { useSystemStore } from '@/stores/system';
+import { useShowStore } from '@/stores/show';
+import type { Act, Scene } from '@/types/api/show';
+
+export function useStatsTable() {
+  const systemStore = useSystemStore();
+  const showStore = useShowStore();
+
+  const sortedActs = computed((): Act[] => {
+    const show = systemStore.currentShow;
+    if (show?.first_act_id == null) return [];
+    let current = showStore.actById(show.first_act_id);
+    const acts: Act[] = [];
+    while (current != null) {
+      acts.push(current);
+      current = showStore.actById(current.next_act);
+    }
+    return acts;
+  });
+
+  const sortedScenes = computed((): Scene[] => {
+    const show = systemStore.currentShow;
+    if (show?.first_act_id == null) return [];
+    let currentAct = showStore.actById(show.first_act_id);
+    if (currentAct == null || currentAct.first_scene == null) return [];
+    const scenes: Scene[] = [];
+    while (currentAct != null) {
+      let currentScene = showStore.sceneById(currentAct.first_scene);
+      while (currentScene != null) {
+        scenes.push(currentScene);
+        currentScene = showStore.sceneById(currentScene.next_scene);
+      }
+      currentAct = showStore.actById(currentAct.next_act);
+    }
+    return scenes;
+  });
+
+  function numScenesPerAct(actId: number): number {
+    return sortedScenes.value.filter((scene) => scene.act === actId).length;
+  }
+
+  function getHeaderName(sceneId: number): string {
+    return `head(${sceneId})`;
+  }
+
+  function getCellName(sceneId: number): string {
+    return `cell(${sceneId})`;
+  }
+
+  return { sortedActs, sortedScenes, numScenesPerAct, getHeaderName, getCellName };
+}

--- a/client-v3/src/router/index.ts
+++ b/client-v3/src/router/index.ts
@@ -45,13 +45,13 @@ const router = createRouter({
         {
           name: 'show-config',
           path: '',
-          component: PlaceholderView,
+          component: () => import('@/views/show/config/ConfigShow.vue'),
           meta: { requiresAuth: true, requiresShowAccess: true },
         },
         {
           name: 'show-config-cast',
           path: 'cast',
-          component: PlaceholderView,
+          component: () => import('@/views/show/config/ConfigCast.vue'),
           meta: { requiresAuth: true, requiresShowAccess: true },
         },
         {
@@ -63,13 +63,13 @@ const router = createRouter({
         {
           name: 'show-config-characters',
           path: 'characters',
-          component: PlaceholderView,
+          component: () => import('@/views/show/config/ConfigCharacters.vue'),
           meta: { requiresAuth: true, requiresShowAccess: true },
         },
         {
           name: 'show-config-acts-scenes',
           path: 'acts',
-          component: PlaceholderView,
+          component: () => import('@/views/show/config/ConfigActsAndScenes.vue'),
           meta: { requiresAuth: true, requiresShowAccess: true },
         },
         {

--- a/client-v3/src/stores/system.ts
+++ b/client-v3/src/stores/system.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia';
 import log from 'loglevel';
 import { makeURL } from '@/js/utils';
+import { toast } from '@/js/toast';
 import type { Show } from '@/types/api/show';
 import type { SystemSettings } from '@/types/api/settings';
 import { useUserStore } from '@/stores/user';
@@ -179,6 +180,28 @@ export const useSystemStore = defineStore('system', {
         }
       } else {
         this.currentShow = null;
+      }
+    },
+    async getShowDetails(): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show'));
+      if (response.ok) {
+        this.currentShow = await response.json();
+      } else {
+        log.error('Unable to get show details');
+      }
+    },
+    async updateShow(showDetails: Partial<Show>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(showDetails),
+      });
+      if (response.ok) {
+        await this.getShowDetails();
+        toast.success('Updated show!');
+      } else {
+        log.error('Unable to edit show');
+        toast.error('Unable to edit show');
       }
     },
     async getRbacRoles() {

--- a/client-v3/src/types/api/show.ts
+++ b/client-v3/src/types/api/show.ts
@@ -32,9 +32,10 @@ export interface CharacterGroup {
   show_id: number | null;
   name: string | null;
   description: string | null;
+  characters: number[];
 }
 
-// first_scene and next_act are serialized as IDs by the marshmallow schema
+// first_scene, next_act, and previous_act are serialized as IDs by the marshmallow schema
 export interface Act {
   id: number;
   show_id: number | null;
@@ -42,13 +43,15 @@ export interface Act {
   interval_after: boolean | null;
   first_scene: number | null;
   next_act: number | null;
+  previous_act: number | null;
 }
 
-// act and next_scene are serialized as IDs by the marshmallow schema
+// act, next_scene, and previous_scene are serialized as IDs by the marshmallow schema
 export interface Scene {
   id: number;
   show_id: number | null;
   act: number | null;
   name: string | null;
   next_scene: number | null;
+  previous_scene: number | null;
 }

--- a/client-v3/src/views/show/config/ConfigActsAndScenes.vue
+++ b/client-v3/src/views/show/config/ConfigActsAndScenes.vue
@@ -1,0 +1,21 @@
+<template>
+  <BContainer class="mx-0" fluid>
+    <BRow>
+      <BCol>
+        <BTabs content-class="mt-3">
+          <BTab title="Acts" active>
+            <ConfigActs />
+          </BTab>
+          <BTab title="Scenes">
+            <ConfigScenes />
+          </BTab>
+        </BTabs>
+      </BCol>
+    </BRow>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import ConfigActs from '@/components/show/config/acts_and_scenes/ConfigActs.vue';
+import ConfigScenes from '@/components/show/config/acts_and_scenes/ConfigScenes.vue';
+</script>

--- a/client-v3/src/views/show/config/ConfigCast.vue
+++ b/client-v3/src/views/show/config/ConfigCast.vue
@@ -1,0 +1,257 @@
+<template>
+  <BContainer class="mx-0" fluid>
+    <BRow>
+      <BCol>
+        <BTabs content-class="mt-3">
+          <BTab title="Cast List" active>
+            <BTable
+              id="cast-table"
+              :items="showStore.castList"
+              :fields="castFields"
+              :per-page="rowsPerPage"
+              :current-page="currentPage"
+              show-empty
+            >
+              <template #head(btn)>
+                <BButton
+                  v-if="systemStore.isShowEditor"
+                  v-b-modal.new-cast
+                  variant="outline-success"
+                >
+                  New Cast Member
+                </BButton>
+              </template>
+              <template #cell(btn)="data">
+                <BButtonGroup v-if="systemStore.isShowEditor">
+                  <BButton
+                    variant="warning"
+                    :disabled="submittingEditCast || deletingCast"
+                    @click="openEditForm(data.item)"
+                  >
+                    Edit
+                  </BButton>
+                  <BButton
+                    variant="danger"
+                    :disabled="submittingEditCast || deletingCast"
+                    @click="deleteCastMember(data.item)"
+                  >
+                    Delete
+                  </BButton>
+                </BButtonGroup>
+              </template>
+            </BTable>
+            <BPagination
+              v-show="showStore.castList.length > rowsPerPage"
+              v-model="currentPage"
+              :total-rows="showStore.castList.length"
+              :per-page="rowsPerPage"
+              aria-controls="cast-table"
+              class="justify-content-center"
+            />
+          </BTab>
+          <BTab title="Line Counts">
+            <CastLineStats />
+          </BTab>
+        </BTabs>
+      </BCol>
+    </BRow>
+
+    <BModal
+      id="new-cast"
+      ref="newCastModal"
+      title="Add New Cast Member"
+      size="sm"
+      :ok-disabled="newV$.newFormState.$invalid || submittingNewCast"
+      @show="resetNewForm"
+      @hide="resetNewForm"
+      @ok="onSubmitNew"
+    >
+      <BForm @submit.stop.prevent="onSubmitNew">
+        <BFormGroup label="First Name" label-for="new-first-name-input" label-cols="4">
+          <BFormInput
+            id="new-first-name-input"
+            v-model="newFormState.firstName"
+            :state="newFieldState('firstName')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Last Name" label-for="new-last-name-input" label-cols="4">
+          <BFormInput
+            id="new-last-name-input"
+            v-model="newFormState.lastName"
+            :state="newFieldState('lastName')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+        </BFormGroup>
+      </BForm>
+    </BModal>
+
+    <BModal
+      id="edit-cast"
+      ref="editCastModal"
+      title="Edit Cast Member"
+      size="sm"
+      :ok-disabled="editV$.editFormState.$invalid || submittingEditCast"
+      @hide="resetEditForm"
+      @ok="onSubmitEdit"
+    >
+      <BForm @submit.stop.prevent="onSubmitEdit">
+        <BFormGroup label="First Name" label-for="edit-first-name-input" label-cols="4">
+          <BFormInput
+            id="edit-first-name-input"
+            v-model="editFormState.firstName"
+            :state="editFieldState('firstName')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Last Name" label-for="edit-last-name-input" label-cols="4">
+          <BFormInput
+            id="edit-last-name-input"
+            v-model="editFormState.lastName"
+            :state="editFieldState('lastName')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+        </BFormGroup>
+      </BForm>
+    </BModal>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useVuelidate } from '@vuelidate/core';
+import { required } from '@vuelidate/validators';
+import { BModal } from 'bootstrap-vue-next';
+import log from 'loglevel';
+import { useSystemStore } from '@/stores/system';
+import { useShowStore } from '@/stores/show';
+import { useConfirm } from '@/composables/useConfirm';
+import CastLineStats from '@/components/show/config/cast/CastLineStats.vue';
+import type { Cast } from '@/types/api/show';
+
+const systemStore = useSystemStore();
+const showStore = useShowStore();
+const { confirm } = useConfirm();
+
+const rowsPerPage = 15;
+const currentPage = ref(1);
+const submittingNewCast = ref(false);
+const submittingEditCast = ref(false);
+const deletingCast = ref(false);
+
+const newCastModal = ref<InstanceType<typeof BModal>>();
+const editCastModal = ref<InstanceType<typeof BModal>>();
+
+const castFields = ['first_name', 'last_name', { key: 'btn', label: '' }];
+
+interface NewCastForm {
+  firstName: string;
+  lastName: string;
+}
+
+interface EditCastForm {
+  id: number | null;
+  showID: number | null;
+  firstName: string;
+  lastName: string;
+}
+
+const newFormState = ref<NewCastForm>({ firstName: '', lastName: '' });
+const editFormState = ref<EditCastForm>({ id: null, showID: null, firstName: '', lastName: '' });
+
+const newRules = { newFormState: { firstName: { required }, lastName: { required } } };
+const editRules = { editFormState: { firstName: { required }, lastName: { required } } };
+
+const newV$ = useVuelidate(newRules, { newFormState });
+const editV$ = useVuelidate(editRules, { editFormState });
+
+function newFieldState(key: keyof NewCastForm): boolean | null {
+  const field = newV$.value.newFormState[key];
+  if (!field) return null;
+  return field.$dirty ? !field.$error : null;
+}
+
+function editFieldState(key: keyof EditCastForm): boolean | null {
+  const field = editV$.value.editFormState[key];
+  if (!field) return null;
+  return field.$dirty ? !field.$error : null;
+}
+
+function resetNewForm(): void {
+  newFormState.value = { firstName: '', lastName: '' };
+  submittingNewCast.value = false;
+  newV$.value.$reset();
+}
+
+function resetEditForm(): void {
+  editFormState.value = { id: null, showID: null, firstName: '', lastName: '' };
+  submittingEditCast.value = false;
+  deletingCast.value = false;
+  editV$.value.$reset();
+}
+
+function openEditForm(cast: Cast): void {
+  editFormState.value.id = cast.id;
+  editFormState.value.showID = cast.show_id;
+  editFormState.value.firstName = cast.first_name ?? '';
+  editFormState.value.lastName = cast.last_name ?? '';
+  editCastModal.value?.show();
+}
+
+async function onSubmitNew(event: Event): Promise<void> {
+  newV$.value.newFormState.$touch();
+  if (newV$.value.newFormState.$invalid || submittingNewCast.value) {
+    event.preventDefault();
+    return;
+  }
+  submittingNewCast.value = true;
+  try {
+    await showStore.addCastMember(newFormState.value);
+    newCastModal.value?.hide();
+    resetNewForm();
+  } catch (error) {
+    log.error('Error submitting new cast member:', error);
+    event.preventDefault();
+  } finally {
+    submittingNewCast.value = false;
+  }
+}
+
+async function onSubmitEdit(event: Event): Promise<void> {
+  editV$.value.editFormState.$touch();
+  if (editV$.value.editFormState.$invalid || submittingEditCast.value) {
+    event.preventDefault();
+    return;
+  }
+  submittingEditCast.value = true;
+  try {
+    await showStore.updateCastMember(editFormState.value);
+    editCastModal.value?.hide();
+    resetEditForm();
+  } catch (error) {
+    log.error('Error submitting edit cast member:', error);
+    event.preventDefault();
+  } finally {
+    submittingEditCast.value = false;
+  }
+}
+
+async function deleteCastMember(cast: Cast): Promise<void> {
+  if (deletingCast.value) return;
+  const ok = await confirm(`Are you sure you want to delete ${cast.first_name} ${cast.last_name}?`);
+  if (ok) {
+    deletingCast.value = true;
+    try {
+      await showStore.deleteCastMember(cast.id);
+    } catch (error) {
+      log.error('Error deleting cast member:', error);
+    } finally {
+      deletingCast.value = false;
+    }
+  }
+}
+
+onMounted(async () => {
+  await showStore.getCastList();
+});
+</script>

--- a/client-v3/src/views/show/config/ConfigCharacters.vue
+++ b/client-v3/src/views/show/config/ConfigCharacters.vue
@@ -1,0 +1,295 @@
+<template>
+  <BContainer class="mx-0" fluid>
+    <BRow>
+      <BCol>
+        <BTabs content-class="mt-3">
+          <BTab title="Characters" active>
+            <BTable
+              id="character-table"
+              :items="showStore.characterList"
+              :fields="characterFields"
+              :per-page="rowsPerPage"
+              :current-page="currentPage"
+              show-empty
+            >
+              <template #head(btn)>
+                <BButton
+                  v-if="systemStore.isShowEditor"
+                  v-b-modal.new-character
+                  variant="outline-success"
+                >
+                  New Character
+                </BButton>
+              </template>
+              <template #cell(cast_member)="data">
+                <template v-if="data.item.cast_member">
+                  {{ data.item.cast_member.first_name }} {{ data.item.cast_member.last_name }}
+                </template>
+                <template v-else-if="systemStore.isShowEditor">
+                  <BLink @click="openEditForm(data.item)">Set Cast Member</BLink>
+                </template>
+              </template>
+              <template #cell(btn)="data">
+                <BButtonGroup v-if="systemStore.isShowEditor">
+                  <BButton
+                    variant="warning"
+                    :disabled="submittingEditCharacter || deletingCharacter"
+                    @click="openEditForm(data.item)"
+                  >
+                    Edit
+                  </BButton>
+                  <BButton
+                    variant="danger"
+                    :disabled="submittingEditCharacter || deletingCharacter"
+                    @click="deleteCharacter(data.item)"
+                  >
+                    Delete
+                  </BButton>
+                </BButtonGroup>
+              </template>
+            </BTable>
+            <BPagination
+              v-show="showStore.characterList.length > rowsPerPage"
+              v-model="currentPage"
+              :total-rows="showStore.characterList.length"
+              :per-page="rowsPerPage"
+              aria-controls="character-table"
+              class="justify-content-center"
+            />
+          </BTab>
+          <BTab title="Character Groups">
+            <CharacterGroups />
+          </BTab>
+          <BTab title="Line Counts">
+            <CharacterLineStats />
+          </BTab>
+        </BTabs>
+      </BCol>
+    </BRow>
+
+    <BModal
+      id="new-character"
+      ref="newCharacterModal"
+      title="Add New Character"
+      size="md"
+      :ok-disabled="newV$.newFormState.$invalid || submittingNewCharacter"
+      @show="resetNewForm"
+      @hide="resetNewForm"
+      @ok="onSubmitNew"
+    >
+      <BForm @submit.stop.prevent="onSubmitNew">
+        <BFormGroup label="Name" label-for="new-name-input" label-cols="4">
+          <BFormInput
+            id="new-name-input"
+            v-model="newFormState.name"
+            :state="newFieldState('name')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Description" label-for="new-description-input" label-cols="4">
+          <BFormInput id="new-description-input" v-model="newFormState.description" />
+        </BFormGroup>
+        <BFormGroup label="Played By" label-for="new-played-by-input" label-cols="4">
+          <BFormSelect
+            id="new-played-by-input"
+            v-model="newFormState.played_by"
+            :options="castOptions"
+          />
+        </BFormGroup>
+      </BForm>
+    </BModal>
+
+    <BModal
+      id="edit-character"
+      ref="editCharacterModal"
+      title="Edit Character"
+      size="md"
+      :ok-disabled="editV$.editFormState.$invalid || submittingEditCharacter"
+      @hide="resetEditForm"
+      @ok="onSubmitEdit"
+    >
+      <BForm @submit.stop.prevent="onSubmitEdit">
+        <BFormGroup label="Name" label-for="edit-name-input" label-cols="4">
+          <BFormInput
+            id="edit-name-input"
+            v-model="editFormState.name"
+            :state="editFieldState('name')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Description" label-for="edit-description-input" label-cols="4">
+          <BFormInput id="edit-description-input" v-model="editFormState.description" />
+        </BFormGroup>
+        <BFormGroup label="Played By" label-for="edit-played-by-input" label-cols="4">
+          <BFormSelect
+            id="edit-played-by-input"
+            v-model="editFormState.played_by"
+            :options="castOptions"
+          />
+        </BFormGroup>
+      </BForm>
+    </BModal>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { useVuelidate } from '@vuelidate/core';
+import { required } from '@vuelidate/validators';
+import { BModal } from 'bootstrap-vue-next';
+import log from 'loglevel';
+import { useSystemStore } from '@/stores/system';
+import { useShowStore } from '@/stores/show';
+import { useConfirm } from '@/composables/useConfirm';
+import CharacterGroups from '@/components/show/config/characters/CharacterGroups.vue';
+import CharacterLineStats from '@/components/show/config/characters/CharacterLineStats.vue';
+import type { Character } from '@/types/api/show';
+
+const systemStore = useSystemStore();
+const showStore = useShowStore();
+const { confirm } = useConfirm();
+
+const rowsPerPage = 15;
+const currentPage = ref(1);
+const submittingNewCharacter = ref(false);
+const submittingEditCharacter = ref(false);
+const deletingCharacter = ref(false);
+
+const newCharacterModal = ref<InstanceType<typeof BModal>>();
+const editCharacterModal = ref<InstanceType<typeof BModal>>();
+
+const characterFields = [
+  'name',
+  'description',
+  { key: 'cast_member', label: 'Played By' },
+  { key: 'btn', label: '' },
+];
+
+interface NewCharacterForm {
+  name: string;
+  description: string;
+  played_by: number | null;
+}
+
+interface EditCharacterForm {
+  id: number | null;
+  showID: number | null;
+  name: string;
+  description: string;
+  played_by: number | null;
+}
+
+const newFormState = ref<NewCharacterForm>({ name: '', description: '', played_by: null });
+const editFormState = ref<EditCharacterForm>({
+  id: null,
+  showID: null,
+  name: '',
+  description: '',
+  played_by: null,
+});
+
+const newRules = { newFormState: { name: { required } } };
+const editRules = { editFormState: { name: { required } } };
+
+const newV$ = useVuelidate(newRules, { newFormState });
+const editV$ = useVuelidate(editRules, { editFormState });
+
+const castOptions = computed(() => [
+  { value: null, text: 'Please select an option', disabled: true },
+  ...showStore.castList.map((c) => ({
+    value: c.id,
+    text: `${c.first_name} ${c.last_name}`,
+  })),
+]);
+
+function newFieldState(key: keyof NewCharacterForm): boolean | null {
+  const field = newV$.value.newFormState[key];
+  if (!field) return null;
+  return field.$dirty ? !field.$error : null;
+}
+
+function editFieldState(key: keyof EditCharacterForm): boolean | null {
+  const field = editV$.value.editFormState[key];
+  if (!field) return null;
+  return field.$dirty ? !field.$error : null;
+}
+
+function resetNewForm(): void {
+  newFormState.value = { name: '', description: '', played_by: null };
+  submittingNewCharacter.value = false;
+  newV$.value.$reset();
+}
+
+function resetEditForm(): void {
+  editFormState.value = { id: null, showID: null, name: '', description: '', played_by: null };
+  submittingEditCharacter.value = false;
+  deletingCharacter.value = false;
+  editV$.value.$reset();
+}
+
+function openEditForm(character: Character): void {
+  editFormState.value.id = character.id;
+  editFormState.value.showID = character.show_id;
+  editFormState.value.name = character.name ?? '';
+  editFormState.value.description = character.description ?? '';
+  editFormState.value.played_by = character.played_by;
+  editCharacterModal.value?.show();
+}
+
+async function onSubmitNew(event: Event): Promise<void> {
+  newV$.value.newFormState.$touch();
+  if (newV$.value.newFormState.$invalid || submittingNewCharacter.value) {
+    event.preventDefault();
+    return;
+  }
+  submittingNewCharacter.value = true;
+  try {
+    await showStore.addCharacter(newFormState.value);
+    newCharacterModal.value?.hide();
+    resetNewForm();
+  } catch (error) {
+    log.error('Error submitting new character:', error);
+    event.preventDefault();
+  } finally {
+    submittingNewCharacter.value = false;
+  }
+}
+
+async function onSubmitEdit(event: Event): Promise<void> {
+  editV$.value.editFormState.$touch();
+  if (editV$.value.editFormState.$invalid || submittingEditCharacter.value) {
+    event.preventDefault();
+    return;
+  }
+  submittingEditCharacter.value = true;
+  try {
+    await showStore.updateCharacter(editFormState.value);
+    editCharacterModal.value?.hide();
+    resetEditForm();
+  } catch (error) {
+    log.error('Error submitting edit character:', error);
+    event.preventDefault();
+  } finally {
+    submittingEditCharacter.value = false;
+  }
+}
+
+async function deleteCharacter(character: Character): Promise<void> {
+  if (deletingCharacter.value) return;
+  const ok = await confirm(`Are you sure you want to delete ${character.name}?`);
+  if (ok) {
+    deletingCharacter.value = true;
+    try {
+      await showStore.deleteCharacter(character.id);
+    } catch (error) {
+      log.error('Error deleting character:', error);
+    } finally {
+      deletingCharacter.value = false;
+    }
+  }
+}
+
+onMounted(async () => {
+  await Promise.all([showStore.getCharacterList(), showStore.getCastList()]);
+});
+</script>

--- a/client-v3/src/views/show/config/ConfigShow.vue
+++ b/client-v3/src/views/show/config/ConfigShow.vue
@@ -1,0 +1,200 @@
+<template>
+  <BContainer id="show-config" class="mx-0" fluid>
+    <BRow>
+      <BCol cols="12" class="text-end">
+        <BButton
+          v-if="systemStore.isShowEditor"
+          variant="warning"
+          :disabled="submittingEditShow"
+          @click="openEditForm"
+        >
+          Edit Show
+        </BButton>
+      </BCol>
+    </BRow>
+    <BRow>
+      <BCol>
+        <BTableSimple class="w-100">
+          <BTbody>
+            <BTr v-for="key in orderedKeys" :key="key">
+              <BTh>{{ key }}</BTh>
+              <BTd>{{ tableData[key] != null ? tableData[key] : 'N/A' }}</BTd>
+            </BTr>
+          </BTbody>
+        </BTableSimple>
+      </BCol>
+    </BRow>
+
+    <BModal
+      ref="editShowModal"
+      title="Edit Show"
+      size="md"
+      :ok-disabled="v$.editFormState.$invalid || submittingEditShow"
+      @hide="resetEditForm"
+      @ok="onSubmitEdit"
+    >
+      <BForm @submit.stop.prevent="onSubmitEdit">
+        <BFormGroup label="Name" label-for="name-input" label-cols="4">
+          <BFormInput id="name-input" v-model="editFormState.name" :state="fieldState('name')" />
+          <BFormInvalidFeedback>
+            This is a required field and must be less than 100 characters.
+          </BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Start Date" label-for="start-input" label-cols="4">
+          <BFormInput
+            id="start-input"
+            v-model="editFormState.start_date"
+            type="date"
+            :state="fieldState('start_date')"
+          />
+          <BFormInvalidFeedback>
+            This is a required field and must be before or the same as the end date.
+          </BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="End Date" label-for="end-input" label-cols="4">
+          <BFormInput
+            id="end-input"
+            v-model="editFormState.end_date"
+            type="date"
+            :state="fieldState('end_date')"
+          />
+          <BFormInvalidFeedback>
+            This is a required field and must be after or the same as the start date.
+          </BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Act" label-for="act-input" label-cols="4">
+          <BFormSelect id="act-input" v-model="editFormState.first_act_id" :options="actOptions" />
+        </BFormGroup>
+      </BForm>
+    </BModal>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { useVuelidate } from '@vuelidate/core';
+import { required, maxLength, helpers } from '@vuelidate/validators';
+import { BModal } from 'bootstrap-vue-next';
+import log from 'loglevel';
+import { titleCase } from '@/js/utils';
+import { useSystemStore } from '@/stores/system';
+import { useShowStore } from '@/stores/show';
+
+const systemStore = useSystemStore();
+const showStore = useShowStore();
+
+const submittingEditShow = ref(false);
+const editShowModal = ref<InstanceType<typeof BModal>>();
+
+interface EditShowForm {
+  name: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  first_act_id: number | null;
+}
+
+const editFormState = ref<EditShowForm>({
+  name: null,
+  start_date: null,
+  end_date: null,
+  first_act_id: null,
+});
+
+const beforeEnd = helpers.withMessage(
+  'Start date must be before or the same as end date',
+  () =>
+    !editFormState.value.start_date ||
+    !editFormState.value.end_date ||
+    new Date(editFormState.value.start_date) <= new Date(editFormState.value.end_date)
+);
+
+const afterStart = helpers.withMessage(
+  'End date must be after or the same as start date',
+  () =>
+    !editFormState.value.start_date ||
+    !editFormState.value.end_date ||
+    new Date(editFormState.value.end_date) >= new Date(editFormState.value.start_date)
+);
+
+const rules = {
+  editFormState: {
+    name: { required, maxLength: maxLength(100) },
+    start_date: { required, beforeEnd },
+    end_date: { required, afterStart },
+    first_act_id: {},
+  },
+};
+
+const v$ = useVuelidate(rules, { editFormState });
+
+const tableData = computed((): Record<string, unknown> => {
+  const show = systemStore.currentShow;
+  if (!show) return {};
+  const data: Record<string, unknown> = {};
+  for (const key of Object.keys(show)) {
+    data[titleCase(key, '_')] = (show as Record<string, unknown>)[key];
+  }
+  return data;
+});
+
+const orderedKeys = computed(() => Object.keys(tableData.value).sort());
+
+const actOptions = computed(() => [
+  { value: null, text: 'N/A', disabled: false },
+  ...showStore.actList.map((act) => ({ value: act.id, text: act.name })),
+]);
+
+function fieldState(key: keyof EditShowForm): boolean | null {
+  const field = v$.value.editFormState[key];
+  if (!field) return null;
+  return field.$dirty ? !field.$error : null;
+}
+
+function resetEditForm(): void {
+  editFormState.value = { name: null, start_date: null, end_date: null, first_act_id: null };
+  submittingEditShow.value = false;
+  v$.value.$reset();
+}
+
+function openEditForm(): void {
+  const show = systemStore.currentShow;
+  if (show) {
+    editFormState.value.name = show.name;
+    editFormState.value.start_date = show.start_date;
+    editFormState.value.end_date = show.end_date;
+    editFormState.value.first_act_id = show.first_act_id;
+  }
+  editShowModal.value?.show();
+}
+
+async function onSubmitEdit(event: Event): Promise<void> {
+  v$.value.editFormState.$touch();
+  if (v$.value.editFormState.$invalid || submittingEditShow.value) {
+    event.preventDefault();
+    return;
+  }
+  submittingEditShow.value = true;
+  try {
+    await systemStore.updateShow(editFormState.value);
+    editShowModal.value?.hide();
+    resetEditForm();
+  } catch (error) {
+    log.error('Error submitting edit show:', error);
+    event.preventDefault();
+  } finally {
+    submittingEditShow.value = false;
+  }
+}
+
+onMounted(async () => {
+  await systemStore.getShowDetails();
+  await showStore.getActList();
+});
+</script>
+
+<style scoped>
+.row {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+</style>


### PR DESCRIPTION
## Summary

- Ports the four core show config tabs to Vue 3 + BVN: Show details, Acts & Scenes, Cast, and Characters
- Adds `getShowDetails()` / `updateShow()` to `systemStore` (ported from V2 root store)
- Adds `useStatsTable()` composable (port of `statsTableMixin.ts`) for linked-list act/scene traversal in stats tables
- Full CRUD for acts, scenes, cast members, characters, and character groups; all delete confirmations use `useConfirm()` (not browser native)
- Acts/scenes include circular-dependency validators to prevent linked-list loops
- Character groups use vue-multiselect v3 with separate `characterObjects` ref; IDs derived at submit time
- Stats tables (cast and character) use dynamic BTable slot syntax for per-scene columns with act grouping headers
- Wires four previously-`PlaceholderView` child routes to real components

## Test plan

- [ ] `/ui-new/show-config` → shows detail table with titleCase keys; Edit Show button visible for editors; edit modal validates and saves
- [ ] `/ui-new/show-config/acts` → Acts tab lists acts in linked-list order; add/edit/delete work; previous act dropdown only shows acts at end of chain; loop validator fires for circular references
- [ ] `/ui-new/show-config/acts` → Scenes tab shows 2-column layout; first-scene-per-act table updates on change; previous scene resets when act changes in edit form
- [ ] `/ui-new/show-config/cast` → Cast list CRUD works; Line Counts tab shows per-scene counts with act grouping headers
- [ ] `/ui-new/show-config/characters` → Characters CRUD works; Character Groups tab multiselect works; Line Counts tab renders stats
- [ ] Delete confirmations use the app's confirm dialog, not the browser native dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)