### PR TITLE
Vue 3 migration: Phase 10 — Stage configuration

### DIFF
--- a/client-v3/src/components/show/config/stage/CrewList.vue
+++ b/client-v3/src/components/show/config/stage/CrewList.vue
@@ -1,0 +1,203 @@
+<template>
+  <BContainer class="mx-0" fluid>
+    <BRow>
+      <BCol>
+        <BTable
+          :items="stageStore.crewList"
+          :fields="fields"
+          :per-page="rowsPerPage"
+          :current-page="currentPage"
+          show-empty
+        >
+          <template #head(btn)>
+            <BButton
+              v-if="systemStore.isShowEditor"
+              variant="outline-success"
+              @click="newModal?.show()"
+            >
+              Add Crew Member
+            </BButton>
+          </template>
+          <template #cell(btn)="data">
+            <BButtonGroup v-if="systemStore.isShowEditor">
+              <BButton variant="warning" :disabled="isSubmitting" @click="openEdit(data.item)">
+                Edit
+              </BButton>
+              <BButton variant="danger" :disabled="isSubmitting" @click="confirmDelete(data.item)">
+                Delete
+              </BButton>
+            </BButtonGroup>
+          </template>
+        </BTable>
+        <BPagination
+          v-if="stageStore.crewList.length > rowsPerPage"
+          v-model="currentPage"
+          :total-rows="stageStore.crewList.length"
+          :per-page="rowsPerPage"
+        />
+      </BCol>
+    </BRow>
+
+    <BModal
+      ref="newModal"
+      title="Add Crew Member"
+      :ok-disabled="isSubmitting"
+      @hidden="resetNew"
+      @ok.prevent="submitNew"
+    >
+      <BForm>
+        <BFormGroup label="First Name" label-for="new-first-name">
+          <BFormInput
+            id="new-first-name"
+            v-model="newForm.first_name"
+            :state="validationState(vNew$.first_name)"
+          />
+          <BFormInvalidFeedback>{{ vNew$.first_name.$errors[0]?.$message }}</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Last Name" label-for="new-last-name">
+          <BFormInput
+            id="new-last-name"
+            v-model="newForm.last_name"
+            :state="validationState(vNew$.last_name)"
+          />
+          <BFormInvalidFeedback>{{ vNew$.last_name.$errors[0]?.$message }}</BFormInvalidFeedback>
+        </BFormGroup>
+      </BForm>
+    </BModal>
+
+    <BModal
+      ref="editModal"
+      title="Edit Crew Member"
+      :ok-disabled="isSubmitting"
+      @hidden="resetEdit"
+      @ok.prevent="submitEdit"
+    >
+      <BForm>
+        <BFormGroup label="First Name" label-for="edit-first-name">
+          <BFormInput
+            id="edit-first-name"
+            v-model="editForm.first_name"
+            :state="validationState(vEdit$.first_name)"
+          />
+          <BFormInvalidFeedback>{{ vEdit$.first_name.$errors[0]?.$message }}</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Last Name" label-for="edit-last-name">
+          <BFormInput
+            id="edit-last-name"
+            v-model="editForm.last_name"
+            :state="validationState(vEdit$.last_name)"
+          />
+          <BFormInvalidFeedback>{{ vEdit$.last_name.$errors[0]?.$message }}</BFormInvalidFeedback>
+        </BFormGroup>
+      </BForm>
+    </BModal>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import type { BModal } from 'bootstrap-vue-next';
+import { useVuelidate } from '@vuelidate/core';
+import { required } from '@vuelidate/validators';
+import { useStageStore } from '@/stores/stage';
+import { useSystemStore } from '@/stores/system';
+import { useConfirm } from '@/composables/useConfirm';
+import { useFormValidation } from '@/composables/useFormValidation';
+import type { Crew } from '@/types/api/stage';
+import log from 'loglevel';
+
+const stageStore = useStageStore();
+const systemStore = useSystemStore();
+const { confirm } = useConfirm();
+const { validationState } = useFormValidation();
+
+const rowsPerPage = 15;
+const currentPage = ref(1);
+const isSubmitting = ref(false);
+
+const newModal = ref<InstanceType<typeof BModal>>();
+const editModal = ref<InstanceType<typeof BModal>>();
+
+const newForm = ref({ first_name: '', last_name: '' });
+const editForm = ref({ id: null as number | null, first_name: '', last_name: '' });
+
+const fields = [
+  { key: 'first_name', label: 'First Name' },
+  { key: 'last_name', label: 'Last Name' },
+  { key: 'btn', label: '' },
+];
+
+const vNew$ = useVuelidate({ first_name: { required }, last_name: { required } }, newForm);
+const vEdit$ = useVuelidate({ first_name: { required }, last_name: { required } }, editForm);
+
+function openEdit(crew: Crew): void {
+  editForm.value = { id: crew.id, first_name: crew.first_name, last_name: crew.last_name ?? '' };
+  editModal.value?.show();
+}
+
+function resetNew(): void {
+  newForm.value = { first_name: '', last_name: '' };
+  isSubmitting.value = false;
+  vNew$.value.$reset();
+}
+
+function resetEdit(): void {
+  editForm.value = { id: null, first_name: '', last_name: '' };
+  isSubmitting.value = false;
+  vEdit$.value.$reset();
+}
+
+async function submitNew(): Promise<void> {
+  const valid = await vNew$.value.$validate();
+  if (!valid || isSubmitting.value) return;
+  isSubmitting.value = true;
+  try {
+    await stageStore.addCrewMember({
+      first_name: newForm.value.first_name,
+      last_name: newForm.value.last_name || null,
+    });
+    newModal.value?.hide();
+  } catch (e) {
+    log.error('Error adding crew member:', e);
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+async function submitEdit(): Promise<void> {
+  const valid = await vEdit$.value.$validate();
+  if (!valid || isSubmitting.value) return;
+  isSubmitting.value = true;
+  try {
+    await stageStore.updateCrewMember({
+      id: editForm.value.id!,
+      first_name: editForm.value.first_name,
+      last_name: editForm.value.last_name || null,
+    });
+    editModal.value?.hide();
+  } catch (e) {
+    log.error('Error updating crew member:', e);
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+async function confirmDelete(crew: Crew): Promise<void> {
+  const name = [crew.first_name, crew.last_name].filter(Boolean).join(' ');
+  const ok = await confirm(`Are you sure you want to delete ${name}?`, {
+    title: 'Delete Crew Member',
+    okVariant: 'danger',
+    okTitle: 'Delete',
+  });
+  if (!ok) return;
+  try {
+    await stageStore.deleteCrewMember(crew.id);
+  } catch (e) {
+    log.error('Error deleting crew member:', e);
+  }
+}
+
+onMounted(async () => {
+  await stageStore.getCrewList();
+});
+</script>

--- a/client-v3/src/components/show/config/stage/CrewTimeline.vue
+++ b/client-v3/src/components/show/config/stage/CrewTimeline.vue
@@ -1,0 +1,353 @@
+<template>
+  <div class="timeline-container">
+    <div v-if="!dataLoaded" class="text-center py-5">
+      <BSpinner label="Loading timeline..." />
+    </div>
+    <div v-else class="timeline-wrapper">
+      <div class="timeline-controls-bar">
+        <span class="text-light small">Crew Assignments</span>
+        <BButton size="sm" variant="outline-secondary" title="Export as PNG" @click="handleExport">
+          &#8659;
+        </BButton>
+      </div>
+      <div class="svg-container">
+        <div v-if="!hasData" class="text-center py-5 text-muted">
+          No crew assignments to display. Assign crew members to SET/STRIKE tasks in the Stage
+          Manager tab.
+        </div>
+        <svg v-else ref="svgRef" :width="totalWidth" :height="totalHeight" class="timeline-svg">
+          <g class="act-labels" :transform="`translate(${margin.left},0)`">
+            <g v-for="actGroup in actGroups" :key="`act-${actGroup.actId}`">
+              <rect
+                :x="actGroup.startX"
+                :y="5"
+                :width="actGroup.width"
+                :height="25"
+                class="act-header"
+              />
+              <text
+                :x="actGroup.startX + actGroup.width / 2"
+                :y="22"
+                class="act-label"
+                text-anchor="middle"
+              >
+                {{ actGroup.actName }}
+              </text>
+            </g>
+          </g>
+          <g class="scene-labels" :transform="`translate(${margin.left},${margin.top})`">
+            <text
+              v-for="(scene, index) in scenes"
+              :key="`scene-label-${scene.id}`"
+              :x="getSceneX(index) + sceneWidth / 2"
+              :y="-10"
+              class="scene-label"
+              text-anchor="middle"
+            >
+              {{ scene.name }}
+            </text>
+          </g>
+          <g :transform="`translate(${margin.left},${margin.top})`">
+            <g class="scene-dividers">
+              <line
+                v-for="(scene, index) in scenes"
+                :key="`divider-${scene.id}`"
+                :x1="getSceneX(index)"
+                :y1="0"
+                :x2="getSceneX(index)"
+                :y2="contentHeight"
+                class="scene-divider"
+              />
+            </g>
+            <g class="allocation-bars">
+              <g v-for="bar in allocationBars" :key="bar.id">
+                <rect
+                  :x="bar.x"
+                  :y="bar.y"
+                  :width="bar.width"
+                  :height="bar.height"
+                  :fill="bar.color"
+                  :class="['assignment-bar', bar.cssClass]"
+                />
+                <title>{{ bar.tooltip }}</title>
+                <text
+                  v-if="bar.width >= 30"
+                  :x="bar.x + bar.width / 2"
+                  :y="bar.y + bar.height / 2"
+                  class="bar-label"
+                  text-anchor="middle"
+                  dominant-baseline="middle"
+                  pointer-events="none"
+                  :style="{ fontSize: Math.min(11, (bar.width / bar.label.length) * 1.5) + 'px' }"
+                >
+                  {{ bar.label }}
+                </text>
+              </g>
+            </g>
+            <g class="row-separators">
+              <line
+                v-for="(row, index) in rows"
+                :key="`separator-${row.id}`"
+                :x1="0"
+                :y1="getRowY(index) + rowHeight"
+                :x2="contentWidth"
+                :y2="getRowY(index) + rowHeight"
+                class="row-separator"
+              />
+            </g>
+            <g class="row-labels">
+              <text
+                v-for="(row, index) in rows"
+                :key="`row-label-${row.id}`"
+                :x="-10"
+                :y="getRowY(index) + rowHeight / 2"
+                class="row-label"
+                text-anchor="end"
+                dominant-baseline="middle"
+              >
+                {{ row.name }}
+              </text>
+            </g>
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import type { TimelineRow } from '@/composables/useTimeline';
+import { useTimeline } from '@/composables/useTimeline';
+import { useStageStore } from '@/stores/stage';
+import { useShowStore } from '@/stores/show';
+import type { CrewAssignment } from '@/types/api/stage';
+
+interface CrewBar {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  color: string;
+  label: string;
+  tooltip: string;
+  cssClass: string;
+}
+
+const stageStore = useStageStore();
+const showStore = useShowStore();
+
+const svgRef = ref<SVGSVGElement | null>(null);
+const dataLoaded = ref(false);
+
+const scenes = computed(() => showStore.orderedScenes);
+
+const rows = computed((): TimelineRow[] =>
+  stageStore.crewList
+    .filter((c) => (stageStore.crewAssignmentsByCrew[c.id] ?? []).length > 0)
+    .map(
+      (c): TimelineRow => ({
+        id: c.id,
+        name: [c.first_name, c.last_name].filter(Boolean).join(' '),
+        type: 'crew',
+      })
+    )
+);
+
+const {
+  margin,
+  sceneWidth,
+  rowHeight,
+  barPadding,
+  contentWidth,
+  contentHeight,
+  totalWidth,
+  totalHeight,
+  actGroups,
+  getSceneX,
+  getRowY,
+  getColorForEntity,
+  exportTimeline,
+} = useTimeline(scenes, rows);
+
+const hasData = computed(() => scenes.value.length > 0 && rows.value.length > 0);
+
+const sceneIndexMap = computed(() => Object.fromEntries(scenes.value.map((s, i) => [s.id, i])));
+
+const conflicts = computed((): Record<string, 'hard' | 'soft'> => {
+  const conflictMap: Record<string, 'hard' | 'soft'> = {};
+
+  rows.value.forEach((row) => {
+    const assignments: CrewAssignment[] = stageStore.crewAssignmentsByCrew[row.id] ?? [];
+
+    const byScene: Record<number, Set<string>> = {};
+    assignments.forEach((a) => {
+      if (!byScene[a.scene_id]) byScene[a.scene_id] = new Set();
+      const itemKey = a.prop_id != null ? `prop-${a.prop_id}` : `scenery-${a.scenery_id}`;
+      byScene[a.scene_id].add(itemKey);
+    });
+
+    const assignedSceneIds = Object.keys(byScene).map(Number);
+
+    assignedSceneIds.forEach((sceneId) => {
+      if (byScene[sceneId].size >= 2) {
+        conflictMap[`${row.id}-${sceneId}`] = 'hard';
+      }
+    });
+
+    assignedSceneIds.forEach((sceneId) => {
+      const sceneIndex = sceneIndexMap.value[sceneId];
+      if (sceneIndex == null) return;
+      const scene = scenes.value[sceneIndex];
+      const nextIndex = sceneIndex + 1;
+      if (nextIndex < scenes.value.length) {
+        const nextScene = scenes.value[nextIndex];
+        if (nextScene.act === scene.act && assignedSceneIds.includes(nextScene.id)) {
+          const itemsA = byScene[sceneId];
+          const itemsB = byScene[nextScene.id];
+          const sameItems = itemsA.size === itemsB.size && [...itemsA].every((k) => itemsB.has(k));
+          if (!sameItems) {
+            const k1 = `${row.id}-${sceneId}`;
+            const k2 = `${row.id}-${nextScene.id}`;
+            if (!conflictMap[k1]) conflictMap[k1] = 'soft';
+            if (!conflictMap[k2]) conflictMap[k2] = 'soft';
+          }
+        }
+      }
+    });
+  });
+
+  return conflictMap;
+});
+
+function getItemName(assignment: CrewAssignment): string {
+  if (assignment.prop_id != null) {
+    return stageStore.propById(assignment.prop_id)?.name ?? `Prop ${assignment.prop_id}`;
+  }
+  return stageStore.sceneryById(assignment.scenery_id)?.name ?? `Scenery ${assignment.scenery_id}`;
+}
+
+const allocationBars = computed((): CrewBar[] => {
+  const bars: CrewBar[] = [];
+
+  rows.value.forEach((row, rowIndex) => {
+    const assignments: CrewAssignment[] = stageStore.crewAssignmentsByCrew[row.id] ?? [];
+
+    const byScene: Record<number, Record<string, CrewAssignment[]>> = {};
+    assignments.forEach((a) => {
+      if (!byScene[a.scene_id]) byScene[a.scene_id] = {};
+      const itemKey = a.prop_id != null ? `prop-${a.prop_id}` : `scenery-${a.scenery_id}`;
+      if (!byScene[a.scene_id][itemKey]) byScene[a.scene_id][itemKey] = [];
+      byScene[a.scene_id][itemKey].push(a);
+    });
+
+    const availableHeight = rowHeight - 2 * barPadding;
+
+    Object.entries(byScene).forEach(([sceneIdStr, itemGroups]) => {
+      const sceneId = Number(sceneIdStr);
+      const sceneIndex = sceneIndexMap.value[sceneId];
+      if (sceneIndex == null) return;
+
+      const scene = scenes.value[sceneIndex];
+      const conflictType = conflicts.value[`${row.id}-${sceneId}`];
+      const cssClass =
+        conflictType === 'hard' ? 'conflict-hard' : conflictType === 'soft' ? 'conflict-soft' : '';
+
+      const itemCount = Object.keys(itemGroups).length;
+      const barHeight = availableHeight / itemCount;
+
+      const sortedKeys = Object.keys(itemGroups).sort((a, b) => {
+        const nameA = getItemName(itemGroups[a][0]);
+        const nameB = getItemName(itemGroups[b][0]);
+        return nameA.localeCompare(nameB);
+      });
+
+      sortedKeys.forEach((itemKey, stackIndex) => {
+        const group = itemGroups[itemKey];
+        const representative = group[0];
+        const itemName = getItemName(representative);
+        const hasSet = group.some((a) => a.assignment_type === 'set');
+        const hasStrike = group.some((a) => a.assignment_type === 'strike');
+
+        let label: string;
+        let tooltip: string;
+        if (hasSet && hasStrike) {
+          label = `▲ ${itemName} ▼`;
+          tooltip = `SET & STRIKE: ${itemName} (${scene.name})`;
+        } else if (hasSet) {
+          label = `▲ ${itemName}`;
+          tooltip = `SET: ${itemName} (${scene.name})`;
+        } else {
+          label = `▼ ${itemName}`;
+          tooltip = `STRIKE: ${itemName} (${scene.name})`;
+        }
+
+        const itemId =
+          representative.prop_id != null
+            ? representative.prop_id
+            : (representative.scenery_id ?? 0);
+        const itemType = representative.prop_id != null ? 'prop' : 'scenery';
+
+        bars.push({
+          id: `crew-${row.id}-scene-${sceneId}-${stackIndex}`,
+          x: getSceneX(sceneIndex),
+          y: getRowY(rowIndex) + barPadding + stackIndex * barHeight,
+          width: sceneWidth,
+          height: barHeight,
+          color: getColorForEntity(itemId, itemType),
+          label,
+          tooltip,
+          cssClass,
+        });
+      });
+    });
+  });
+
+  return bars;
+});
+
+function handleExport(): void {
+  exportTimeline(svgRef, 'crew-timeline', 'Crew');
+}
+
+onMounted(async () => {
+  await Promise.all([
+    showStore.getActList(),
+    showStore.getSceneList(),
+    stageStore.getCrewList(),
+    stageStore.getCrewAssignments(),
+    stageStore.getPropsList(),
+    stageStore.getSceneryList(),
+    stageStore.getPropsAllocations(),
+    stageStore.getSceneryAllocations(),
+  ]);
+  dataLoaded.value = true;
+});
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/styles/timeline';
+
+.assignment-bar {
+  cursor: default;
+  stroke: #212529;
+  stroke-width: 1px;
+  transition: opacity 0.2s ease;
+
+  &:hover {
+    opacity: 0.85;
+  }
+
+  &.conflict-hard {
+    stroke: #dc3545;
+    stroke-width: 2px;
+  }
+
+  &.conflict-soft {
+    stroke: #fd7e14;
+    stroke-width: 2px;
+    stroke-dasharray: 4 2;
+  }
+}
+</style>

--- a/client-v3/src/components/show/config/stage/PropsList.vue
+++ b/client-v3/src/components/show/config/stage/PropsList.vue
@@ -1,0 +1,419 @@
+<template>
+  <BContainer class="mx-0" fluid>
+    <BRow>
+      <BCol cols="5">
+        <h5>Prop Types</h5>
+        <BTable
+          :items="stageStore.propTypes"
+          :fields="propTypeFields"
+          :per-page="rowsPerPage"
+          :current-page="currentPropTypesPage"
+          show-empty
+        >
+          <template #head(btn)>
+            <BButton
+              v-if="systemStore.isShowEditor"
+              variant="outline-success"
+              @click="newPropTypeModal?.show()"
+            >
+              New Prop Type
+            </BButton>
+          </template>
+          <template #cell(btn)="data">
+            <BButtonGroup v-if="systemStore.isShowEditor">
+              <BButton
+                variant="warning"
+                :disabled="isSubmitting"
+                @click="openEditPropType(data.item)"
+              >
+                Edit
+              </BButton>
+              <BButton
+                variant="danger"
+                :disabled="isSubmitting"
+                @click="confirmDeletePropType(data.item)"
+              >
+                Delete
+              </BButton>
+            </BButtonGroup>
+          </template>
+        </BTable>
+        <BPagination
+          v-if="stageStore.propTypes.length > rowsPerPage"
+          v-model="currentPropTypesPage"
+          :total-rows="stageStore.propTypes.length"
+          :per-page="rowsPerPage"
+        />
+      </BCol>
+      <BCol cols="7">
+        <h5>Props List</h5>
+        <BTable
+          :items="stageStore.propsList"
+          :fields="propsFields"
+          :per-page="rowsPerPage"
+          :current-page="currentPropsPage"
+          show-empty
+        >
+          <template #head(btn)>
+            <BButton
+              v-if="systemStore.isShowEditor"
+              variant="outline-success"
+              @click="newPropModal?.show()"
+            >
+              New Props Item
+            </BButton>
+          </template>
+          <template #cell(prop_type_id)="data">
+            <span>{{ stageStore.propTypeById(data.item.prop_type_id)?.name }}</span>
+          </template>
+          <template #cell(btn)="data">
+            <BButtonGroup v-if="systemStore.isShowEditor">
+              <BButton variant="warning" :disabled="isSubmitting" @click="openEditProp(data.item)">
+                Edit
+              </BButton>
+              <BButton
+                variant="danger"
+                :disabled="isSubmitting"
+                @click="confirmDeleteProp(data.item)"
+              >
+                Delete
+              </BButton>
+            </BButtonGroup>
+          </template>
+        </BTable>
+        <BPagination
+          v-if="stageStore.propsList.length > rowsPerPage"
+          v-model="currentPropsPage"
+          :total-rows="stageStore.propsList.length"
+          :per-page="rowsPerPage"
+        />
+      </BCol>
+    </BRow>
+
+    <BModal
+      ref="newPropTypeModal"
+      title="Add New Prop Type"
+      :ok-disabled="isSubmitting"
+      @hidden="resetNewPropType"
+      @ok.prevent="submitNewPropType"
+    >
+      <BForm>
+        <BFormGroup label="Name" label-for="new-ptype-name">
+          <BFormInput
+            id="new-ptype-name"
+            v-model="newPropTypeForm.name"
+            :state="validationState(vNewPropType$.name)"
+          />
+          <BFormInvalidFeedback>{{ vNewPropType$.name.$errors[0]?.$message }}</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Description" label-for="new-ptype-desc">
+          <BFormInput id="new-ptype-desc" v-model="newPropTypeForm.description" />
+        </BFormGroup>
+      </BForm>
+    </BModal>
+
+    <BModal
+      ref="editPropTypeModal"
+      title="Edit Prop Type"
+      :ok-disabled="isSubmitting"
+      @hidden="resetEditPropType"
+      @ok.prevent="submitEditPropType"
+    >
+      <BForm>
+        <BFormGroup label="Name" label-for="edit-ptype-name">
+          <BFormInput
+            id="edit-ptype-name"
+            v-model="editPropTypeForm.name"
+            :state="validationState(vEditPropType$.name)"
+          />
+          <BFormInvalidFeedback>
+            {{ vEditPropType$.name.$errors[0]?.$message }}
+          </BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Description" label-for="edit-ptype-desc">
+          <BFormInput id="edit-ptype-desc" v-model="editPropTypeForm.description" />
+        </BFormGroup>
+      </BForm>
+    </BModal>
+
+    <BModal
+      ref="newPropModal"
+      title="Add New Prop"
+      :ok-disabled="isSubmitting"
+      @hidden="resetNewProp"
+      @ok.prevent="submitNewProp"
+    >
+      <BForm>
+        <BFormGroup label="Prop Type" label-for="new-prop-type-sel">
+          <BFormSelect
+            id="new-prop-type-sel"
+            v-model="newPropForm.prop_type_id"
+            :options="propTypeOptions"
+            :state="validationState(vNewProp$.prop_type_id)"
+          />
+          <BFormInvalidFeedback>
+            {{ vNewProp$.prop_type_id.$errors[0]?.$message }}
+          </BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Name" label-for="new-prop-name">
+          <BFormInput
+            id="new-prop-name"
+            v-model="newPropForm.name"
+            :state="validationState(vNewProp$.name)"
+          />
+          <BFormInvalidFeedback>{{ vNewProp$.name.$errors[0]?.$message }}</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Description" label-for="new-prop-desc">
+          <BFormInput id="new-prop-desc" v-model="newPropForm.description" />
+        </BFormGroup>
+      </BForm>
+    </BModal>
+
+    <BModal
+      ref="editPropModal"
+      title="Edit Prop"
+      :ok-disabled="isSubmitting"
+      @hidden="resetEditProp"
+      @ok.prevent="submitEditProp"
+    >
+      <BForm>
+        <BFormGroup label="Prop Type" label-for="edit-prop-type-sel">
+          <BFormSelect
+            id="edit-prop-type-sel"
+            v-model="editPropForm.prop_type_id"
+            :options="propTypeOptions"
+            :state="validationState(vEditProp$.prop_type_id)"
+          />
+          <BFormInvalidFeedback>
+            {{ vEditProp$.prop_type_id.$errors[0]?.$message }}
+          </BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Name" label-for="edit-prop-name">
+          <BFormInput
+            id="edit-prop-name"
+            v-model="editPropForm.name"
+            :state="validationState(vEditProp$.name)"
+          />
+          <BFormInvalidFeedback>{{ vEditProp$.name.$errors[0]?.$message }}</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Description" label-for="edit-prop-desc">
+          <BFormInput id="edit-prop-desc" v-model="editPropForm.description" />
+        </BFormGroup>
+      </BForm>
+    </BModal>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import type { BModal } from 'bootstrap-vue-next';
+import { useVuelidate } from '@vuelidate/core';
+import { required, helpers } from '@vuelidate/validators';
+import { useStageStore } from '@/stores/stage';
+import { useSystemStore } from '@/stores/system';
+import { useConfirm } from '@/composables/useConfirm';
+import { useFormValidation } from '@/composables/useFormValidation';
+import type { PropType, Props } from '@/types/api/stage';
+import log from 'loglevel';
+
+const stageStore = useStageStore();
+const systemStore = useSystemStore();
+const { confirm } = useConfirm();
+const { validationState } = useFormValidation();
+
+const rowsPerPage = 15;
+const currentPropTypesPage = ref(1);
+const currentPropsPage = ref(1);
+const isSubmitting = ref(false);
+
+const newPropTypeModal = ref<InstanceType<typeof BModal>>();
+const editPropTypeModal = ref<InstanceType<typeof BModal>>();
+const newPropModal = ref<InstanceType<typeof BModal>>();
+const editPropModal = ref<InstanceType<typeof BModal>>();
+
+const newPropTypeForm = ref({ name: '', description: '' });
+const editPropTypeForm = ref({ id: null as number | null, name: '', description: '' });
+const newPropForm = ref({ name: '', description: '', prop_type_id: null as number | null });
+const editPropForm = ref({
+  id: null as number | null,
+  name: '',
+  description: '',
+  prop_type_id: null as number | null,
+});
+
+const propTypeFields = [
+  { key: 'name', label: 'Name' },
+  { key: 'description', label: 'Description' },
+  { key: 'btn', label: '' },
+];
+const propsFields = [
+  { key: 'name', label: 'Name' },
+  { key: 'description', label: 'Description' },
+  { key: 'prop_type_id', label: 'Prop Type' },
+  { key: 'btn', label: '' },
+];
+
+const propTypeOptions = computed(() => [
+  { value: null, text: 'Please select an option', disabled: true },
+  ...stageStore.propTypes.map((t) => ({ value: t.id, text: t.name })),
+]);
+
+const notNull = helpers.withMessage('This is a required field.', (v: unknown) => v !== null);
+
+const vNewPropType$ = useVuelidate({ name: { required } }, newPropTypeForm);
+const vEditPropType$ = useVuelidate({ name: { required } }, editPropTypeForm);
+const vNewProp$ = useVuelidate(
+  { name: { required }, prop_type_id: { required, notNull } },
+  newPropForm
+);
+const vEditProp$ = useVuelidate(
+  { name: { required }, prop_type_id: { required, notNull } },
+  editPropForm
+);
+
+function openEditPropType(type: PropType): void {
+  editPropTypeForm.value = { id: type.id, name: type.name, description: type.description ?? '' };
+  editPropTypeModal.value?.show();
+}
+
+function openEditProp(prop: Props): void {
+  editPropForm.value = {
+    id: prop.id,
+    name: prop.name,
+    description: prop.description ?? '',
+    prop_type_id: prop.prop_type_id,
+  };
+  editPropModal.value?.show();
+}
+
+function resetNewPropType(): void {
+  newPropTypeForm.value = { name: '', description: '' };
+  isSubmitting.value = false;
+  vNewPropType$.value.$reset();
+}
+
+function resetEditPropType(): void {
+  editPropTypeForm.value = { id: null, name: '', description: '' };
+  isSubmitting.value = false;
+  vEditPropType$.value.$reset();
+}
+
+function resetNewProp(): void {
+  newPropForm.value = { name: '', description: '', prop_type_id: null };
+  isSubmitting.value = false;
+  vNewProp$.value.$reset();
+}
+
+function resetEditProp(): void {
+  editPropForm.value = { id: null, name: '', description: '', prop_type_id: null };
+  isSubmitting.value = false;
+  vEditProp$.value.$reset();
+}
+
+async function submitNewPropType(): Promise<void> {
+  const valid = await vNewPropType$.value.$validate();
+  if (!valid || isSubmitting.value) return;
+  isSubmitting.value = true;
+  try {
+    await stageStore.addPropType({
+      name: newPropTypeForm.value.name,
+      description: newPropTypeForm.value.description || null,
+    });
+    newPropTypeModal.value?.hide();
+  } catch (e) {
+    log.error('Error adding prop type:', e);
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+async function submitEditPropType(): Promise<void> {
+  const valid = await vEditPropType$.value.$validate();
+  if (!valid || isSubmitting.value) return;
+  isSubmitting.value = true;
+  try {
+    await stageStore.updatePropType({
+      id: editPropTypeForm.value.id!,
+      name: editPropTypeForm.value.name,
+      description: editPropTypeForm.value.description || null,
+    });
+    editPropTypeModal.value?.hide();
+  } catch (e) {
+    log.error('Error updating prop type:', e);
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+async function submitNewProp(): Promise<void> {
+  const valid = await vNewProp$.value.$validate();
+  if (!valid || isSubmitting.value) return;
+  isSubmitting.value = true;
+  try {
+    await stageStore.addProp({
+      name: newPropForm.value.name,
+      description: newPropForm.value.description || null,
+      prop_type_id: newPropForm.value.prop_type_id!,
+    });
+    newPropModal.value?.hide();
+  } catch (e) {
+    log.error('Error adding prop:', e);
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+async function submitEditProp(): Promise<void> {
+  const valid = await vEditProp$.value.$validate();
+  if (!valid || isSubmitting.value) return;
+  isSubmitting.value = true;
+  try {
+    await stageStore.updateProp({
+      id: editPropForm.value.id!,
+      name: editPropForm.value.name,
+      description: editPropForm.value.description || null,
+      prop_type_id: editPropForm.value.prop_type_id!,
+    });
+    editPropModal.value?.hide();
+  } catch (e) {
+    log.error('Error updating prop:', e);
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+async function confirmDeletePropType(type: PropType): Promise<void> {
+  const itemCount = stageStore.propsList.filter((p) => p.prop_type_id === type.id).length;
+  let msg = `Are you sure you want to delete ${type.name}?`;
+  if (itemCount > 0) msg += ` This will also delete ${itemCount} props.`;
+  const ok = await confirm(msg, {
+    title: 'Delete Prop Type',
+    okVariant: 'danger',
+    okTitle: 'Delete',
+  });
+  if (!ok) return;
+  try {
+    await stageStore.deletePropType(type.id);
+  } catch (e) {
+    log.error('Error deleting prop type:', e);
+  }
+}
+
+async function confirmDeleteProp(prop: Props): Promise<void> {
+  const ok = await confirm(`Are you sure you want to delete ${prop.name}?`, {
+    title: 'Delete Prop',
+    okVariant: 'danger',
+    okTitle: 'Delete',
+  });
+  if (!ok) return;
+  try {
+    await stageStore.deleteProp(prop.id);
+  } catch (e) {
+    log.error('Error deleting prop:', e);
+  }
+}
+
+onMounted(async () => {
+  await Promise.all([stageStore.getPropTypes(), stageStore.getPropsList()]);
+});
+</script>

--- a/client-v3/src/components/show/config/stage/SceneryList.vue
+++ b/client-v3/src/components/show/config/stage/SceneryList.vue
@@ -1,0 +1,425 @@
+<template>
+  <BContainer class="mx-0" fluid>
+    <BRow>
+      <BCol cols="5">
+        <h5>Scenery Types</h5>
+        <BTable
+          :items="stageStore.sceneryTypes"
+          :fields="sceneryTypeFields"
+          :per-page="rowsPerPage"
+          :current-page="currentSceneryTypesPage"
+          show-empty
+        >
+          <template #head(btn)>
+            <BButton
+              v-if="systemStore.isShowEditor"
+              variant="outline-success"
+              @click="newSceneryTypeModal?.show()"
+            >
+              New Scenery Type
+            </BButton>
+          </template>
+          <template #cell(btn)="data">
+            <BButtonGroup v-if="systemStore.isShowEditor">
+              <BButton
+                variant="warning"
+                :disabled="isSubmitting"
+                @click="openEditSceneryType(data.item)"
+              >
+                Edit
+              </BButton>
+              <BButton
+                variant="danger"
+                :disabled="isSubmitting"
+                @click="confirmDeleteSceneryType(data.item)"
+              >
+                Delete
+              </BButton>
+            </BButtonGroup>
+          </template>
+        </BTable>
+        <BPagination
+          v-if="stageStore.sceneryTypes.length > rowsPerPage"
+          v-model="currentSceneryTypesPage"
+          :total-rows="stageStore.sceneryTypes.length"
+          :per-page="rowsPerPage"
+        />
+      </BCol>
+      <BCol cols="7">
+        <h5>Scenery List</h5>
+        <BTable
+          :items="stageStore.sceneryList"
+          :fields="sceneryFields"
+          :per-page="rowsPerPage"
+          :current-page="currentSceneryPage"
+          show-empty
+        >
+          <template #head(btn)>
+            <BButton
+              v-if="systemStore.isShowEditor"
+              variant="outline-success"
+              @click="newSceneryModal?.show()"
+            >
+              New Scenery Item
+            </BButton>
+          </template>
+          <template #cell(scenery_type_id)="data">
+            <span>{{ stageStore.sceneryTypeById(data.item.scenery_type_id)?.name }}</span>
+          </template>
+          <template #cell(btn)="data">
+            <BButtonGroup v-if="systemStore.isShowEditor">
+              <BButton
+                variant="warning"
+                :disabled="isSubmitting"
+                @click="openEditScenery(data.item)"
+              >
+                Edit
+              </BButton>
+              <BButton
+                variant="danger"
+                :disabled="isSubmitting"
+                @click="confirmDeleteScenery(data.item)"
+              >
+                Delete
+              </BButton>
+            </BButtonGroup>
+          </template>
+        </BTable>
+        <BPagination
+          v-if="stageStore.sceneryList.length > rowsPerPage"
+          v-model="currentSceneryPage"
+          :total-rows="stageStore.sceneryList.length"
+          :per-page="rowsPerPage"
+        />
+      </BCol>
+    </BRow>
+
+    <BModal
+      ref="newSceneryTypeModal"
+      title="Add New Scenery Type"
+      :ok-disabled="isSubmitting"
+      @hidden="resetNewSceneryType"
+      @ok.prevent="submitNewSceneryType"
+    >
+      <BForm>
+        <BFormGroup label="Name" label-for="new-stype-name">
+          <BFormInput
+            id="new-stype-name"
+            v-model="newSceneryTypeForm.name"
+            :state="validationState(vNewType$.name)"
+          />
+          <BFormInvalidFeedback>{{ vNewType$.name.$errors[0]?.$message }}</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Description" label-for="new-stype-desc">
+          <BFormInput id="new-stype-desc" v-model="newSceneryTypeForm.description" />
+        </BFormGroup>
+      </BForm>
+    </BModal>
+
+    <BModal
+      ref="editSceneryTypeModal"
+      title="Edit Scenery Type"
+      :ok-disabled="isSubmitting"
+      @hidden="resetEditSceneryType"
+      @ok.prevent="submitEditSceneryType"
+    >
+      <BForm>
+        <BFormGroup label="Name" label-for="edit-stype-name">
+          <BFormInput
+            id="edit-stype-name"
+            v-model="editSceneryTypeForm.name"
+            :state="validationState(vEditType$.name)"
+          />
+          <BFormInvalidFeedback>{{ vEditType$.name.$errors[0]?.$message }}</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Description" label-for="edit-stype-desc">
+          <BFormInput id="edit-stype-desc" v-model="editSceneryTypeForm.description" />
+        </BFormGroup>
+      </BForm>
+    </BModal>
+
+    <BModal
+      ref="newSceneryModal"
+      title="Add New Scenery"
+      :ok-disabled="isSubmitting"
+      @hidden="resetNewScenery"
+      @ok.prevent="submitNewScenery"
+    >
+      <BForm>
+        <BFormGroup label="Scenery Type" label-for="new-scenery-type-sel">
+          <BFormSelect
+            id="new-scenery-type-sel"
+            v-model="newSceneryForm.scenery_type_id"
+            :options="sceneryTypeOptions"
+            :state="validationState(vNewScenery$.scenery_type_id)"
+          />
+          <BFormInvalidFeedback>
+            {{ vNewScenery$.scenery_type_id.$errors[0]?.$message }}
+          </BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Name" label-for="new-scenery-name">
+          <BFormInput
+            id="new-scenery-name"
+            v-model="newSceneryForm.name"
+            :state="validationState(vNewScenery$.name)"
+          />
+          <BFormInvalidFeedback>{{ vNewScenery$.name.$errors[0]?.$message }}</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Description" label-for="new-scenery-desc">
+          <BFormInput id="new-scenery-desc" v-model="newSceneryForm.description" />
+        </BFormGroup>
+      </BForm>
+    </BModal>
+
+    <BModal
+      ref="editSceneryModal"
+      title="Edit Scenery"
+      :ok-disabled="isSubmitting"
+      @hidden="resetEditScenery"
+      @ok.prevent="submitEditScenery"
+    >
+      <BForm>
+        <BFormGroup label="Scenery Type" label-for="edit-scenery-type-sel">
+          <BFormSelect
+            id="edit-scenery-type-sel"
+            v-model="editSceneryForm.scenery_type_id"
+            :options="sceneryTypeOptions"
+            :state="validationState(vEditScenery$.scenery_type_id)"
+          />
+          <BFormInvalidFeedback>
+            {{ vEditScenery$.scenery_type_id.$errors[0]?.$message }}
+          </BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Name" label-for="edit-scenery-name">
+          <BFormInput
+            id="edit-scenery-name"
+            v-model="editSceneryForm.name"
+            :state="validationState(vEditScenery$.name)"
+          />
+          <BFormInvalidFeedback>{{ vEditScenery$.name.$errors[0]?.$message }}</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Description" label-for="edit-scenery-desc">
+          <BFormInput id="edit-scenery-desc" v-model="editSceneryForm.description" />
+        </BFormGroup>
+      </BForm>
+    </BModal>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import type { BModal } from 'bootstrap-vue-next';
+import { useVuelidate } from '@vuelidate/core';
+import { required, helpers } from '@vuelidate/validators';
+import { useStageStore } from '@/stores/stage';
+import { useSystemStore } from '@/stores/system';
+import { useConfirm } from '@/composables/useConfirm';
+import { useFormValidation } from '@/composables/useFormValidation';
+import type { SceneryType, Scenery } from '@/types/api/stage';
+import log from 'loglevel';
+
+const stageStore = useStageStore();
+const systemStore = useSystemStore();
+const { confirm } = useConfirm();
+const { validationState } = useFormValidation();
+
+const rowsPerPage = 15;
+const currentSceneryTypesPage = ref(1);
+const currentSceneryPage = ref(1);
+const isSubmitting = ref(false);
+
+const newSceneryTypeModal = ref<InstanceType<typeof BModal>>();
+const editSceneryTypeModal = ref<InstanceType<typeof BModal>>();
+const newSceneryModal = ref<InstanceType<typeof BModal>>();
+const editSceneryModal = ref<InstanceType<typeof BModal>>();
+
+const newSceneryTypeForm = ref({ name: '', description: '' });
+const editSceneryTypeForm = ref({ id: null as number | null, name: '', description: '' });
+const newSceneryForm = ref({
+  name: '',
+  description: '',
+  scenery_type_id: null as number | null,
+});
+const editSceneryForm = ref({
+  id: null as number | null,
+  name: '',
+  description: '',
+  scenery_type_id: null as number | null,
+});
+
+const sceneryTypeFields = [
+  { key: 'name', label: 'Name' },
+  { key: 'description', label: 'Description' },
+  { key: 'btn', label: '' },
+];
+const sceneryFields = [
+  { key: 'name', label: 'Name' },
+  { key: 'description', label: 'Description' },
+  { key: 'scenery_type_id', label: 'Scenery Type' },
+  { key: 'btn', label: '' },
+];
+
+const sceneryTypeOptions = computed(() => [
+  { value: null, text: 'Please select an option', disabled: true },
+  ...stageStore.sceneryTypes.map((t) => ({ value: t.id, text: t.name })),
+]);
+
+const notNull = helpers.withMessage('This is a required field.', (v: unknown) => v !== null);
+
+const vNewType$ = useVuelidate({ name: { required } }, newSceneryTypeForm);
+const vEditType$ = useVuelidate({ name: { required } }, editSceneryTypeForm);
+const vNewScenery$ = useVuelidate(
+  { name: { required }, scenery_type_id: { required, notNull } },
+  newSceneryForm
+);
+const vEditScenery$ = useVuelidate(
+  { name: { required }, scenery_type_id: { required, notNull } },
+  editSceneryForm
+);
+
+function openEditSceneryType(type: SceneryType): void {
+  editSceneryTypeForm.value = { id: type.id, name: type.name, description: type.description ?? '' };
+  editSceneryTypeModal.value?.show();
+}
+
+function openEditScenery(scenery: Scenery): void {
+  editSceneryForm.value = {
+    id: scenery.id,
+    name: scenery.name,
+    description: scenery.description ?? '',
+    scenery_type_id: scenery.scenery_type_id,
+  };
+  editSceneryModal.value?.show();
+}
+
+function resetNewSceneryType(): void {
+  newSceneryTypeForm.value = { name: '', description: '' };
+  isSubmitting.value = false;
+  vNewType$.value.$reset();
+}
+
+function resetEditSceneryType(): void {
+  editSceneryTypeForm.value = { id: null, name: '', description: '' };
+  isSubmitting.value = false;
+  vEditType$.value.$reset();
+}
+
+function resetNewScenery(): void {
+  newSceneryForm.value = { name: '', description: '', scenery_type_id: null };
+  isSubmitting.value = false;
+  vNewScenery$.value.$reset();
+}
+
+function resetEditScenery(): void {
+  editSceneryForm.value = { id: null, name: '', description: '', scenery_type_id: null };
+  isSubmitting.value = false;
+  vEditScenery$.value.$reset();
+}
+
+async function submitNewSceneryType(): Promise<void> {
+  const valid = await vNewType$.value.$validate();
+  if (!valid || isSubmitting.value) return;
+  isSubmitting.value = true;
+  try {
+    await stageStore.addSceneryType({
+      name: newSceneryTypeForm.value.name,
+      description: newSceneryTypeForm.value.description || null,
+    });
+    newSceneryTypeModal.value?.hide();
+  } catch (e) {
+    log.error('Error adding scenery type:', e);
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+async function submitEditSceneryType(): Promise<void> {
+  const valid = await vEditType$.value.$validate();
+  if (!valid || isSubmitting.value) return;
+  isSubmitting.value = true;
+  try {
+    await stageStore.updateSceneryType({
+      id: editSceneryTypeForm.value.id!,
+      name: editSceneryTypeForm.value.name,
+      description: editSceneryTypeForm.value.description || null,
+    });
+    editSceneryTypeModal.value?.hide();
+  } catch (e) {
+    log.error('Error updating scenery type:', e);
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+async function submitNewScenery(): Promise<void> {
+  const valid = await vNewScenery$.value.$validate();
+  if (!valid || isSubmitting.value) return;
+  isSubmitting.value = true;
+  try {
+    await stageStore.addScenery({
+      name: newSceneryForm.value.name,
+      description: newSceneryForm.value.description || null,
+      scenery_type_id: newSceneryForm.value.scenery_type_id!,
+    });
+    newSceneryModal.value?.hide();
+  } catch (e) {
+    log.error('Error adding scenery:', e);
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+async function submitEditScenery(): Promise<void> {
+  const valid = await vEditScenery$.value.$validate();
+  if (!valid || isSubmitting.value) return;
+  isSubmitting.value = true;
+  try {
+    await stageStore.updateScenery({
+      id: editSceneryForm.value.id!,
+      name: editSceneryForm.value.name,
+      description: editSceneryForm.value.description || null,
+      scenery_type_id: editSceneryForm.value.scenery_type_id!,
+    });
+    editSceneryModal.value?.hide();
+  } catch (e) {
+    log.error('Error updating scenery:', e);
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+async function confirmDeleteSceneryType(type: SceneryType): Promise<void> {
+  const itemCount = stageStore.sceneryList.filter((s) => s.scenery_type_id === type.id).length;
+  let msg = `Are you sure you want to delete ${type.name}?`;
+  if (itemCount > 0) msg += ` This will also delete ${itemCount} scenery items.`;
+  const ok = await confirm(msg, {
+    title: 'Delete Scenery Type',
+    okVariant: 'danger',
+    okTitle: 'Delete',
+  });
+  if (!ok) return;
+  try {
+    await stageStore.deleteSceneryType(type.id);
+  } catch (e) {
+    log.error('Error deleting scenery type:', e);
+  }
+}
+
+async function confirmDeleteScenery(scenery: Scenery): Promise<void> {
+  const ok = await confirm(`Are you sure you want to delete ${scenery.name}?`, {
+    title: 'Delete Scenery',
+    okVariant: 'danger',
+    okTitle: 'Delete',
+  });
+  if (!ok) return;
+  try {
+    await stageStore.deleteScenery(scenery.id);
+  } catch (e) {
+    log.error('Error deleting scenery:', e);
+  }
+}
+
+onMounted(async () => {
+  await Promise.all([stageStore.getSceneryTypes(), stageStore.getSceneryList()]);
+});
+</script>

--- a/client-v3/src/components/show/config/stage/StageManager.vue
+++ b/client-v3/src/components/show/config/stage/StageManager.vue
@@ -1,0 +1,962 @@
+<template>
+  <BContainer class="mx-0 px-0 stage-manager-container" fluid>
+    <template v-if="loaded && orderedScenes.length > 0">
+      <div class="sticky-header" :style="{ top: navbarHeight + 'px' }">
+        <BRow>
+          <BCol cols="2">
+            <BButton
+              :disabled="orderedScenes.length === 0"
+              variant="success"
+              @click="goToSceneModal?.show()"
+            >
+              Go to Scene
+            </BButton>
+          </BCol>
+          <BCol cols="2" style="text-align: right">
+            <BButton variant="success" :disabled="currentSceneIndex === 0" @click="decrScene">
+              Prev Scene
+            </BButton>
+          </BCol>
+          <BCol cols="4" class="text-center">
+            <b>{{ currentSceneLabel }}</b>
+          </BCol>
+          <BCol cols="2" style="text-align: left">
+            <BButton
+              variant="success"
+              :disabled="
+                orderedScenes.length === 0 || currentSceneIndex === orderedScenes.length - 1
+              "
+              @click="incrScene"
+            >
+              Next Scene
+            </BButton>
+          </BCol>
+          <BCol cols="2" />
+        </BRow>
+      </div>
+
+      <!-- Allocations card -->
+      <BCard no-body class="section-card mt-2">
+        <BCardHeader
+          class="section-card-header"
+          @click="allocationsExpanded = !allocationsExpanded"
+        >
+          <div class="d-flex justify-content-between align-items-center">
+            <span>
+              Allocations
+              <BBadge variant="light" class="ml-1">
+                {{ currentSceneSceneryAllocations.length + currentScenePropsAllocations.length }}
+              </BBadge>
+            </span>
+            <span>{{ allocationsExpanded ? '▲' : '▼' }}</span>
+          </div>
+        </BCardHeader>
+        <BCollapse v-model="allocationsExpanded">
+          <BCardBody>
+            <div class="d-flex justify-content-end mb-2">
+              <BDropdown :disabled="orderedScenes.length === 0" right text="Add" variant="success">
+                <BDropdownItem @click="addSceneryModal?.show()">Scenery</BDropdownItem>
+                <BDropdownItem @click="addPropModal?.show()">Prop</BDropdownItem>
+              </BDropdown>
+            </div>
+            <BRow>
+              <BCol cols="6" style="border-right: 1px solid #dee2e6">
+                <h5>Scenery</h5>
+                <BTable
+                  :items="currentSceneSceneryAllocations"
+                  :fields="sceneryAllocFields"
+                  :per-page="rowsPerPage"
+                  :current-page="currentSceneryAllocPage"
+                  show-empty
+                  empty-text="No scenery allocated to this scene"
+                >
+                  <template #cell(scenery_name)="data">
+                    {{ stageStore.sceneryById(data.item.scenery_id)?.name }}
+                  </template>
+                  <template #cell(scenery_type)="data">
+                    {{
+                      stageStore.sceneryTypeById(
+                        stageStore.sceneryById(data.item.scenery_id)?.scenery_type_id ?? null
+                      )?.name
+                    }}
+                  </template>
+                  <template #cell(btn)="data">
+                    <BButton variant="danger" size="sm" @click="deleteSceneryAllocation(data.item)">
+                      Delete
+                    </BButton>
+                  </template>
+                </BTable>
+                <BPagination
+                  v-if="currentSceneSceneryAllocations.length > rowsPerPage"
+                  v-model="currentSceneryAllocPage"
+                  :total-rows="currentSceneSceneryAllocations.length"
+                  :per-page="rowsPerPage"
+                />
+              </BCol>
+              <BCol cols="6">
+                <h5>Props</h5>
+                <BTable
+                  :items="currentScenePropsAllocations"
+                  :fields="propsAllocFields"
+                  :per-page="rowsPerPage"
+                  :current-page="currentPropsAllocPage"
+                  show-empty
+                  empty-text="No props allocated to this scene"
+                >
+                  <template #cell(prop_name)="data">
+                    {{ stageStore.propById(data.item.props_id)?.name }}
+                  </template>
+                  <template #cell(prop_type)="data">
+                    {{
+                      stageStore.propTypeById(
+                        stageStore.propById(data.item.props_id)?.prop_type_id ?? null
+                      )?.name
+                    }}
+                  </template>
+                  <template #cell(btn)="data">
+                    <BButton variant="danger" size="sm" @click="deletePropAllocation(data.item)">
+                      Delete
+                    </BButton>
+                  </template>
+                </BTable>
+                <BPagination
+                  v-if="currentScenePropsAllocations.length > rowsPerPage"
+                  v-model="currentPropsAllocPage"
+                  :total-rows="currentScenePropsAllocations.length"
+                  :per-page="rowsPerPage"
+                />
+              </BCol>
+            </BRow>
+          </BCardBody>
+        </BCollapse>
+      </BCard>
+
+      <!-- SET card -->
+      <BCard v-if="setItems.length > 0" no-body class="section-card mt-2">
+        <BCardHeader class="section-card-header" @click="setExpanded = !setExpanded">
+          <div class="d-flex justify-content-between align-items-center">
+            <span>
+              SET
+              <BBadge variant="light" class="ml-1">{{ setItems.length }}</BBadge>
+            </span>
+            <span class="d-flex align-items-center gap-1">
+              <BBadge v-if="unassignedSetCount > 0" variant="warning">
+                {{ unassignedSetCount }} unassigned
+              </BBadge>
+              <span>{{ setExpanded ? '▲' : '▼' }}</span>
+            </span>
+          </div>
+        </BCardHeader>
+        <BCollapse v-model="setExpanded">
+          <BCardBody class="crew-card-body">
+            <div class="boundary-items-grid">
+              <div
+                v-for="item in setItems"
+                :key="'set-' + item.itemType + '-' + item.itemId"
+                class="boundary-item"
+              >
+                <div class="boundary-item-header">
+                  <span class="item-name">{{ item.name }}</span>
+                  <BBadge variant="secondary" pill class="ml-1">{{ item.itemType }}</BBadge>
+                </div>
+                <div class="assignment-list">
+                  <span
+                    v-for="assignment in getAssignmentsForItem(item.itemId, item.itemType, 'set')"
+                    :key="assignment.id"
+                    class="crew-badge"
+                  >
+                    {{ formatCrewName(stageStore.crewById(assignment.crew_id)) }}
+                    <BButton
+                      variant="link"
+                      size="sm"
+                      class="remove-btn text-danger p-0 ml-1"
+                      :disabled="savingAssignment"
+                      @click="removeCrewAssignment(assignment)"
+                    >
+                      &#215;
+                    </BButton>
+                  </span>
+                  <span
+                    v-if="getAssignmentsForItem(item.itemId, item.itemType, 'set').length === 0"
+                    class="text-muted small"
+                  >
+                    No crew assigned
+                  </span>
+                </div>
+                <div class="add-crew-container mt-1">
+                  <BFormSelect
+                    :model-value="
+                      newCrewSelections[crewSelectionKey(item.itemId, item.itemType, 'set')]
+                    "
+                    :options="getAvailableCrewForItem(item.itemId, item.itemType, 'set')"
+                    :disabled="savingAssignment"
+                    size="sm"
+                    class="add-crew-select"
+                    @update:model-value="
+                      newCrewSelections[crewSelectionKey(item.itemId, item.itemType, 'set')] =
+                        $event
+                    "
+                  >
+                    <template #first>
+                      <BFormSelectOption :value="null" disabled>+ Add crew</BFormSelectOption>
+                    </template>
+                  </BFormSelect>
+                  <BButton
+                    v-show="newCrewSelections[crewSelectionKey(item.itemId, item.itemType, 'set')]"
+                    variant="primary"
+                    size="sm"
+                    :disabled="savingAssignment"
+                    @click="addCrewAssignment(item.itemId, item.itemType, 'set')"
+                  >
+                    Add
+                  </BButton>
+                </div>
+              </div>
+            </div>
+          </BCardBody>
+        </BCollapse>
+      </BCard>
+
+      <!-- STRIKE card -->
+      <BCard v-if="strikeItems.length > 0" no-body class="section-card mt-2">
+        <BCardHeader class="section-card-header" @click="strikeExpanded = !strikeExpanded">
+          <div class="d-flex justify-content-between align-items-center">
+            <span>
+              STRIKE
+              <BBadge variant="light" class="ml-1">{{ strikeItems.length }}</BBadge>
+            </span>
+            <span class="d-flex align-items-center gap-1">
+              <BBadge v-if="unassignedStrikeCount > 0" variant="warning">
+                {{ unassignedStrikeCount }} unassigned
+              </BBadge>
+              <span>{{ strikeExpanded ? '▲' : '▼' }}</span>
+            </span>
+          </div>
+        </BCardHeader>
+        <BCollapse v-model="strikeExpanded">
+          <BCardBody class="crew-card-body">
+            <div class="boundary-items-grid">
+              <div
+                v-for="item in strikeItems"
+                :key="'strike-' + item.itemType + '-' + item.itemId"
+                class="boundary-item"
+              >
+                <div class="boundary-item-header">
+                  <span class="item-name">{{ item.name }}</span>
+                  <BBadge variant="secondary" pill class="ml-1">{{ item.itemType }}</BBadge>
+                </div>
+                <div class="assignment-list">
+                  <span
+                    v-for="assignment in getAssignmentsForItem(
+                      item.itemId,
+                      item.itemType,
+                      'strike'
+                    )"
+                    :key="assignment.id"
+                    class="crew-badge"
+                  >
+                    {{ formatCrewName(stageStore.crewById(assignment.crew_id)) }}
+                    <BButton
+                      variant="link"
+                      size="sm"
+                      class="remove-btn text-danger p-0 ml-1"
+                      :disabled="savingAssignment"
+                      @click="removeCrewAssignment(assignment)"
+                    >
+                      &#215;
+                    </BButton>
+                  </span>
+                  <span
+                    v-if="getAssignmentsForItem(item.itemId, item.itemType, 'strike').length === 0"
+                    class="text-muted small"
+                  >
+                    No crew assigned
+                  </span>
+                </div>
+                <div class="add-crew-container mt-1">
+                  <BFormSelect
+                    :model-value="
+                      newCrewSelections[crewSelectionKey(item.itemId, item.itemType, 'strike')]
+                    "
+                    :options="getAvailableCrewForItem(item.itemId, item.itemType, 'strike')"
+                    :disabled="savingAssignment"
+                    size="sm"
+                    class="add-crew-select"
+                    @update:model-value="
+                      newCrewSelections[crewSelectionKey(item.itemId, item.itemType, 'strike')] =
+                        $event
+                    "
+                  >
+                    <template #first>
+                      <BFormSelectOption :value="null" disabled>+ Add crew</BFormSelectOption>
+                    </template>
+                  </BFormSelect>
+                  <BButton
+                    v-show="
+                      newCrewSelections[crewSelectionKey(item.itemId, item.itemType, 'strike')]
+                    "
+                    variant="primary"
+                    size="sm"
+                    :disabled="savingAssignment"
+                    @click="addCrewAssignment(item.itemId, item.itemType, 'strike')"
+                  >
+                    Add
+                  </BButton>
+                </div>
+              </div>
+            </div>
+          </BCardBody>
+        </BCollapse>
+      </BCard>
+
+      <!-- Go to Scene modal -->
+      <BModal
+        ref="goToSceneModal"
+        title="Go To Scene"
+        @hidden="resetGoToSceneForm"
+        @ok.prevent="onSubmitGoToScene"
+      >
+        <BForm>
+          <BFormGroup label="Scene" label-for="goto-scene-select">
+            <BFormSelect
+              id="goto-scene-select"
+              v-model="goToSceneForm.scene_index"
+              :options="sceneFormOptions"
+              :state="validationState(vGoTo$.scene_index)"
+            />
+            <BFormInvalidFeedback>
+              {{ vGoTo$.scene_index.$errors[0]?.$message }}
+            </BFormInvalidFeedback>
+          </BFormGroup>
+        </BForm>
+      </BModal>
+
+      <!-- Add Scenery modal -->
+      <BModal
+        ref="addSceneryModal"
+        title="Add Scenery to Scene"
+        @hidden="resetAddSceneryForm"
+        @ok.prevent="onSubmitAddScenery"
+      >
+        <BForm>
+          <BFormGroup label="Scenery" label-for="add-scenery-select">
+            <BFormSelect
+              id="add-scenery-select"
+              v-model="addSceneryForm.scenery_id"
+              :state="validationState(vAddScenery$.scenery_id)"
+            >
+              <template #first>
+                <BFormSelectOption :value="null" disabled
+                  >Please select scenery...</BFormSelectOption
+                >
+              </template>
+              <BFormSelectOptionGroup
+                v-for="group in sceneryOptionsByType"
+                :key="group.label"
+                :label="group.label"
+              >
+                <BFormSelectOption
+                  v-for="option in group.options"
+                  :key="option.value"
+                  :value="option.value"
+                >
+                  {{ option.text }}
+                </BFormSelectOption>
+              </BFormSelectOptionGroup>
+            </BFormSelect>
+            <BFormInvalidFeedback>
+              {{ vAddScenery$.scenery_id.$errors[0]?.$message }}
+            </BFormInvalidFeedback>
+          </BFormGroup>
+        </BForm>
+      </BModal>
+
+      <!-- Add Prop modal -->
+      <BModal
+        ref="addPropModal"
+        title="Add Prop to Scene"
+        @hidden="resetAddPropForm"
+        @ok.prevent="onSubmitAddProp"
+      >
+        <BForm>
+          <BFormGroup label="Prop" label-for="add-prop-select">
+            <BFormSelect
+              id="add-prop-select"
+              v-model="addPropForm.props_id"
+              :state="validationState(vAddProp$.props_id)"
+            >
+              <template #first>
+                <BFormSelectOption :value="null" disabled
+                  >Please select a prop...</BFormSelectOption
+                >
+              </template>
+              <BFormSelectOptionGroup
+                v-for="group in propOptionsByType"
+                :key="group.label"
+                :label="group.label"
+              >
+                <BFormSelectOption
+                  v-for="option in group.options"
+                  :key="option.value"
+                  :value="option.value"
+                >
+                  {{ option.text }}
+                </BFormSelectOption>
+              </BFormSelectOptionGroup>
+            </BFormSelect>
+            <BFormInvalidFeedback>
+              {{ vAddProp$.props_id.$errors[0]?.$message }}
+            </BFormInvalidFeedback>
+          </BFormGroup>
+        </BForm>
+      </BModal>
+    </template>
+
+    <BRow v-else>
+      <BCol>
+        <BAlert v-if="loaded" variant="danger" show>
+          There are no scenes configured for this show.
+        </BAlert>
+        <div v-else class="text-center py-5">
+          <BSpinner label="Loading" />
+        </div>
+      </BCol>
+    </BRow>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue';
+import type { BModal } from 'bootstrap-vue-next';
+import { useVuelidate } from '@vuelidate/core';
+import { required, helpers } from '@vuelidate/validators';
+import { useStageStore } from '@/stores/stage';
+import { useShowStore } from '@/stores/show';
+import { useConfirm } from '@/composables/useConfirm';
+import { useFormValidation } from '@/composables/useFormValidation';
+import { findOrphanedAssignments } from '@/js/blockOrphanUtils';
+import type { SceneryAllocation, PropsAllocation, CrewAssignment, Crew } from '@/types/api/stage';
+import log from 'loglevel';
+
+const stageStore = useStageStore();
+const showStore = useShowStore();
+const { confirm } = useConfirm();
+const { validationState } = useFormValidation();
+
+const loaded = ref(false);
+const navbarHeight = ref(56);
+const currentSceneIndex = ref(0);
+const allocationsExpanded = ref(true);
+const setExpanded = ref(false);
+const strikeExpanded = ref(false);
+const savingAssignment = ref(false);
+const newCrewSelections = ref<Record<string, number | null>>({});
+const rowsPerPage = 10;
+const currentSceneryAllocPage = ref(1);
+const currentPropsAllocPage = ref(1);
+
+const goToSceneModal = ref<InstanceType<typeof BModal>>();
+const addSceneryModal = ref<InstanceType<typeof BModal>>();
+const addPropModal = ref<InstanceType<typeof BModal>>();
+
+const goToSceneForm = ref<{ scene_index: number | null }>({ scene_index: null });
+const addSceneryForm = ref<{ scenery_id: number | null }>({ scenery_id: null });
+const addPropForm = ref<{ props_id: number | null }>({ props_id: null });
+
+const sceneryAllocFields = [
+  { key: 'scenery_name', label: 'Name' },
+  { key: 'scenery_type', label: 'Type' },
+  { key: 'btn', label: '' },
+];
+const propsAllocFields = [
+  { key: 'prop_name', label: 'Name' },
+  { key: 'prop_type', label: 'Type' },
+  { key: 'btn', label: '' },
+];
+
+const notNull = helpers.withMessage('This is a required field.', (v: unknown) => v !== null);
+const vGoTo$ = useVuelidate({ scene_index: { required, notNull } }, goToSceneForm);
+const vAddScenery$ = useVuelidate({ scenery_id: { required, notNull } }, addSceneryForm);
+const vAddProp$ = useVuelidate({ props_id: { required, notNull } }, addPropForm);
+
+const orderedScenes = computed(() => showStore.orderedScenes);
+const currentScene = computed(() => orderedScenes.value[currentSceneIndex.value] ?? null);
+
+const currentSceneLabel = computed(() => {
+  if (!currentScene.value) return 'N/A';
+  const act = showStore.actById(currentScene.value.act);
+  return `${act?.name ?? 'Act'}: ${currentScene.value.name}`;
+});
+
+const sceneFormOptions = computed(() => [
+  { value: null, text: 'Please select an option', disabled: true },
+  ...orderedScenes.value.map((scene, index) => ({
+    value: index,
+    text: `${showStore.actById(scene.act)?.name ?? 'Act'}: ${scene.name}`,
+  })),
+]);
+
+const previousSceneInAct = computed(() => {
+  if (currentSceneIndex.value <= 0 || !currentScene.value) return null;
+  const prev = orderedScenes.value[currentSceneIndex.value - 1];
+  return prev?.act === currentScene.value.act ? prev : null;
+});
+
+const nextSceneInAct = computed(() => {
+  if (!currentScene.value || currentSceneIndex.value >= orderedScenes.value.length - 1) return null;
+  const next = orderedScenes.value[currentSceneIndex.value + 1];
+  return next?.act === currentScene.value.act ? next : null;
+});
+
+const currentSceneSceneryAllocations = computed((): SceneryAllocation[] => {
+  if (!currentScene.value) return [];
+  return stageStore.sceneryAllocations.filter((a) => a.scene_id === currentScene.value!.id);
+});
+
+const currentScenePropsAllocations = computed((): PropsAllocation[] => {
+  if (!currentScene.value) return [];
+  return stageStore.propsAllocations.filter((a) => a.scene_id === currentScene.value!.id);
+});
+
+const setItems = computed(() => {
+  if (!currentScene.value) return [];
+  const sceneId = currentScene.value.id;
+  const prevSceneId = previousSceneInAct.value?.id;
+  const items: Array<{ itemId: number; itemType: string; name: string }> = [];
+
+  for (const scenery of stageStore.sceneryList) {
+    const allocs = stageStore.sceneryAllocationsByItem[scenery.id] ?? [];
+    if (!allocs.some((a) => a.scene_id === sceneId)) continue;
+    if (!prevSceneId || !allocs.some((a) => a.scene_id === prevSceneId)) {
+      items.push({ itemId: scenery.id, itemType: 'scenery', name: scenery.name });
+    }
+  }
+  for (const prop of stageStore.propsList) {
+    const allocs = stageStore.propsAllocationsByItem[prop.id] ?? [];
+    if (!allocs.some((a) => a.scene_id === sceneId)) continue;
+    if (!prevSceneId || !allocs.some((a) => a.scene_id === prevSceneId)) {
+      items.push({ itemId: prop.id, itemType: 'prop', name: prop.name });
+    }
+  }
+  return items;
+});
+
+const strikeItems = computed(() => {
+  if (!currentScene.value) return [];
+  const sceneId = currentScene.value.id;
+  const nextSceneId = nextSceneInAct.value?.id;
+  const items: Array<{ itemId: number; itemType: string; name: string }> = [];
+
+  for (const scenery of stageStore.sceneryList) {
+    const allocs = stageStore.sceneryAllocationsByItem[scenery.id] ?? [];
+    if (!allocs.some((a) => a.scene_id === sceneId)) continue;
+    if (!nextSceneId || !allocs.some((a) => a.scene_id === nextSceneId)) {
+      items.push({ itemId: scenery.id, itemType: 'scenery', name: scenery.name });
+    }
+  }
+  for (const prop of stageStore.propsList) {
+    const allocs = stageStore.propsAllocationsByItem[prop.id] ?? [];
+    if (!allocs.some((a) => a.scene_id === sceneId)) continue;
+    if (!nextSceneId || !allocs.some((a) => a.scene_id === nextSceneId)) {
+      items.push({ itemId: prop.id, itemType: 'prop', name: prop.name });
+    }
+  }
+  return items;
+});
+
+const unassignedSetCount = computed(
+  () =>
+    setItems.value.filter(
+      (item) => getAssignmentsForItem(item.itemId, item.itemType, 'set').length === 0
+    ).length
+);
+
+const unassignedStrikeCount = computed(
+  () =>
+    strikeItems.value.filter(
+      (item) => getAssignmentsForItem(item.itemId, item.itemType, 'strike').length === 0
+    ).length
+);
+
+const availableSceneryForScene = computed(() => {
+  if (!currentScene.value) return [];
+  const allocatedIds = new Set(
+    stageStore.sceneryAllocations
+      .filter((a) => a.scene_id === currentScene.value!.id)
+      .map((a) => a.scenery_id)
+  );
+  return stageStore.sceneryList.filter((s) => !allocatedIds.has(s.id));
+});
+
+const availablePropsForScene = computed(() => {
+  if (!currentScene.value) return [];
+  const allocatedIds = new Set(
+    stageStore.propsAllocations
+      .filter((a) => a.scene_id === currentScene.value!.id)
+      .map((a) => a.props_id)
+  );
+  return stageStore.propsList.filter((p) => !allocatedIds.has(p.id));
+});
+
+const sceneryOptionsByType = computed(() =>
+  stageStore.sceneryTypes
+    .map((type) => ({
+      label: type.name,
+      options: availableSceneryForScene.value
+        .filter((s) => s.scenery_type_id === type.id)
+        .map((s) => ({ value: s.id, text: s.name })),
+    }))
+    .filter((group) => group.options.length > 0)
+);
+
+const propOptionsByType = computed(() =>
+  stageStore.propTypes
+    .map((type) => ({
+      label: type.name,
+      options: availablePropsForScene.value
+        .filter((p) => p.prop_type_id === type.id)
+        .map((p) => ({ value: p.id, text: p.name })),
+    }))
+    .filter((group) => group.options.length > 0)
+);
+
+function calculateNavbarHeight(): void {
+  const navbar = document.querySelector('.navbar') as HTMLElement | null;
+  navbarHeight.value = navbar?.offsetHeight ?? 56;
+}
+
+function incrScene(): void {
+  if (currentSceneIndex.value < orderedScenes.value.length - 1) {
+    currentSceneIndex.value += 1;
+  }
+}
+
+function decrScene(): void {
+  if (currentSceneIndex.value > 0) {
+    currentSceneIndex.value -= 1;
+  }
+}
+
+function formatCrewName(crew: Crew | null): string {
+  if (!crew) return 'Unknown';
+  return [crew.first_name, crew.last_name].filter(Boolean).join(' ');
+}
+
+function crewSelectionKey(itemId: number, itemType: string, assignmentType: string): string {
+  return `${itemType}-${itemId}-${assignmentType}`;
+}
+
+function getAssignmentsForItem(
+  itemId: number,
+  itemType: string,
+  assignmentType: string
+): CrewAssignment[] {
+  const assignments: CrewAssignment[] =
+    itemType === 'prop'
+      ? (stageStore.crewAssignmentsByProp[itemId] ?? [])
+      : (stageStore.crewAssignmentsByScenery[itemId] ?? []);
+  return assignments.filter(
+    (a) => a.assignment_type === assignmentType && a.scene_id === currentScene.value?.id
+  );
+}
+
+function getAvailableCrewForItem(
+  itemId: number,
+  itemType: string,
+  assignmentType: string
+): Array<{ value: number; text: string }> {
+  const assigned = new Set(
+    getAssignmentsForItem(itemId, itemType, assignmentType).map((a) => a.crew_id)
+  );
+  return stageStore.crewList
+    .filter((c) => !assigned.has(c.id))
+    .map((c) => ({ value: c.id, text: formatCrewName(c) }));
+}
+
+function buildOrphanMessage(orphans: CrewAssignment[]): string {
+  const lines = orphans.map((o) => {
+    const crew = stageStore.crewById(o.crew_id);
+    return `• ${formatCrewName(crew)} (${o.assignment_type.toUpperCase()})`;
+  });
+  return `This action will remove the following crew assignments:\n${lines.join('\n')}\n\nYou can reassign crew after the change.`;
+}
+
+function findOrphansForItem(
+  itemId: number,
+  itemType: string,
+  changeType: 'add' | 'remove',
+  sceneId: number
+): CrewAssignment[] {
+  const allocations =
+    itemType === 'scenery'
+      ? stageStore.sceneryAllocations.filter((a) => a.scenery_id === itemId)
+      : stageStore.propsAllocations.filter((a) => a.props_id === itemId);
+  const crewAssignments: CrewAssignment[] =
+    itemType === 'scenery'
+      ? (stageStore.crewAssignmentsByScenery[itemId] ?? [])
+      : (stageStore.crewAssignmentsByProp[itemId] ?? []);
+  return findOrphanedAssignments({
+    orderedScenes: orderedScenes.value,
+    currentAllocations: allocations,
+    crewAssignments,
+    changeType,
+    changeSceneId: sceneId,
+  }) as unknown as CrewAssignment[];
+}
+
+function resetGoToSceneForm(): void {
+  goToSceneForm.value = { scene_index: null };
+  vGoTo$.value.$reset();
+}
+
+function resetAddSceneryForm(): void {
+  addSceneryForm.value = { scenery_id: null };
+  vAddScenery$.value.$reset();
+}
+
+function resetAddPropForm(): void {
+  addPropForm.value = { props_id: null };
+  vAddProp$.value.$reset();
+}
+
+async function onSubmitGoToScene(): Promise<void> {
+  const valid = await vGoTo$.value.$validate();
+  if (!valid) return;
+  currentSceneIndex.value = goToSceneForm.value.scene_index!;
+  goToSceneModal.value?.hide();
+}
+
+async function onSubmitAddScenery(): Promise<void> {
+  const valid = await vAddScenery$.value.$validate();
+  if (!valid || !currentScene.value) return;
+  const sceneryId = addSceneryForm.value.scenery_id!;
+  const orphans = findOrphansForItem(sceneryId, 'scenery', 'add', currentScene.value.id);
+  if (orphans.length > 0) {
+    const ok = await confirm(buildOrphanMessage(orphans), {
+      title: 'Crew assignments will be removed',
+      okTitle: 'Continue',
+      okVariant: 'warning',
+    });
+    if (!ok) return;
+  }
+  try {
+    await stageStore.addSceneryAllocation({
+      scenery_id: sceneryId,
+      scene_id: currentScene.value.id,
+    });
+    addSceneryModal.value?.hide();
+  } catch (e) {
+    log.error('Error adding scenery allocation:', e);
+  }
+}
+
+async function onSubmitAddProp(): Promise<void> {
+  const valid = await vAddProp$.value.$validate();
+  if (!valid || !currentScene.value) return;
+  const propsId = addPropForm.value.props_id!;
+  const orphans = findOrphansForItem(propsId, 'prop', 'add', currentScene.value.id);
+  if (orphans.length > 0) {
+    const ok = await confirm(buildOrphanMessage(orphans), {
+      title: 'Crew assignments will be removed',
+      okTitle: 'Continue',
+      okVariant: 'warning',
+    });
+    if (!ok) return;
+  }
+  try {
+    await stageStore.addPropsAllocation({ props_id: propsId, scene_id: currentScene.value.id });
+    addPropModal.value?.hide();
+  } catch (e) {
+    log.error('Error adding prop allocation:', e);
+  }
+}
+
+async function deleteSceneryAllocation(allocation: SceneryAllocation): Promise<void> {
+  const orphans = findOrphansForItem(
+    allocation.scenery_id,
+    'scenery',
+    'remove',
+    currentScene.value!.id
+  );
+  const sceneryName = stageStore.sceneryById(allocation.scenery_id)?.name ?? 'Unknown';
+  if (orphans.length > 0) {
+    const ok = await confirm(buildOrphanMessage(orphans), {
+      title: 'Crew assignments will be removed',
+      okTitle: 'Continue',
+      okVariant: 'danger',
+    });
+    if (!ok) return;
+  } else {
+    const ok = await confirm(`Remove "${sceneryName}" from this scene?`, {
+      okVariant: 'danger',
+      okTitle: 'Remove',
+    });
+    if (!ok) return;
+  }
+  try {
+    await stageStore.deleteSceneryAllocation(allocation.id);
+  } catch (e) {
+    log.error('Error deleting scenery allocation:', e);
+  }
+}
+
+async function deletePropAllocation(allocation: PropsAllocation): Promise<void> {
+  const orphans = findOrphansForItem(allocation.props_id, 'prop', 'remove', currentScene.value!.id);
+  const propName = stageStore.propById(allocation.props_id)?.name ?? 'Unknown';
+  if (orphans.length > 0) {
+    const ok = await confirm(buildOrphanMessage(orphans), {
+      title: 'Crew assignments will be removed',
+      okTitle: 'Continue',
+      okVariant: 'danger',
+    });
+    if (!ok) return;
+  } else {
+    const ok = await confirm(`Remove "${propName}" from this scene?`, {
+      okVariant: 'danger',
+      okTitle: 'Remove',
+    });
+    if (!ok) return;
+  }
+  try {
+    await stageStore.deletePropsAllocation(allocation.id);
+  } catch (e) {
+    log.error('Error deleting prop allocation:', e);
+  }
+}
+
+async function addCrewAssignment(
+  itemId: number,
+  itemType: string,
+  assignmentType: string
+): Promise<void> {
+  const key = crewSelectionKey(itemId, itemType, assignmentType);
+  const crewId = newCrewSelections.value[key];
+  if (!crewId || !currentScene.value || savingAssignment.value) return;
+  savingAssignment.value = true;
+  try {
+    const assignment: Record<string, unknown> = {
+      crew_id: crewId,
+      scene_id: currentScene.value.id,
+      assignment_type: assignmentType,
+    };
+    if (itemType === 'prop') {
+      assignment.prop_id = itemId;
+    } else {
+      assignment.scenery_id = itemId;
+    }
+    const success = await stageStore.addCrewAssignment(assignment);
+    if (success) newCrewSelections.value[key] = null;
+  } finally {
+    savingAssignment.value = false;
+  }
+}
+
+async function removeCrewAssignment(assignment: CrewAssignment): Promise<void> {
+  if (savingAssignment.value) return;
+  const crewName = formatCrewName(stageStore.crewById(assignment.crew_id));
+  const ok = await confirm(
+    `Remove ${crewName} from this ${assignment.assignment_type.toUpperCase()} assignment?`,
+    { okTitle: 'Remove', okVariant: 'danger' }
+  );
+  if (!ok) return;
+  savingAssignment.value = true;
+  try {
+    await stageStore.deleteCrewAssignment(assignment.id);
+  } catch (e) {
+    log.error('Error removing crew assignment:', e);
+  } finally {
+    savingAssignment.value = false;
+  }
+}
+
+onMounted(async () => {
+  window.addEventListener('resize', calculateNavbarHeight);
+  await Promise.all([
+    showStore.getActList(),
+    showStore.getSceneList(),
+    stageStore.getSceneryTypes(),
+    stageStore.getSceneryList(),
+    stageStore.getSceneryAllocations(),
+    stageStore.getPropTypes(),
+    stageStore.getPropsList(),
+    stageStore.getPropsAllocations(),
+    stageStore.getCrewList(),
+    stageStore.getCrewAssignments(),
+  ]);
+  loaded.value = true;
+  calculateNavbarHeight();
+});
+
+onUnmounted(() => {
+  window.removeEventListener('resize', calculateNavbarHeight);
+});
+</script>
+
+<style scoped>
+.stage-manager-container {
+  position: relative;
+}
+
+.sticky-header {
+  position: sticky;
+  z-index: 100;
+  padding: 10px 0;
+  border-bottom: 1px solid #dee2e6;
+  background: var(--body-background);
+}
+
+.section-card-header {
+  cursor: pointer;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.crew-card-body {
+  padding: 0.75rem;
+}
+
+.boundary-items-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 0.5rem;
+}
+
+.boundary-item {
+  padding: 0.5rem 0.65rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+}
+
+.boundary-item-header {
+  margin-bottom: 0.25rem;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.assignment-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+.crew-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 0.8rem;
+}
+
+.add-crew-container {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.add-crew-select {
+  flex: 1;
+}
+</style>

--- a/client-v3/src/components/show/config/stage/StageTimeline.vue
+++ b/client-v3/src/components/show/config/stage/StageTimeline.vue
@@ -1,0 +1,340 @@
+<template>
+  <div class="timeline-container">
+    <div v-if="!dataLoaded" class="text-center py-5">
+      <BSpinner label="Loading timeline..." />
+    </div>
+    <div v-else class="timeline-with-panel">
+      <div class="timeline-wrapper">
+        <div class="timeline-controls-bar">
+          <BButtonGroup>
+            <BButton
+              :variant="viewMode === 'combined' ? 'primary' : 'outline-primary'"
+              size="sm"
+              @click="viewMode = 'combined'"
+            >
+              Combined
+            </BButton>
+            <BButton
+              :variant="viewMode === 'props' ? 'primary' : 'outline-primary'"
+              size="sm"
+              @click="viewMode = 'props'"
+            >
+              Props
+            </BButton>
+            <BButton
+              :variant="viewMode === 'scenery' ? 'primary' : 'outline-primary'"
+              size="sm"
+              @click="viewMode = 'scenery'"
+            >
+              Scenery
+            </BButton>
+          </BButtonGroup>
+          <BButton
+            size="sm"
+            variant="outline-secondary"
+            title="Export as PNG"
+            @click="handleExport"
+          >
+            &#8659;
+          </BButton>
+        </div>
+        <div class="svg-container">
+          <div v-if="!hasData" class="text-center py-5 text-muted">
+            No allocation data to display for this view
+          </div>
+          <svg v-else ref="svgRef" :width="totalWidth" :height="totalHeight" class="timeline-svg">
+            <g class="act-labels" :transform="`translate(${margin.left},0)`">
+              <g v-for="actGroup in actGroups" :key="`act-${actGroup.actId}`">
+                <rect
+                  :x="actGroup.startX"
+                  :y="5"
+                  :width="actGroup.width"
+                  :height="25"
+                  class="act-header"
+                />
+                <text
+                  :x="actGroup.startX + actGroup.width / 2"
+                  :y="22"
+                  class="act-label"
+                  text-anchor="middle"
+                >
+                  {{ actGroup.actName }}
+                </text>
+              </g>
+            </g>
+            <g class="scene-labels" :transform="`translate(${margin.left},${margin.top})`">
+              <text
+                v-for="(scene, index) in scenes"
+                :key="`scene-label-${scene.id}`"
+                :x="getSceneX(index) + sceneWidth / 2"
+                :y="-10"
+                class="scene-label"
+                text-anchor="middle"
+              >
+                {{ scene.name }}
+              </text>
+            </g>
+            <g :transform="`translate(${margin.left},${margin.top})`">
+              <g class="scene-dividers">
+                <line
+                  v-for="(scene, index) in scenes"
+                  :key="`divider-${scene.id}`"
+                  :x1="getSceneX(index)"
+                  :y1="0"
+                  :x2="getSceneX(index)"
+                  :y2="contentHeight"
+                  class="scene-divider"
+                />
+              </g>
+              <g class="allocation-bars">
+                <g v-for="bar in allocationBars" :key="bar.id">
+                  <rect
+                    :x="bar.x"
+                    :y="bar.y"
+                    :width="bar.width"
+                    :height="bar.height"
+                    :fill="bar.color"
+                    :class="['allocation-bar', { selected: isBarSelected(bar) }]"
+                    @click="handleBarClick(bar)"
+                  />
+                  <title>{{ bar.tooltip }}</title>
+                  <text
+                    v-if="bar.width >= 30"
+                    :x="bar.x + bar.width / 2"
+                    :y="bar.y + bar.height / 2"
+                    class="bar-label"
+                    text-anchor="middle"
+                    dominant-baseline="middle"
+                    pointer-events="none"
+                    :style="{ fontSize: Math.min(12, (bar.width / bar.label.length) * 1.5) + 'px' }"
+                  >
+                    {{ bar.label }}
+                  </text>
+                </g>
+              </g>
+              <g class="row-separators">
+                <line
+                  v-for="(row, index) in rows"
+                  :key="`separator-${row.id}`"
+                  :x1="0"
+                  :y1="getRowY(index) + rowHeight"
+                  :x2="contentWidth"
+                  :y2="getRowY(index) + rowHeight"
+                  class="row-separator"
+                />
+              </g>
+              <g class="row-labels">
+                <text
+                  v-for="(row, index) in rows"
+                  :key="`row-label-${row.id}`"
+                  :x="-10"
+                  :y="getRowY(index) + rowHeight / 2"
+                  class="row-label"
+                  text-anchor="end"
+                  dominant-baseline="middle"
+                >
+                  {{ row.name }}
+                </text>
+              </g>
+            </g>
+          </svg>
+        </div>
+      </div>
+      <TimelineSidePanel
+        :selected-item="selectedItem"
+        :is-open="sidePanelOpen"
+        @close="closeSidePanel"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import type { TimelineRow } from '@/composables/useTimeline';
+import { useTimeline } from '@/composables/useTimeline';
+import { useStageStore } from '@/stores/stage';
+import { useShowStore } from '@/stores/show';
+import TimelineSidePanel from './TimelineSidePanel.vue';
+
+interface BarData {
+  type: 'prop' | 'scenery';
+  itemId: number;
+  startScene: number;
+  endScene: number;
+}
+
+interface TimelineBar {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  color: string;
+  label: string;
+  tooltip: string;
+  data: BarData;
+}
+
+const stageStore = useStageStore();
+const showStore = useShowStore();
+
+const svgRef = ref<SVGSVGElement | null>(null);
+const dataLoaded = ref(false);
+const viewMode = ref<'combined' | 'props' | 'scenery'>('combined');
+const selectedItem = ref<BarData | null>(null);
+const sidePanelOpen = ref(false);
+
+const scenes = computed(() => showStore.orderedScenes);
+
+const rows = computed((): TimelineRow[] => {
+  const propRows = stageStore.propsList
+    .filter((p) => (stageStore.propsAllocationsByItem[p.id] ?? []).length > 0)
+    .map((p): TimelineRow => ({ id: p.id, name: p.name, type: 'prop' }));
+
+  const sceneryRows = stageStore.sceneryList
+    .filter((s) => (stageStore.sceneryAllocationsByItem[s.id] ?? []).length > 0)
+    .map((s): TimelineRow => ({ id: s.id, name: s.name, type: 'scenery' }));
+
+  if (viewMode.value === 'props') return propRows;
+  if (viewMode.value === 'scenery') return sceneryRows;
+  return [...propRows, ...sceneryRows];
+});
+
+const {
+  margin,
+  sceneWidth,
+  rowHeight,
+  barPadding,
+  contentWidth,
+  contentHeight,
+  totalWidth,
+  totalHeight,
+  actGroups,
+  getSceneX,
+  getRowY,
+  getColorForEntity,
+  groupConsecutiveScenes,
+  exportTimeline,
+} = useTimeline(scenes, rows);
+
+const hasData = computed(() => scenes.value.length > 0 && rows.value.length > 0);
+
+const allocationBars = computed((): TimelineBar[] => {
+  const bars: TimelineBar[] = [];
+  rows.value.forEach((row, rowIndex) => {
+    const allocations =
+      row.type === 'prop'
+        ? (stageStore.propsAllocationsByItem[row.id] ?? [])
+        : (stageStore.sceneryAllocationsByItem[row.id] ?? []);
+
+    const segments = groupConsecutiveScenes(
+      allocations as Array<Record<string, unknown>>,
+      'scene_id'
+    );
+
+    segments.forEach((segment, idx) => {
+      const startX = getSceneX(segment.startIndex);
+      const width = sceneWidth * (segment.endIndex - segment.startIndex + 1);
+      const sceneRange =
+        segment.startScene === segment.endScene
+          ? segment.startScene
+          : `${segment.startScene} - ${segment.endScene}`;
+
+      bars.push({
+        id: `${row.type}-${row.id}-seg-${idx}`,
+        x: startX,
+        y: getRowY(rowIndex) + barPadding,
+        width,
+        height: rowHeight - 2 * barPadding,
+        color: getColorForEntity(row.id, row.type),
+        label: row.name,
+        tooltip: `${row.name} (${sceneRange})`,
+        data: {
+          type: row.type as 'prop' | 'scenery',
+          itemId: row.id,
+          startScene: segment.startIndex,
+          endScene: segment.endIndex,
+        },
+      });
+    });
+  });
+  return bars;
+});
+
+function isBarSelected(bar: TimelineBar): boolean {
+  if (!selectedItem.value) return false;
+  return (
+    selectedItem.value.type === bar.data.type &&
+    selectedItem.value.itemId === bar.data.itemId &&
+    selectedItem.value.startScene === bar.data.startScene &&
+    selectedItem.value.endScene === bar.data.endScene
+  );
+}
+
+function handleBarClick(bar: TimelineBar): void {
+  selectedItem.value = bar.data;
+  sidePanelOpen.value = true;
+}
+
+function closeSidePanel(): void {
+  sidePanelOpen.value = false;
+  selectedItem.value = null;
+}
+
+function handleExport(): void {
+  const modeNames: Record<string, string> = {
+    combined: 'Combined',
+    props: 'Props',
+    scenery: 'Scenery',
+  };
+  exportTimeline(svgRef, 'stage-timeline', modeNames[viewMode.value]);
+}
+
+onMounted(async () => {
+  await Promise.all([
+    showStore.getActList(),
+    showStore.getSceneList(),
+    stageStore.getPropTypes(),
+    stageStore.getSceneryTypes(),
+    stageStore.getPropsList(),
+    stageStore.getSceneryList(),
+    stageStore.getPropsAllocations(),
+    stageStore.getSceneryAllocations(),
+    stageStore.getCrewList(),
+    stageStore.getCrewAssignments(),
+  ]);
+  dataLoaded.value = true;
+});
+</script>
+
+<style lang="scss">
+@use '@/assets/styles/timeline';
+
+.timeline-with-panel {
+  display: flex;
+  height: 100%;
+  overflow: hidden;
+}
+
+.timeline-wrapper {
+  flex: 1;
+  overflow: auto;
+  min-width: 0;
+}
+
+.allocation-bar {
+  cursor: pointer;
+  transition: stroke-width 0.15s ease;
+
+  &.selected {
+    stroke: #212529;
+    stroke-width: 3px;
+  }
+
+  &:hover:not(.selected) {
+    stroke: #495057;
+    stroke-width: 2px;
+  }
+}
+</style>

--- a/client-v3/src/components/show/config/stage/TimelineSidePanel.vue
+++ b/client-v3/src/components/show/config/stage/TimelineSidePanel.vue
@@ -1,0 +1,464 @@
+<template>
+  <div class="side-panel" :class="{ open: isOpen }">
+    <div v-if="selectedItem" class="panel-content">
+      <div class="panel-header">
+        <h5>{{ itemName }}</h5>
+        <BButton variant="link" size="sm" class="close-btn" @click="$emit('close')">
+          &#215;
+        </BButton>
+      </div>
+      <div class="panel-body">
+        <div class="block-info text-muted mb-3">Block: {{ blockRange }}</div>
+
+        <div class="assignment-section mb-4">
+          <h6 class="section-header">SET ({{ setSceneName }})</h6>
+          <div v-if="setAssignments.length === 0" class="text-muted small">No crew assigned</div>
+          <div v-else class="assignment-list">
+            <div v-for="assignment in setAssignments" :key="assignment.id" class="assignment-item">
+              <span class="crew-name">{{ getCrewDisplayName(assignment.crew_id) }}</span>
+              <BButton
+                variant="link"
+                size="sm"
+                class="remove-btn text-danger"
+                :disabled="saving"
+                @click="removeAssignment(assignment)"
+              >
+                &#215;
+              </BButton>
+            </div>
+          </div>
+          <div class="add-crew-container mt-2">
+            <BFormSelect
+              v-model="newSetCrewId"
+              :options="availableCrewForSet"
+              :disabled="saving"
+              size="sm"
+              class="add-crew-select"
+            >
+              <template #first>
+                <BFormSelectOption :value="null" disabled>+ Add crew member</BFormSelectOption>
+              </template>
+            </BFormSelect>
+            <BButton
+              v-show="newSetCrewId"
+              variant="primary"
+              size="sm"
+              :disabled="saving"
+              @click="addSetAssignment"
+            >
+              Add
+            </BButton>
+          </div>
+        </div>
+
+        <div class="assignment-section mb-4">
+          <h6 class="section-header">STRIKE ({{ strikeSceneName }})</h6>
+          <div v-if="strikeAssignments.length === 0" class="text-muted small">No crew assigned</div>
+          <div v-else class="assignment-list">
+            <div
+              v-for="assignment in strikeAssignments"
+              :key="assignment.id"
+              class="assignment-item"
+            >
+              <span class="crew-name">{{ getCrewDisplayName(assignment.crew_id) }}</span>
+              <BButton
+                variant="link"
+                size="sm"
+                class="remove-btn text-danger"
+                :disabled="saving"
+                @click="removeAssignment(assignment)"
+              >
+                &#215;
+              </BButton>
+            </div>
+          </div>
+          <div class="add-crew-container mt-2">
+            <BFormSelect
+              v-model="newStrikeCrewId"
+              :options="availableCrewForStrike"
+              :disabled="saving"
+              size="sm"
+              class="add-crew-select"
+            >
+              <template #first>
+                <BFormSelectOption :value="null" disabled>+ Add crew member</BFormSelectOption>
+              </template>
+            </BFormSelect>
+            <BButton
+              v-show="newStrikeCrewId"
+              variant="primary"
+              size="sm"
+              :disabled="saving"
+              @click="addStrikeAssignment"
+            >
+              Add
+            </BButton>
+          </div>
+        </div>
+
+        <div v-if="conflicts.length > 0" class="conflicts-section">
+          <h6 class="section-header text-warning">⚠ Conflicts</h6>
+          <div v-for="conflict in conflicts" :key="conflict.key" class="conflict-item small">
+            <strong>{{ conflict.crewName }}</strong> has conflict in {{ conflict.sceneName }} ({{
+              conflict.itemName
+            }}
+            {{ conflict.type }})
+          </div>
+        </div>
+      </div>
+    </div>
+    <div v-else class="panel-placeholder text-muted">Click an allocation bar to view details</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue';
+import { useStageStore } from '@/stores/stage';
+import { useShowStore } from '@/stores/show';
+import { useConfirm } from '@/composables/useConfirm';
+import type { Crew, CrewAssignment } from '@/types/api/stage';
+import log from 'loglevel';
+
+interface SelectedItem {
+  type: 'prop' | 'scenery';
+  itemId: number;
+  startScene: number;
+  endScene: number;
+}
+
+const props = defineProps<{
+  selectedItem: SelectedItem | null;
+  isOpen: boolean;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+}>();
+
+const stageStore = useStageStore();
+const showStore = useShowStore();
+const { confirm } = useConfirm();
+
+const newSetCrewId = ref<number | null>(null);
+const newStrikeCrewId = ref<number | null>(null);
+const saving = ref(false);
+
+watch(
+  () => props.selectedItem,
+  () => {
+    newSetCrewId.value = null;
+    newStrikeCrewId.value = null;
+  }
+);
+
+const item = computed(() => {
+  if (!props.selectedItem) return null;
+  return props.selectedItem.type === 'prop'
+    ? stageStore.propById(props.selectedItem.itemId)
+    : stageStore.sceneryById(props.selectedItem.itemId);
+});
+
+const itemName = computed(() => item.value?.name ?? 'Unknown');
+
+const setScene = computed(() =>
+  props.selectedItem ? (showStore.orderedScenes[props.selectedItem.startScene] ?? null) : null
+);
+const strikeScene = computed(() =>
+  props.selectedItem ? (showStore.orderedScenes[props.selectedItem.endScene] ?? null) : null
+);
+
+const setSceneId = computed(() => setScene.value?.id ?? null);
+const strikeSceneId = computed(() => strikeScene.value?.id ?? null);
+
+const setSceneName = computed(() => {
+  if (!setScene.value) return '';
+  const act = showStore.actById(setScene.value.act);
+  return `${act?.name ?? 'Act'}: ${setScene.value.name}`;
+});
+
+const strikeSceneName = computed(() => {
+  if (!strikeScene.value) return '';
+  const act = showStore.actById(strikeScene.value.act);
+  return `${act?.name ?? 'Act'}: ${strikeScene.value.name}`;
+});
+
+const isSingleSceneBlock = computed(() => setSceneId.value === strikeSceneId.value);
+
+const blockRange = computed(() => {
+  if (isSingleSceneBlock.value) return setSceneName.value;
+  return `${setSceneName.value} - ${strikeSceneName.value}`;
+});
+
+const itemAssignments = computed((): CrewAssignment[] => {
+  if (!props.selectedItem) return [];
+  return props.selectedItem.type === 'prop'
+    ? (stageStore.crewAssignmentsByProp[props.selectedItem.itemId] ?? [])
+    : (stageStore.crewAssignmentsByScenery[props.selectedItem.itemId] ?? []);
+});
+
+const setAssignments = computed(() =>
+  itemAssignments.value.filter(
+    (a) => a.assignment_type === 'set' && a.scene_id === setSceneId.value
+  )
+);
+
+const strikeAssignments = computed(() =>
+  itemAssignments.value.filter(
+    (a) => a.assignment_type === 'strike' && a.scene_id === strikeSceneId.value
+  )
+);
+
+const assignedSetCrewIds = computed(() => new Set(setAssignments.value.map((a) => a.crew_id)));
+const assignedStrikeCrewIds = computed(
+  () => new Set(strikeAssignments.value.map((a) => a.crew_id))
+);
+
+function formatCrewName(crew: Crew | null): string {
+  if (!crew) return 'Unknown';
+  return [crew.first_name, crew.last_name].filter(Boolean).join(' ');
+}
+
+function getCrewDisplayName(crewId: number): string {
+  return formatCrewName(stageStore.crewById(crewId));
+}
+
+const availableCrewForSet = computed(() =>
+  stageStore.crewList
+    .filter((c) => !assignedSetCrewIds.value.has(c.id))
+    .map((c) => ({ value: c.id, text: formatCrewName(c) }))
+);
+
+const availableCrewForStrike = computed(() =>
+  stageStore.crewList
+    .filter((c) => !assignedStrikeCrewIds.value.has(c.id))
+    .map((c) => ({ value: c.id, text: formatCrewName(c) }))
+);
+
+const conflicts = computed(() => {
+  const result: Array<{
+    key: string;
+    crewName: string;
+    sceneName: string;
+    itemName: string;
+    type: string;
+  }> = [];
+
+  for (const assignment of [...setAssignments.value, ...strikeAssignments.value]) {
+    const sceneAssignments = stageStore.crewAssignmentsByScene[assignment.scene_id] ?? [];
+    const otherAssignments = sceneAssignments.filter(
+      (a) =>
+        a.crew_id === assignment.crew_id &&
+        a.id !== assignment.id &&
+        !(a.prop_id === props.selectedItem?.itemId && props.selectedItem?.type === 'prop') &&
+        !(a.scenery_id === props.selectedItem?.itemId && props.selectedItem?.type === 'scenery')
+    );
+
+    for (const other of otherAssignments) {
+      const otherItem =
+        other.prop_id != null
+          ? stageStore.propById(other.prop_id)
+          : stageStore.sceneryById(other.scenery_id);
+      const crew = stageStore.crewById(assignment.crew_id);
+      const scene = showStore.orderedScenes.find((s) => s.id === assignment.scene_id);
+      result.push({
+        key: `${assignment.id}-${other.id}`,
+        crewName: formatCrewName(crew),
+        sceneName: scene?.name ?? 'Unknown',
+        itemName: otherItem?.name ?? 'Unknown',
+        type: other.assignment_type.toUpperCase(),
+      });
+    }
+  }
+
+  return result;
+});
+
+async function addSetAssignment(): Promise<void> {
+  if (!newSetCrewId.value || !setSceneId.value || saving.value) return;
+  saving.value = true;
+  try {
+    const assignment: Record<string, unknown> = {
+      crew_id: newSetCrewId.value,
+      scene_id: setSceneId.value,
+      assignment_type: 'set',
+    };
+    if (props.selectedItem?.type === 'prop') {
+      assignment.prop_id = props.selectedItem.itemId;
+    } else {
+      assignment.scenery_id = props.selectedItem?.itemId;
+    }
+    const success = await stageStore.addCrewAssignment(assignment);
+    if (success) newSetCrewId.value = null;
+  } catch (e) {
+    log.error('Error adding set assignment:', e);
+  } finally {
+    saving.value = false;
+  }
+}
+
+async function addStrikeAssignment(): Promise<void> {
+  if (!newStrikeCrewId.value || !strikeSceneId.value || saving.value) return;
+  saving.value = true;
+  try {
+    const assignment: Record<string, unknown> = {
+      crew_id: newStrikeCrewId.value,
+      scene_id: strikeSceneId.value,
+      assignment_type: 'strike',
+    };
+    if (props.selectedItem?.type === 'prop') {
+      assignment.prop_id = props.selectedItem.itemId;
+    } else {
+      assignment.scenery_id = props.selectedItem?.itemId;
+    }
+    const success = await stageStore.addCrewAssignment(assignment);
+    if (success) newStrikeCrewId.value = null;
+  } catch (e) {
+    log.error('Error adding strike assignment:', e);
+  } finally {
+    saving.value = false;
+  }
+}
+
+async function removeAssignment(assignment: CrewAssignment): Promise<void> {
+  if (saving.value) return;
+  const crewName = getCrewDisplayName(assignment.crew_id);
+  const ok = await confirm(
+    `Remove ${crewName} from this ${assignment.assignment_type.toUpperCase()} assignment?`,
+    { okTitle: 'Remove', okVariant: 'danger' }
+  );
+  if (!ok) return;
+  saving.value = true;
+  try {
+    await stageStore.deleteCrewAssignment(assignment.id);
+  } catch (e) {
+    log.error('Error removing assignment:', e);
+  } finally {
+    saving.value = false;
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.side-panel {
+  width: 0;
+  min-width: 0;
+  overflow: hidden;
+  transition:
+    width 0.3s ease,
+    min-width 0.3s ease;
+  border-left: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--body-background);
+
+  &.open {
+    width: 300px;
+    min-width: 300px;
+  }
+}
+
+.panel-content {
+  width: 300px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+
+  h5 {
+    margin: 0;
+    font-size: 1rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .close-btn {
+    padding: 0;
+    line-height: 1;
+  }
+}
+
+.panel-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}
+
+.block-info {
+  font-size: 0.85rem;
+}
+
+.assignment-section {
+  .section-header {
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    padding-bottom: 0.25rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  }
+}
+
+.assignment-list {
+  margin-bottom: 0.5rem;
+}
+
+.assignment-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.05);
+  margin-bottom: 0.25rem;
+
+  .crew-name {
+    font-size: 0.9rem;
+  }
+
+  .remove-btn {
+    padding: 0;
+    line-height: 1;
+  }
+}
+
+.add-crew-container {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+
+  .add-crew-select {
+    flex: 1;
+  }
+}
+
+.conflicts-section {
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding-top: 1rem;
+
+  .section-header {
+    font-size: 0.9rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .conflict-item {
+    padding: 0.5rem;
+    background: rgba(255, 193, 7, 0.2);
+    border-radius: 4px;
+    margin-bottom: 0.25rem;
+  }
+}
+
+.panel-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 1rem;
+  text-align: center;
+}
+</style>

--- a/client-v3/src/js/blockOrphanUtils.test.ts
+++ b/client-v3/src/js/blockOrphanUtils.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest';
+import { computeBlocks, findOrphanedAssignments } from './blockOrphanUtils';
+
+describe('blockOrphanUtils', () => {
+  describe('computeBlocks', () => {
+    it('returns empty array for empty inputs', () => {
+      expect(computeBlocks([], new Set())).toEqual([]);
+      expect(computeBlocks([], new Set([1]))).toEqual([]);
+      expect(computeBlocks(null, null)).toEqual([]);
+    });
+
+    it('returns single block for one allocated scene', () => {
+      const scenes = [{ id: 1, act: 1 }];
+      const result = computeBlocks(scenes, new Set([1]));
+      expect(result).toEqual([{ actId: 1, sceneIds: [1], setSceneId: 1, strikeSceneId: 1 }]);
+    });
+
+    it('returns one block for consecutive scenes in one act', () => {
+      const scenes = [
+        { id: 1, act: 1 },
+        { id: 2, act: 1 },
+        { id: 3, act: 1 },
+      ];
+      const result = computeBlocks(scenes, new Set([1, 2, 3]));
+      expect(result).toEqual([{ actId: 1, sceneIds: [1, 2, 3], setSceneId: 1, strikeSceneId: 3 }]);
+    });
+
+    it('splits into two blocks when there is a gap in the middle', () => {
+      const scenes = [
+        { id: 1, act: 1 },
+        { id: 2, act: 1 },
+        { id: 3, act: 1 },
+        { id: 4, act: 1 },
+      ];
+      const result = computeBlocks(scenes, new Set([1, 2, 4]));
+      expect(result).toEqual([
+        { actId: 1, sceneIds: [1, 2], setSceneId: 1, strikeSceneId: 2 },
+        { actId: 1, sceneIds: [4], setSceneId: 4, strikeSceneId: 4 },
+      ]);
+    });
+
+    it('breaks blocks at act boundaries even for consecutive scenes', () => {
+      const scenes = [
+        { id: 1, act: 1 },
+        { id: 2, act: 1 },
+        { id: 3, act: 2 },
+        { id: 4, act: 2 },
+      ];
+      const result = computeBlocks(scenes, new Set([1, 2, 3, 4]));
+      expect(result).toEqual([
+        { actId: 1, sceneIds: [1, 2], setSceneId: 1, strikeSceneId: 2 },
+        { actId: 2, sceneIds: [3, 4], setSceneId: 3, strikeSceneId: 4 },
+      ]);
+    });
+
+    it('handles multiple acts with multiple blocks each', () => {
+      const scenes = [
+        { id: 1, act: 1 },
+        { id: 2, act: 1 },
+        { id: 3, act: 1 },
+        { id: 4, act: 2 },
+        { id: 5, act: 2 },
+        { id: 6, act: 2 },
+      ];
+      // Allocated: 1, 3 (act 1 gap), 4, 6 (act 2 gap)
+      const result = computeBlocks(scenes, new Set([1, 3, 4, 6]));
+      expect(result).toEqual([
+        { actId: 1, sceneIds: [1], setSceneId: 1, strikeSceneId: 1 },
+        { actId: 1, sceneIds: [3], setSceneId: 3, strikeSceneId: 3 },
+        { actId: 2, sceneIds: [4], setSceneId: 4, strikeSceneId: 4 },
+        { actId: 2, sceneIds: [6], setSceneId: 6, strikeSceneId: 6 },
+      ]);
+    });
+
+    it('ignores scenes not in the allocated set', () => {
+      const scenes = [
+        { id: 1, act: 1 },
+        { id: 2, act: 1 },
+        { id: 3, act: 1 },
+      ];
+      const result = computeBlocks(scenes, new Set([2]));
+      expect(result).toEqual([{ actId: 1, sceneIds: [2], setSceneId: 2, strikeSceneId: 2 }]);
+    });
+  });
+
+  describe('findOrphanedAssignments', () => {
+    // Reusable test data
+    const orderedScenes = [
+      { id: 1, act: 1 },
+      { id: 2, act: 1 },
+      { id: 3, act: 1 },
+      { id: 4, act: 1 },
+    ];
+
+    it('returns empty array when there are no crew assignments', () => {
+      const result = findOrphanedAssignments({
+        orderedScenes,
+        currentAllocations: [{ scene_id: 1 }, { scene_id: 2 }],
+        crewAssignments: [],
+        changeType: 'remove',
+        changeSceneId: 1,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty when boundary does not change', () => {
+      // Block is scenes 1-3, remove scene 2 (middle) → boundaries stay at 1 and 3
+      // Actually removing middle splits block: [1] and [3], boundaries change!
+      // Use: remove scene 2 from [1,2,3] → [1] block (set=1,strike=1) + [3] (set=3,strike=3)
+      // Original: [1,2,3] → set=1, strike=3
+      // So boundaries DO change for strike. Let's use a case where they don't change.
+      // Add scene 2 to [1,3] → no boundary change (set=1, strike=3 in both)
+      const result = findOrphanedAssignments({
+        orderedScenes,
+        currentAllocations: [{ scene_id: 1 }, { scene_id: 3 }],
+        crewAssignments: [
+          { id: 10, scene_id: 1, assignment_type: 'set', crew_id: 1 },
+          { id: 11, scene_id: 3, assignment_type: 'strike', crew_id: 2 },
+        ],
+        changeType: 'add',
+        changeSceneId: 2,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('orphans SET assignments when block start is removed', () => {
+      // Block [1,2,3] → remove scene 1 → block becomes [2,3], SET moves to 2
+      const setAssignment = { id: 10, scene_id: 1, assignment_type: 'set', crew_id: 1 };
+      const strikeAssignment = { id: 11, scene_id: 3, assignment_type: 'strike', crew_id: 2 };
+      const result = findOrphanedAssignments({
+        orderedScenes,
+        currentAllocations: [{ scene_id: 1 }, { scene_id: 2 }, { scene_id: 3 }],
+        crewAssignments: [setAssignment, strikeAssignment],
+        changeType: 'remove',
+        changeSceneId: 1,
+      });
+      expect(result).toEqual([setAssignment]);
+    });
+
+    it('orphans STRIKE assignments when block end is removed', () => {
+      // Block [1,2,3] → remove scene 3 → block becomes [1,2], STRIKE moves to 2
+      const setAssignment = { id: 10, scene_id: 1, assignment_type: 'set', crew_id: 1 };
+      const strikeAssignment = { id: 11, scene_id: 3, assignment_type: 'strike', crew_id: 2 };
+      const result = findOrphanedAssignments({
+        orderedScenes,
+        currentAllocations: [{ scene_id: 1 }, { scene_id: 2 }, { scene_id: 3 }],
+        crewAssignments: [setAssignment, strikeAssignment],
+        changeType: 'remove',
+        changeSceneId: 3,
+      });
+      expect(result).toEqual([strikeAssignment]);
+    });
+
+    it('orphans both SET and STRIKE when a single-scene block is removed', () => {
+      // Block [2] only → remove scene 2 → block disappears
+      const setAssignment = { id: 10, scene_id: 2, assignment_type: 'set', crew_id: 1 };
+      const strikeAssignment = { id: 11, scene_id: 2, assignment_type: 'strike', crew_id: 2 };
+      const result = findOrphanedAssignments({
+        orderedScenes,
+        currentAllocations: [{ scene_id: 2 }],
+        crewAssignments: [setAssignment, strikeAssignment],
+        changeType: 'remove',
+        changeSceneId: 2,
+      });
+      expect(result).toContainEqual(setAssignment);
+      expect(result).toContainEqual(strikeAssignment);
+      expect(result).toHaveLength(2);
+    });
+
+    it('does not orphan when removing a middle scene (split keeps original boundaries)', () => {
+      // Block [1,2,3] → remove scene 2 → blocks [1] and [3]
+      // SET scene 1 stays valid (set of block [1]), STRIKE scene 3 stays valid (strike of block [3])
+      const result = findOrphanedAssignments({
+        orderedScenes,
+        currentAllocations: [{ scene_id: 1 }, { scene_id: 2 }, { scene_id: 3 }],
+        crewAssignments: [
+          { id: 10, scene_id: 1, assignment_type: 'set', crew_id: 1 },
+          { id: 11, scene_id: 3, assignment_type: 'strike', crew_id: 2 },
+        ],
+        changeType: 'remove',
+        changeSceneId: 2,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('orphans old SET when adding a scene before block start', () => {
+      // Block [2,3] → add scene 1 → block becomes [1,2,3], SET moves to 1
+      const oldSetAssignment = { id: 10, scene_id: 2, assignment_type: 'set', crew_id: 1 };
+      const result = findOrphanedAssignments({
+        orderedScenes,
+        currentAllocations: [{ scene_id: 2 }, { scene_id: 3 }],
+        crewAssignments: [
+          oldSetAssignment,
+          { id: 11, scene_id: 3, assignment_type: 'strike', crew_id: 2 },
+        ],
+        changeType: 'add',
+        changeSceneId: 1,
+      });
+      expect(result).toEqual([oldSetAssignment]);
+    });
+
+    it('orphans old STRIKE when adding a scene after block end', () => {
+      // Block [1,2] → add scene 3 → block becomes [1,2,3], STRIKE moves to 3
+      const oldStrikeAssignment = { id: 11, scene_id: 2, assignment_type: 'strike', crew_id: 2 };
+      const result = findOrphanedAssignments({
+        orderedScenes,
+        currentAllocations: [{ scene_id: 1 }, { scene_id: 2 }],
+        crewAssignments: [
+          { id: 10, scene_id: 1, assignment_type: 'set', crew_id: 1 },
+          oldStrikeAssignment,
+        ],
+        changeType: 'add',
+        changeSceneId: 3,
+      });
+      expect(result).toEqual([oldStrikeAssignment]);
+    });
+
+    it('does not affect assignments in a different act', () => {
+      const multiActScenes = [
+        { id: 1, act: 1 },
+        { id: 2, act: 1 },
+        { id: 3, act: 2 },
+        { id: 4, act: 2 },
+      ];
+      // Act 1 block [1,2], Act 2 block [3,4]
+      // Remove scene 1 (act 1 boundary change) → Act 2 should be unaffected
+      const act1Set = { id: 10, scene_id: 1, assignment_type: 'set', crew_id: 1 };
+      const act2Set = { id: 20, scene_id: 3, assignment_type: 'set', crew_id: 1 };
+      const act2Strike = { id: 21, scene_id: 4, assignment_type: 'strike', crew_id: 2 };
+      const result = findOrphanedAssignments({
+        orderedScenes: multiActScenes,
+        currentAllocations: [{ scene_id: 1 }, { scene_id: 2 }, { scene_id: 3 }, { scene_id: 4 }],
+        crewAssignments: [act1Set, act2Set, act2Strike],
+        changeType: 'remove',
+        changeSceneId: 1,
+      });
+      // Only act1 SET is orphaned
+      expect(result).toEqual([act1Set]);
+    });
+  });
+});

--- a/client-v3/src/js/blockOrphanUtils.ts
+++ b/client-v3/src/js/blockOrphanUtils.ts
@@ -1,0 +1,142 @@
+/**
+ * Block computation and orphan detection utilities for stage crew assignments.
+ *
+ * A "block" is a consecutive sequence of scenes (within an act) where an item
+ * is allocated. The first scene is the SET boundary; the last is the STRIKE
+ * boundary. These pure functions mirror the backend logic in
+ * server/utils/show/block_computation.py.
+ */
+
+export interface OrderedScene {
+  id: number;
+  act: number;
+}
+
+export interface AllocationBlock {
+  actId: number;
+  sceneIds: number[];
+  setSceneId: number;
+  strikeSceneId: number;
+}
+
+export interface CrewAssignmentRecord {
+  id: number;
+  scene_id: number;
+  assignment_type: string;
+  crew_id: number;
+}
+
+export interface FindOrphanedParams {
+  orderedScenes: OrderedScene[];
+  currentAllocations: Array<{ scene_id: number }>;
+  crewAssignments: CrewAssignmentRecord[];
+  changeType: 'add' | 'remove';
+  changeSceneId: number;
+}
+
+export function computeBlocks(
+  orderedScenes: OrderedScene[] | null | undefined,
+  allocatedSceneIds: Set<number> | null | undefined
+): AllocationBlock[] {
+  if (
+    !orderedScenes ||
+    orderedScenes.length === 0 ||
+    !allocatedSceneIds ||
+    allocatedSceneIds.size === 0
+  ) {
+    return [];
+  }
+
+  const blocks: AllocationBlock[] = [];
+  let currentBlockScenes: number[] = [];
+  let currentActId: number | null = null;
+
+  for (const scene of orderedScenes) {
+    // Act boundary breaks the current block
+    if (currentActId !== null && scene.act !== currentActId) {
+      if (currentBlockScenes.length > 0) {
+        blocks.push({
+          actId: currentActId,
+          sceneIds: [...currentBlockScenes],
+          setSceneId: currentBlockScenes[0],
+          strikeSceneId: currentBlockScenes[currentBlockScenes.length - 1],
+        });
+        currentBlockScenes = [];
+      }
+    }
+    currentActId = scene.act;
+
+    if (allocatedSceneIds.has(scene.id)) {
+      currentBlockScenes.push(scene.id);
+    } else if (currentBlockScenes.length > 0) {
+      blocks.push({
+        actId: currentActId,
+        sceneIds: [...currentBlockScenes],
+        setSceneId: currentBlockScenes[0],
+        strikeSceneId: currentBlockScenes[currentBlockScenes.length - 1],
+      });
+      currentBlockScenes = [];
+    }
+  }
+
+  // Flush last block
+  if (currentBlockScenes.length > 0) {
+    blocks.push({
+      actId: currentActId as number,
+      sceneIds: [...currentBlockScenes],
+      setSceneId: currentBlockScenes[0],
+      strikeSceneId: currentBlockScenes[currentBlockScenes.length - 1],
+    });
+  }
+
+  return blocks;
+}
+
+export function findOrphanedAssignments({
+  orderedScenes,
+  currentAllocations,
+  crewAssignments,
+  changeType,
+  changeSceneId,
+}: FindOrphanedParams): CrewAssignmentRecord[] {
+  if (!crewAssignments || crewAssignments.length === 0) {
+    return [];
+  }
+
+  // Build current allocated set
+  const currentSet = new Set(currentAllocations.map((a) => a.scene_id));
+
+  // Simulate the change
+  const newSet = new Set(currentSet);
+  if (changeType === 'add') {
+    newSet.add(changeSceneId);
+  } else if (changeType === 'remove') {
+    newSet.delete(changeSceneId);
+  }
+
+  // Compute blocks before and after
+  const oldBlocks = computeBlocks(orderedScenes, currentSet);
+  const newBlocks = computeBlocks(orderedScenes, newSet);
+
+  // Build valid boundary sets from new blocks
+  const validSetScenes = new Set(newBlocks.map((b) => b.setSceneId));
+  const validStrikeScenes = new Set(newBlocks.map((b) => b.strikeSceneId));
+
+  // Also check which assignments were valid before — only flag ones that
+  // become invalid (were on a valid boundary before, but aren't after)
+  const oldValidSetScenes = new Set(oldBlocks.map((b) => b.setSceneId));
+  const oldValidStrikeScenes = new Set(oldBlocks.map((b) => b.strikeSceneId));
+
+  return crewAssignments.filter((assignment) => {
+    if (assignment.assignment_type === 'set') {
+      const wasValid = oldValidSetScenes.has(assignment.scene_id);
+      const isValid = validSetScenes.has(assignment.scene_id);
+      return wasValid && !isValid;
+    } else if (assignment.assignment_type === 'strike') {
+      const wasValid = oldValidStrikeScenes.has(assignment.scene_id);
+      const isValid = validStrikeScenes.has(assignment.scene_id);
+      return wasValid && !isValid;
+    }
+    return false;
+  });
+}

--- a/client-v3/src/router/index.ts
+++ b/client-v3/src/router/index.ts
@@ -57,7 +57,7 @@ const router = createRouter({
         {
           name: 'show-config-stage',
           path: 'stage',
-          component: PlaceholderView,
+          component: () => import('@/views/show/config/ConfigStage.vue'),
           meta: { requiresAuth: true, requiresShowAccess: true },
         },
         {

--- a/client-v3/src/stores/stage.ts
+++ b/client-v3/src/stores/stage.ts
@@ -1,0 +1,510 @@
+import { defineStore } from 'pinia';
+import log from 'loglevel';
+import { makeURL } from '@/js/utils';
+import { toast } from '@/js/toast';
+import type {
+  Crew,
+  CrewAssignment,
+  SceneryType,
+  Scenery,
+  SceneryAllocation,
+  PropType,
+  Props,
+  PropsAllocation,
+} from '@/types/api/stage';
+
+export const useStageStore = defineStore('stage', {
+  state: () => ({
+    crewList: [] as Crew[],
+    crewAssignments: [] as CrewAssignment[],
+    sceneryTypes: [] as SceneryType[],
+    sceneryList: [] as Scenery[],
+    sceneryAllocations: [] as SceneryAllocation[],
+    propTypes: [] as PropType[],
+    propsList: [] as Props[],
+    propsAllocations: [] as PropsAllocation[],
+  }),
+
+  getters: {
+    crewById: (state) => (id: number | null) =>
+      id == null ? null : (state.crewList.find((c) => c.id === id) ?? null),
+
+    sceneryById: (state) => (id: number | null) =>
+      id == null ? null : (state.sceneryList.find((s) => s.id === id) ?? null),
+
+    sceneryTypeById: (state) => (id: number | null) =>
+      id == null ? null : (state.sceneryTypes.find((t) => t.id === id) ?? null),
+
+    propById: (state) => (id: number | null) =>
+      id == null ? null : (state.propsList.find((p) => p.id === id) ?? null),
+
+    propTypeById: (state) => (id: number | null) =>
+      id == null ? null : (state.propTypes.find((t) => t.id === id) ?? null),
+
+    sceneryTypesDict: (state) =>
+      Object.fromEntries(state.sceneryTypes.map((t) => [t.id, t])) as Record<number, SceneryType>,
+
+    propTypesDict: (state) =>
+      Object.fromEntries(state.propTypes.map((t) => [t.id, t])) as Record<number, PropType>,
+
+    propsAllocationsByItem: (state) => {
+      const result: Record<number, PropsAllocation[]> = {};
+      state.propsAllocations.forEach((alloc) => {
+        if (!result[alloc.props_id]) result[alloc.props_id] = [];
+        result[alloc.props_id].push(alloc);
+      });
+      return result;
+    },
+
+    sceneryAllocationsByItem: (state) => {
+      const result: Record<number, SceneryAllocation[]> = {};
+      state.sceneryAllocations.forEach((alloc) => {
+        if (!result[alloc.scenery_id]) result[alloc.scenery_id] = [];
+        result[alloc.scenery_id].push(alloc);
+      });
+      return result;
+    },
+
+    crewAssignmentsByProp: (state) => {
+      const result: Record<number, CrewAssignment[]> = {};
+      state.crewAssignments.forEach((a) => {
+        if (a.prop_id != null) {
+          if (!result[a.prop_id]) result[a.prop_id] = [];
+          result[a.prop_id].push(a);
+        }
+      });
+      return result;
+    },
+
+    crewAssignmentsByScenery: (state) => {
+      const result: Record<number, CrewAssignment[]> = {};
+      state.crewAssignments.forEach((a) => {
+        if (a.scenery_id != null) {
+          if (!result[a.scenery_id]) result[a.scenery_id] = [];
+          result[a.scenery_id].push(a);
+        }
+      });
+      return result;
+    },
+
+    crewAssignmentsByCrew: (state) => {
+      const result: Record<number, CrewAssignment[]> = {};
+      state.crewAssignments.forEach((a) => {
+        if (!result[a.crew_id]) result[a.crew_id] = [];
+        result[a.crew_id].push(a);
+      });
+      return result;
+    },
+
+    crewAssignmentsByScene: (state) => {
+      const result: Record<number, CrewAssignment[]> = {};
+      state.crewAssignments.forEach((a) => {
+        if (!result[a.scene_id]) result[a.scene_id] = [];
+        result[a.scene_id].push(a);
+      });
+      return result;
+    },
+  },
+
+  actions: {
+    async getCrewList() {
+      const response = await fetch(makeURL('/api/v1/show/stage/crew'));
+      if (response.ok) {
+        const data = await response.json();
+        this.crewList = data.crew;
+      } else {
+        log.error('Unable to get crew list');
+      }
+    },
+
+    async addCrewMember(crewMember: Partial<Crew>) {
+      const response = await fetch(makeURL('/api/v1/show/stage/crew'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ firstName: crewMember.first_name, lastName: crewMember.last_name }),
+      });
+      if (response.ok) {
+        await this.getCrewList();
+        toast.success('Added new crew member!');
+      } else {
+        log.error('Unable to add new crew member');
+        toast.error('Unable to add new crew member');
+      }
+    },
+
+    async updateCrewMember(crewMember: Partial<Crew>) {
+      const response = await fetch(makeURL('/api/v1/show/stage/crew'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: crewMember.id,
+          firstName: crewMember.first_name,
+          lastName: crewMember.last_name,
+        }),
+      });
+      if (response.ok) {
+        await this.getCrewList();
+        toast.success('Updated crew member!');
+      } else {
+        log.error('Unable to edit crew member');
+        toast.error('Unable to edit crew member');
+      }
+    },
+
+    async deleteCrewMember(crewId: number) {
+      const params = new URLSearchParams({ id: String(crewId) });
+      const response = await fetch(`${makeURL('/api/v1/show/stage/crew')}?${params}`, {
+        method: 'DELETE',
+      });
+      if (response.ok) {
+        await this.getCrewList();
+        toast.success('Deleted crew member!');
+      } else {
+        log.error('Unable to delete crew member');
+        toast.error('Unable to delete crew member');
+      }
+    },
+
+    async getSceneryTypes() {
+      const response = await fetch(makeURL('/api/v1/show/stage/scenery/types'));
+      if (response.ok) {
+        const data = await response.json();
+        this.sceneryTypes = data.scenery_types;
+      } else {
+        log.error('Unable to get scenery types');
+      }
+    },
+
+    async addSceneryType(sceneryType: Partial<SceneryType>) {
+      const response = await fetch(makeURL('/api/v1/show/stage/scenery/types'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(sceneryType),
+      });
+      if (response.ok) {
+        await this.getSceneryTypes();
+        toast.success('Added new scenery type!');
+      } else {
+        log.error('Unable to add new scenery type');
+        toast.error('Unable to add new scenery type');
+      }
+    },
+
+    async updateSceneryType(sceneryType: Partial<SceneryType>) {
+      const response = await fetch(makeURL('/api/v1/show/stage/scenery/types'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(sceneryType),
+      });
+      if (response.ok) {
+        await this.getSceneryTypes();
+        toast.success('Updated scenery type!');
+      } else {
+        log.error('Unable to edit scenery type');
+        toast.error('Unable to edit scenery type');
+      }
+    },
+
+    async deleteSceneryType(sceneryTypeId: number) {
+      const params = new URLSearchParams({ id: String(sceneryTypeId) });
+      const response = await fetch(`${makeURL('/api/v1/show/stage/scenery/types')}?${params}`, {
+        method: 'DELETE',
+      });
+      if (response.ok) {
+        await Promise.all([this.getSceneryTypes(), this.getSceneryList()]);
+        toast.success('Deleted scenery type!');
+      } else {
+        log.error('Unable to delete scenery type');
+        toast.error('Unable to delete scenery type');
+      }
+    },
+
+    async getSceneryList() {
+      const response = await fetch(makeURL('/api/v1/show/stage/scenery'));
+      if (response.ok) {
+        const data = await response.json();
+        this.sceneryList = data.scenery;
+      } else {
+        log.error('Unable to get scenery list');
+      }
+    },
+
+    async addScenery(scenery: Partial<Scenery>) {
+      const response = await fetch(makeURL('/api/v1/show/stage/scenery'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(scenery),
+      });
+      if (response.ok) {
+        await this.getSceneryList();
+        toast.success('Added new scenery!');
+      } else {
+        log.error('Unable to add new scenery');
+        toast.error('Unable to add new scenery');
+      }
+    },
+
+    async updateScenery(scenery: Partial<Scenery>) {
+      const response = await fetch(makeURL('/api/v1/show/stage/scenery'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(scenery),
+      });
+      if (response.ok) {
+        await this.getSceneryList();
+        toast.success('Updated scenery!');
+      } else {
+        log.error('Unable to edit scenery');
+        toast.error('Unable to edit scenery');
+      }
+    },
+
+    async deleteScenery(sceneryId: number) {
+      const params = new URLSearchParams({ id: String(sceneryId) });
+      const response = await fetch(`${makeURL('/api/v1/show/stage/scenery')}?${params}`, {
+        method: 'DELETE',
+      });
+      if (response.ok) {
+        await this.getSceneryList();
+        toast.success('Deleted scenery!');
+      } else {
+        log.error('Unable to delete scenery');
+        toast.error('Unable to delete scenery');
+      }
+    },
+
+    async getPropTypes() {
+      const response = await fetch(makeURL('/api/v1/show/stage/props/types'));
+      if (response.ok) {
+        const data = await response.json();
+        this.propTypes = data.prop_types;
+      } else {
+        log.error('Unable to get prop types');
+      }
+    },
+
+    async addPropType(propType: Partial<PropType>) {
+      const response = await fetch(makeURL('/api/v1/show/stage/props/types'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(propType),
+      });
+      if (response.ok) {
+        await this.getPropTypes();
+        toast.success('Added new prop type!');
+      } else {
+        log.error('Unable to add new prop type');
+        toast.error('Unable to add new prop type');
+      }
+    },
+
+    async updatePropType(propType: Partial<PropType>) {
+      const response = await fetch(makeURL('/api/v1/show/stage/props/types'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(propType),
+      });
+      if (response.ok) {
+        await this.getPropTypes();
+        toast.success('Updated prop type!');
+      } else {
+        log.error('Unable to edit prop type');
+        toast.error('Unable to edit prop type');
+      }
+    },
+
+    async deletePropType(propTypeId: number) {
+      const params = new URLSearchParams({ id: String(propTypeId) });
+      const response = await fetch(`${makeURL('/api/v1/show/stage/props/types')}?${params}`, {
+        method: 'DELETE',
+      });
+      if (response.ok) {
+        await Promise.all([this.getPropTypes(), this.getPropsList()]);
+        toast.success('Deleted prop type!');
+      } else {
+        log.error('Unable to delete prop type');
+        toast.error('Unable to delete prop type');
+      }
+    },
+
+    async getPropsList() {
+      const response = await fetch(makeURL('/api/v1/show/stage/props'));
+      if (response.ok) {
+        const data = await response.json();
+        this.propsList = data.props;
+      } else {
+        log.error('Unable to get props list');
+      }
+    },
+
+    async addProp(prop: Partial<Props>) {
+      const response = await fetch(makeURL('/api/v1/show/stage/props'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(prop),
+      });
+      if (response.ok) {
+        await this.getPropsList();
+        toast.success('Added new prop!');
+      } else {
+        log.error('Unable to add new prop');
+        toast.error('Unable to add new prop');
+      }
+    },
+
+    async updateProp(prop: Partial<Props>) {
+      const response = await fetch(makeURL('/api/v1/show/stage/props'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(prop),
+      });
+      if (response.ok) {
+        await this.getPropsList();
+        toast.success('Updated prop!');
+      } else {
+        log.error('Unable to edit prop');
+        toast.error('Unable to edit prop');
+      }
+    },
+
+    async deleteProp(propId: number) {
+      const params = new URLSearchParams({ id: String(propId) });
+      const response = await fetch(`${makeURL('/api/v1/show/stage/props')}?${params}`, {
+        method: 'DELETE',
+      });
+      if (response.ok) {
+        await this.getPropsList();
+        toast.success('Deleted prop!');
+      } else {
+        log.error('Unable to delete prop');
+        toast.error('Unable to delete prop');
+      }
+    },
+
+    async getPropsAllocations() {
+      const response = await fetch(makeURL('/api/v1/show/stage/props/allocations'));
+      if (response.ok) {
+        const data = await response.json();
+        this.propsAllocations = data.allocations;
+      } else {
+        log.error('Unable to get props allocations');
+      }
+    },
+
+    async addPropsAllocation(allocation: Partial<PropsAllocation>) {
+      const response = await fetch(makeURL('/api/v1/show/stage/props/allocations'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(allocation),
+      });
+      if (response.ok) {
+        await this.getPropsAllocations();
+        toast.success('Added prop allocation!');
+      } else {
+        log.error('Unable to add prop allocation');
+        toast.error('Unable to add prop allocation');
+      }
+    },
+
+    async deletePropsAllocation(allocationId: number) {
+      const params = new URLSearchParams({ id: String(allocationId) });
+      const response = await fetch(`${makeURL('/api/v1/show/stage/props/allocations')}?${params}`, {
+        method: 'DELETE',
+      });
+      if (response.ok) {
+        await this.getPropsAllocations();
+        toast.success('Deleted prop allocation!');
+      } else {
+        log.error('Unable to delete prop allocation');
+        toast.error('Unable to delete prop allocation');
+      }
+    },
+
+    async getSceneryAllocations() {
+      const response = await fetch(makeURL('/api/v1/show/stage/scenery/allocations'));
+      if (response.ok) {
+        const data = await response.json();
+        this.sceneryAllocations = data.allocations;
+      } else {
+        log.error('Unable to get scenery allocations');
+      }
+    },
+
+    async addSceneryAllocation(allocation: Partial<SceneryAllocation>) {
+      const response = await fetch(makeURL('/api/v1/show/stage/scenery/allocations'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(allocation),
+      });
+      if (response.ok) {
+        await this.getSceneryAllocations();
+        toast.success('Added scenery allocation!');
+      } else {
+        log.error('Unable to add scenery allocation');
+        toast.error('Unable to add scenery allocation');
+      }
+    },
+
+    async deleteSceneryAllocation(allocationId: number) {
+      const params = new URLSearchParams({ id: String(allocationId) });
+      const response = await fetch(
+        `${makeURL('/api/v1/show/stage/scenery/allocations')}?${params}`,
+        { method: 'DELETE' }
+      );
+      if (response.ok) {
+        await this.getSceneryAllocations();
+        toast.success('Deleted scenery allocation!');
+      } else {
+        log.error('Unable to delete scenery allocation');
+        toast.error('Unable to delete scenery allocation');
+      }
+    },
+
+    async getCrewAssignments() {
+      const response = await fetch(makeURL('/api/v1/show/stage/crew/assignments'));
+      if (response.ok) {
+        const data = await response.json();
+        this.crewAssignments = data.assignments;
+      } else {
+        log.error('Unable to get crew assignments');
+      }
+    },
+
+    async addCrewAssignment(assignment: Partial<CrewAssignment>): Promise<boolean> {
+      const response = await fetch(makeURL('/api/v1/show/stage/crew/assignments'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(assignment),
+      });
+      if (response.ok) {
+        await this.getCrewAssignments();
+        toast.success('Added crew assignment!');
+        return true;
+      } else {
+        const errorData = await response.json().catch(() => ({}));
+        const errorMsg =
+          (errorData as { message?: string }).message ?? 'Unable to add crew assignment';
+        log.error(errorMsg);
+        toast.error(errorMsg);
+        return false;
+      }
+    },
+
+    async deleteCrewAssignment(assignmentId: number) {
+      const params = new URLSearchParams({ id: String(assignmentId) });
+      const response = await fetch(`${makeURL('/api/v1/show/stage/crew/assignments')}?${params}`, {
+        method: 'DELETE',
+      });
+      if (response.ok) {
+        await this.getCrewAssignments();
+        toast.success('Deleted crew assignment!');
+      } else {
+        const errorData = await response.json().catch(() => ({}));
+        const errorMsg =
+          (errorData as { message?: string }).message ?? 'Unable to delete crew assignment';
+        log.error(errorMsg);
+        toast.error(errorMsg);
+      }
+    },
+  },
+});

--- a/client-v3/src/views/show/config/ConfigStage.vue
+++ b/client-v3/src/views/show/config/ConfigStage.vue
@@ -1,0 +1,29 @@
+<template>
+  <BContainer class="mx-0" fluid>
+    <BRow>
+      <BCol>
+        <BTabs content-class="mt-3">
+          <BTab title="Crew" active><CrewList /></BTab>
+          <BTab title="Scenery"><SceneryList /></BTab>
+          <BTab title="Props"><PropsList /></BTab>
+          <BTab title="Stage Manager"><StageManager /></BTab>
+          <BTab title="Timeline">
+            <BTabs content-class="mt-2">
+              <BTab title="Props &amp; Scenery" active><StageTimeline /></BTab>
+              <BTab title="Crew" lazy><CrewTimeline /></BTab>
+            </BTabs>
+          </BTab>
+        </BTabs>
+      </BCol>
+    </BRow>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import CrewList from '@/components/show/config/stage/CrewList.vue';
+import SceneryList from '@/components/show/config/stage/SceneryList.vue';
+import PropsList from '@/components/show/config/stage/PropsList.vue';
+import StageManager from '@/components/show/config/stage/StageManager.vue';
+import StageTimeline from '@/components/show/config/stage/StageTimeline.vue';
+import CrewTimeline from '@/components/show/config/stage/CrewTimeline.vue';
+</script>


### PR DESCRIPTION
## Summary

- Ports the full Stage configuration tab from V2 to V3 (5 sub-tabs)
- **Crew**: CRUD table for crew members (first/last name) with Vuelidate validation; store maps snake_case fields to camelCase API keys (`firstName`/`lastName`)
- **Scenery**: Type and item CRUD with cascade-delete warnings; fixes a V2 bug where `scenery_type_id` was not set when opening the edit modal
- **Props**: Mirror of Scenery tab for prop types and items
- **Stage Manager**: Scene-by-scene navigation with Allocations card (Scenery + Props tables), Add dropdown, SET/STRIKE boundary cards with crew assignment per item, and orphan-detection via `blockOrphanUtils` (plain-text confirmation replacing V2's VNode)
- **Timeline → Props & Scenery**: SVG timeline using `useTimeline()` composable; Combined/Props/Scenery view mode toggle; bar click opens `TimelineSidePanel` for crew assignment editing; PNG export
- **Timeline → Crew**: SVG crew timeline with hard (same scene, multiple items) and soft (adjacent scene item change) conflict highlighting; lazy-loaded
- **`stores/stage.ts`**: Pinia store with 8 flat arrays, 13 parameterised getters, 28 actions; all POST/PATCH bodies use camelCase matching the backend API
- **`blockOrphanUtils.ts` + tests**: Direct copy from V2 (pure TS, no Vue deps); all 16 tests pass
- **`ConfigStage.vue`**: 5-tab shell, no parent loading guard (each child self-fetches)

## Test plan

- [x] `npm run build` — passes, no TS errors
- [x] `npm run typecheck` — passes
- [x] `npm run ci-lint` — passes (Prettier + ESLint)
- [x] `npm run test:run` — 16/16 blockOrphanUtils tests pass
- [x] Browser: Crew tab — add/edit/delete crew member works end-to-end
- [x] Browser: Scenery tab — both tables render, buttons visible
- [x] Browser: Stage Manager — scene nav, allocation cards, empty-state messages correct
- [x] Browser: Timeline → Props & Scenery — sub-tabs, view toggle, empty-state message correct
- [x] Zero console errors across all tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)