### PR TITLE
Vue 3 migration: Phase 11 — Script & Revisions configuration

### DIFF
--- a/client-v3/src/App.vue
+++ b/client-v3/src/App.vue
@@ -5,7 +5,7 @@
       toggleable="lg"
       variant="info"
       data-bs-theme="dark"
-      :sticky="true"
+      class="sticky-top"
     >
       <BNavbarBrand to="/"> DigiScript </BNavbarBrand>
       <BNavbarToggle target="nav-collapse" />

--- a/client-v3/src/assets/styles/dark.scss
+++ b/client-v3/src/assets/styles/dark.scss
@@ -9,6 +9,11 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+// Map V2's --body-background variable to Bootstrap 5's equivalent
+:root {
+  --body-background: var(--bs-body-bg);
+}
+
 // BVN's BFormGroup renders .b-form-group; Bootstrap 5 dropped .form-group's built-in margin
 .b-form-group {
   margin-bottom: 1rem;

--- a/client-v3/src/components/show/config/script/BulkActSceneModal.vue
+++ b/client-v3/src/components/show/config/script/BulkActSceneModal.vue
@@ -1,0 +1,114 @@
+<template>
+  <BModal
+    ref="modal"
+    title="Bulk Edit Act/Scene"
+    size="md"
+    ok-title="Apply"
+    :ok-disabled="!canApply"
+    @ok.prevent="handleOk"
+    @hidden="reset"
+  >
+    <p class="text-muted small mb-3">
+      Applies the selected act and scene to all lines from the chosen start line to end line
+      (inclusive).
+    </p>
+    <BFormGroup label="Act" label-for="bulk-act-input">
+      <BFormSelect
+        id="bulk-act-input"
+        v-model="selectedActId"
+        :options="actOptions"
+        @update:model-value="selectedSceneId = null"
+      />
+    </BFormGroup>
+    <BFormGroup label="Scene" label-for="bulk-scene-input">
+      <BFormSelect
+        id="bulk-scene-input"
+        v-model="selectedSceneId"
+        :options="sceneOptions"
+        :disabled="selectedActId == null"
+      />
+    </BFormGroup>
+  </BModal>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import type { BModal } from 'bootstrap-vue-next';
+import type { ScriptLine } from '@/types/api/script';
+import type { Act, Scene } from '@/types/api/show';
+
+const props = defineProps<{
+  previousLineOfStart: ScriptLine | null;
+  nextLineOfEnd: ScriptLine | null;
+  acts: Act[];
+  scenes: Scene[];
+}>();
+
+const emit = defineEmits<{
+  apply: [payload: { actId: number; sceneId: number }];
+}>();
+
+const modal = ref<InstanceType<typeof BModal>>();
+const selectedActId = ref<number | null>(null);
+const selectedSceneId = ref<number | null>(null);
+
+const validActs = computed<Act[]>(() => {
+  let startAct = props.acts.find((a) => a.previous_act == null) ?? null;
+  if (props.previousLineOfStart?.act_id != null) {
+    startAct = props.acts.find((a) => a.id === props.previousLineOfStart!.act_id) ?? startAct;
+  }
+  const result: Act[] = [];
+  let cur = startAct;
+  while (cur) {
+    result.push(cur);
+    if (props.nextLineOfEnd && props.nextLineOfEnd.act_id === cur.id) break;
+    cur = cur.next_act != null ? (props.acts.find((a) => a.id === cur!.next_act) ?? null) : null;
+  }
+  return result;
+});
+
+const validScenes = computed<Scene[]>(() => {
+  if (selectedActId.value == null) return [];
+  const actScenes = props.scenes.filter((s) => s.act === selectedActId.value);
+  let startScene = actScenes.find((s) => s.previous_scene == null) ?? null;
+  if (
+    props.previousLineOfStart?.act_id === selectedActId.value &&
+    props.previousLineOfStart?.scene_id != null
+  ) {
+    startScene = actScenes.find((s) => s.id === props.previousLineOfStart!.scene_id) ?? startScene;
+  }
+  const result: Scene[] = [];
+  let cur = startScene;
+  while (cur) {
+    result.push(cur);
+    if (props.nextLineOfEnd && props.nextLineOfEnd.scene_id === cur.id) break;
+    cur = cur.next_scene != null ? (actScenes.find((s) => s.id === cur!.next_scene) ?? null) : null;
+  }
+  return result;
+});
+
+const actOptions = computed(() => [
+  { value: null, text: 'Select an act', disabled: true },
+  ...validActs.value.map((a) => ({ value: a.id, text: a.name })),
+]);
+
+const sceneOptions = computed(() => [
+  { value: null, text: 'Select a scene', disabled: true },
+  ...validScenes.value.map((s) => ({ value: s.id, text: s.name })),
+]);
+
+const canApply = computed(() => selectedActId.value != null && selectedSceneId.value != null);
+
+function handleOk(): void {
+  if (canApply.value) {
+    emit('apply', { actId: selectedActId.value!, sceneId: selectedSceneId.value! });
+  }
+}
+
+function reset(): void {
+  selectedActId.value = null;
+  selectedSceneId.value = null;
+}
+
+defineExpose({ show: () => modal.value?.show(), hide: () => modal.value?.hide() });
+</script>

--- a/client-v3/src/components/show/config/script/CompiledScripts.vue
+++ b/client-v3/src/components/show/config/script/CompiledScripts.vue
@@ -1,0 +1,122 @@
+<template>
+  <div v-if="!loading">
+    <BTable :items="tableData" :fields="tableColumns" show-empty>
+      <template #cell(revision_id)="data">
+        <span>
+          {{ data.item.revision }}
+          <span v-if="data.item.revision_id === showStore.currentRevision" class="text-success ms-1"
+            >✓</span
+          >
+        </span>
+      </template>
+      <template #cell(btn)="data">
+        <BSpinner v-if="data.item.revision_id === pendingRevisionId" small />
+        <BButtonGroup v-else-if="systemStore.isScriptEditor">
+          <BButton
+            v-if="data.item.data_path != null"
+            variant="danger"
+            size="sm"
+            :disabled="deletingCompiledScript || generatingCompiledScript"
+            @click="deleteCompiledScript(data.item)"
+          >
+            Delete
+          </BButton>
+          <BButton
+            v-else
+            variant="success"
+            size="sm"
+            :disabled="deletingCompiledScript || generatingCompiledScript"
+            @click="generateCompiledScript(data.item)"
+          >
+            Generate
+          </BButton>
+        </BButtonGroup>
+      </template>
+    </BTable>
+  </div>
+  <div v-else class="text-center py-5">
+    <BSpinner label="Loading" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import log from 'loglevel';
+import { useScriptStore } from '@/stores/script';
+import { useShowStore } from '@/stores/show';
+import { useSystemStore } from '@/stores/system';
+import { useConfirm } from '@/composables/useConfirm';
+import { toast } from '@/js/toast';
+
+const scriptStore = useScriptStore();
+const showStore = useShowStore();
+const systemStore = useSystemStore();
+const { confirm } = useConfirm();
+
+const loading = ref(true);
+const deletingCompiledScript = ref(false);
+const generatingCompiledScript = ref(false);
+const pendingRevisionId = ref<number | null>(null);
+
+const tableColumns = [
+  { key: 'revision_id', label: 'Script Revision' },
+  { key: 'created_at', label: 'Created At' },
+  { key: 'updated_at', label: 'Updated At' },
+  { key: 'data_path', label: 'Data Path' },
+  { key: 'btn', label: '' },
+];
+
+const tableData = computed(() =>
+  showStore.scriptRevisions.map((revision) => {
+    const compiled = scriptStore.compiledScripts.find((cs) => cs.revision_id === revision.id);
+    return {
+      revision_id: revision.id,
+      revision: revision.revision,
+      created_at: compiled?.created_at ?? null,
+      updated_at: compiled?.updated_at ?? null,
+      data_path: compiled?.data_path ?? null,
+    };
+  })
+);
+
+async function deleteCompiledScript(item: {
+  revision_id: number;
+  revision: number | null;
+}): Promise<void> {
+  const ok = await confirm(
+    `Are you sure you want to delete the compiled script for revision ${item.revision}?`,
+    { okVariant: 'danger', okTitle: 'Delete' }
+  );
+  if (!ok) return;
+  deletingCompiledScript.value = true;
+  pendingRevisionId.value = item.revision_id;
+  try {
+    await scriptStore.deleteCompiledScript(item.revision_id);
+  } catch (e) {
+    log.error('Error deleting compiled script:', e);
+    toast.error('Unable to delete compiled script!');
+  } finally {
+    deletingCompiledScript.value = false;
+    pendingRevisionId.value = null;
+  }
+}
+
+async function generateCompiledScript(item: { revision_id: number }): Promise<void> {
+  generatingCompiledScript.value = true;
+  pendingRevisionId.value = item.revision_id;
+  try {
+    await scriptStore.generateCompiledScript(item.revision_id);
+  } catch (e) {
+    log.error('Error generating compiled script:', e);
+    toast.error('Unable to compile script revision!');
+  } finally {
+    generatingCompiledScript.value = false;
+    pendingRevisionId.value = null;
+  }
+}
+
+onMounted(async () => {
+  await scriptStore.getCompiledScripts();
+  loading.value = false;
+});
+</script>

--- a/client-v3/src/components/show/config/script/RevisionDetailModal.vue
+++ b/client-v3/src/components/show/config/script/RevisionDetailModal.vue
@@ -1,0 +1,145 @@
+<template>
+  <BModal
+    ref="modal"
+    :title="`Revision ${revision ? revision.revision : ''}`"
+    size="lg"
+    @hidden="$emit('hidden')"
+  >
+    <div v-if="revision">
+      <BRow>
+        <BCol cols="12">
+          <BAlert v-if="isCurrentRevision" variant="success" :model-value="true">
+            This is the current active revision
+          </BAlert>
+        </BCol>
+      </BRow>
+      <BRow>
+        <BCol cols="12" md="6">
+          <dl>
+            <dt>Revision Number</dt>
+            <dd>{{ revision.revision }}</dd>
+            <dt>Description</dt>
+            <dd>{{ revision.description || 'No description' }}</dd>
+            <dt>Created At</dt>
+            <dd>{{ formatDate(revision.created_at) }}</dd>
+            <dt>Last Edited</dt>
+            <dd>{{ formatDate(revision.edited_at) }}</dd>
+          </dl>
+        </BCol>
+        <BCol cols="12" md="6">
+          <dl>
+            <dt>Previous Revision</dt>
+            <dd v-if="previousRevision">
+              Revision {{ previousRevision.revision }}<br />
+              <small class="text-muted">{{ previousRevision.description }}</small>
+            </dd>
+            <dd v-else><em class="text-muted">None (root revision)</em></dd>
+            <dt>Child Revisions</dt>
+            <dd v-if="childRevisions.length > 0">
+              <ul class="list-unstyled">
+                <li v-for="child in childRevisions" :key="child.id">
+                  Revision {{ child.revision }}: {{ child.description }}
+                </li>
+              </ul>
+            </dd>
+            <dd v-else><em class="text-muted">None</em></dd>
+          </dl>
+        </BCol>
+      </BRow>
+    </div>
+    <template #footer>
+      <div class="w-100 d-flex justify-content-between">
+        <div>
+          <BButton
+            v-if="!isCurrentRevision && canEdit"
+            variant="warning"
+            :disabled="!!submitting"
+            @click="$emit('load-revision', revision)"
+          >
+            <BSpinner v-if="submitting === 'load'" small />
+            Load This Revision
+          </BButton>
+        </div>
+        <div class="d-flex gap-2">
+          <BButton
+            v-if="canEdit"
+            variant="success"
+            :disabled="!!submitting"
+            @click="$emit('create-from', revision)"
+          >
+            <BSpinner v-if="submitting === 'create'" small />
+            Create Branch From Here
+          </BButton>
+          <BButton variant="secondary" @click="$emit('close')">Close</BButton>
+        </div>
+      </div>
+    </template>
+  </BModal>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { BModal } from 'bootstrap-vue-next';
+import type { ScriptRevision } from '@/types/api/script';
+
+const props = defineProps<{
+  revision: ScriptRevision | null;
+  revisions: ScriptRevision[];
+  currentRevisionId: number | null;
+  canEdit: boolean;
+  submitting: boolean | string;
+}>();
+
+defineEmits<{
+  'load-revision': [revision: ScriptRevision];
+  'create-from': [revision: ScriptRevision];
+  close: [];
+  hidden: [];
+}>();
+
+const modal = ref<InstanceType<typeof BModal>>();
+
+const isCurrentRevision = computed(
+  () => props.revision != null && props.revision.id === props.currentRevisionId
+);
+
+const previousRevision = computed(() => {
+  if (!props.revision?.previous_revision_id) return null;
+  return props.revisions.find((r) => r.id === props.revision!.previous_revision_id) ?? null;
+});
+
+const childRevisions = computed(() => {
+  if (!props.revision) return [];
+  return props.revisions.filter((r) => r.previous_revision_id === props.revision!.id);
+});
+
+function formatDate(dateString: string | null): string {
+  if (!dateString) return 'N/A';
+  return new Date(dateString).toLocaleString();
+}
+
+function show(): void {
+  modal.value?.show();
+}
+
+function hide(): void {
+  modal.value?.hide();
+}
+
+defineExpose({ show, hide });
+</script>
+
+<style scoped>
+dl {
+  margin-bottom: 0;
+}
+dt {
+  font-weight: 600;
+  margin-top: 0.5rem;
+  color: #dee2e6;
+}
+dd {
+  margin-bottom: 0.5rem;
+  color: #adb5bd;
+}
+</style>

--- a/client-v3/src/components/show/config/script/RevisionGraph.vue
+++ b/client-v3/src/components/show/config/script/RevisionGraph.vue
@@ -1,0 +1,313 @@
+<template>
+  <div class="revision-graph-container">
+    <div v-if="!hasRevisions" class="text-center py-5 text-muted">No revisions to display</div>
+    <div v-else class="graph-wrapper">
+      <svg ref="svgRef" :width="width" :height="height" class="revision-graph">
+        <defs>
+          <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+            <polygon points="0 0, 10 3, 0 6" fill="#6c757d" />
+          </marker>
+        </defs>
+        <g ref="zoomGroupRef" class="zoom-group">
+          <g :transform="`translate(${margin.left},${margin.top})`">
+            <g class="links">
+              <path
+                v-for="link in links"
+                :key="`link-${link.source.data.id}-${link.target.data.id}`"
+                :d="linkPath(link)"
+                class="revision-link"
+                marker-end="url(#arrowhead)"
+              />
+            </g>
+            <g class="nodes">
+              <g
+                v-for="node in nodes"
+                :key="`node-${node.data.id}`"
+                :transform="`translate(${node.y},${node.x})`"
+                class="node-group"
+                @click="$emit('node-click', node.data)"
+              >
+                <title>{{ nodeTooltip(node) }}</title>
+                <circle
+                  v-if="node.data.id === currentRevisionId"
+                  :r="nodeRadius + 4"
+                  class="current-indicator"
+                />
+                <circle :r="nodeRadius" :class="nodeClass(node)" />
+                <text class="node-label" dy=".35em" :x="nodeRadius + 5">
+                  Rev {{ node.data.revision }}
+                </text>
+              </g>
+            </g>
+          </g>
+        </g>
+      </svg>
+      <div class="zoom-controls">
+        <BButtonGroup vertical>
+          <BButton size="sm" variant="outline-secondary" @click="zoomIn">+</BButton>
+          <BButton size="sm" variant="outline-secondary" @click="zoomOut">-</BButton>
+          <BButton size="sm" variant="outline-secondary" @click="resetZoom">↺</BButton>
+        </BButtonGroup>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue';
+import { hierarchy, tree } from 'd3-hierarchy';
+import { select } from 'd3-selection';
+import { zoom as d3zoom, zoomIdentity } from 'd3-zoom';
+import type { ScriptRevision } from '@/types/api/script';
+
+const props = defineProps<{
+  revisions: ScriptRevision[];
+  currentRevisionId: number | null;
+  selectedRevisionId?: number | null;
+}>();
+
+defineEmits<{ 'node-click': [revision: ScriptRevision] }>();
+
+const svgRef = ref<SVGSVGElement | null>(null);
+const zoomGroupRef = ref<SVGGElement | null>(null);
+const width = ref(800);
+const height = 400;
+const margin = { top: 20, right: 120, bottom: 20, left: 40 };
+const nodeRadius = 8;
+
+// D3 state — NOT in Vue reactive state (would cause infinite loops)
+let zoomBehavior: ReturnType<typeof d3zoom> | null = null;
+
+const hasRevisions = computed(() => props.revisions.length > 0);
+
+const treeData = computed(() => {
+  if (!hasRevisions.value) return null;
+  const root = props.revisions.find((r) => !r.previous_revision_id || r.revision === 1);
+  if (!root) return null;
+  const buildTree = (revision: ScriptRevision): any => ({
+    ...revision,
+    children: props.revisions
+      .filter((r) => r.previous_revision_id === revision.id)
+      .map(buildTree)
+      .filter((c) => c.children !== undefined || props.revisions.some((r) => r.id === c.id)),
+  });
+  return buildTree(root);
+});
+
+const hierarchyData = computed(() => {
+  if (!treeData.value) return null;
+  const root = hierarchy(treeData.value);
+  const treeLayout = tree<ScriptRevision>().size([
+    height - margin.top - margin.bottom,
+    width.value - margin.left - margin.right,
+  ]);
+  return treeLayout(root as any);
+});
+
+const nodes = computed(() => hierarchyData.value?.descendants() ?? []);
+const links = computed(() => hierarchyData.value?.links() ?? []);
+
+function nodeClass(node: any): string {
+  const classes = ['revision-node'];
+  if (node.data.id === props.currentRevisionId) classes.push('current');
+  if (node.data.id === props.selectedRevisionId) classes.push('selected');
+  return classes.join(' ');
+}
+
+function nodeTooltip(node: any): string {
+  const parts = [
+    `Revision ${node.data.revision}`,
+    `Description: ${node.data.description || 'N/A'}`,
+    `Created: ${node.data.created_at || 'N/A'}`,
+  ];
+  if (node.data.id === props.currentRevisionId) parts.push('(Current)');
+  return parts.join('\n');
+}
+
+function linkPath(link: any): string {
+  const midY = (link.source.y + link.target.y) / 2;
+  return `M${link.source.y},${link.source.x} C${midY},${link.source.x} ${midY},${link.target.x} ${link.target.y},${link.target.x}`;
+}
+
+function updateWidth(): void {
+  const container = svgRef.value?.parentElement as HTMLElement | null;
+  if (container) width.value = container.clientWidth || 800;
+}
+
+function initZoom(): void {
+  if (!svgRef.value || !zoomGroupRef.value) return;
+  const svg = select(svgRef.value);
+  const g = select(zoomGroupRef.value);
+  zoomBehavior = d3zoom()
+    .scaleExtent([0.1, 4])
+    .on('zoom', (event: any) => {
+      g.attr('transform', event.transform);
+    });
+  svg.call(zoomBehavior as any);
+}
+
+function fitToContent(): void {
+  if (!nodes.value.length || !svgRef.value || !zoomBehavior) return;
+  const padding = 50;
+  const minX = Math.min(...nodes.value.map((n: any) => n.x)) - padding;
+  const maxX = Math.max(...nodes.value.map((n: any) => n.x)) + padding;
+  const minY = Math.min(...nodes.value.map((n: any) => n.y)) - padding;
+  const maxY = Math.max(...nodes.value.map((n: any) => n.y)) + padding;
+  const cw = maxY - minY;
+  const ch = maxX - minX;
+  if (cw === 0 || ch === 0) return;
+  const scale = Math.min(
+    (width.value - margin.left - margin.right) / cw,
+    (height - margin.top - margin.bottom) / ch,
+    1
+  );
+  const tx = (width.value - cw * scale) / 2 - minY * scale;
+  const ty = (height - ch * scale) / 2 - minX * scale;
+  select(svgRef.value as Element)
+    .transition()
+    .duration(500)
+    .call((zoomBehavior as any).transform, zoomIdentity.translate(tx, ty).scale(scale));
+}
+
+function zoomIn(): void {
+  if (!svgRef.value || !zoomBehavior) return;
+  select(svgRef.value as Element)
+    .transition()
+    .duration(300)
+    .call((zoomBehavior as any).scaleBy, 1.3);
+}
+
+function zoomOut(): void {
+  if (!svgRef.value || !zoomBehavior) return;
+  select(svgRef.value as Element)
+    .transition()
+    .duration(300)
+    .call((zoomBehavior as any).scaleBy, 0.7);
+}
+
+function resetZoom(): void {
+  if (!svgRef.value || !zoomBehavior) return;
+  select(svgRef.value as Element)
+    .transition()
+    .duration(300)
+    .call((zoomBehavior as any).transform, zoomIdentity);
+}
+
+onMounted(() => {
+  updateWidth();
+  window.addEventListener('resize', updateWidth);
+  nextTick(() => {
+    initZoom();
+    fitToContent();
+  });
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', updateWidth);
+  if (zoomBehavior && svgRef.value) {
+    select(svgRef.value as Element).on('.zoom', null);
+  }
+});
+
+watch(
+  () => props.revisions,
+  () => {
+    nextTick(() => fitToContent());
+  },
+  { deep: true }
+);
+</script>
+
+<style scoped>
+.revision-graph-container {
+  position: relative;
+  background-color: var(--body-background);
+  border: 1px solid #dee2e6;
+  border-radius: 0.25rem;
+  overflow: hidden;
+}
+.graph-wrapper {
+  position: relative;
+}
+.revision-graph {
+  display: block;
+  cursor: grab;
+  background-color: var(--body-background);
+}
+.revision-graph:active {
+  cursor: grabbing;
+}
+.revision-link {
+  fill: none;
+  stroke: #6c757d;
+  stroke-width: 2px;
+  opacity: 0.6;
+}
+.node-group {
+  cursor: pointer;
+}
+.revision-node {
+  fill: #007bff;
+  stroke: #0056b3;
+  stroke-width: 2px;
+  transition: all 0.2s ease;
+}
+.node-group:hover .revision-node {
+  fill: #0056b3;
+  stroke: #004085;
+  stroke-width: 3px;
+  filter: drop-shadow(0 0 4px rgba(0, 123, 255, 0.6));
+}
+.revision-node.current {
+  fill: #28a745;
+  stroke: #1e7e34;
+}
+.node-group:hover .revision-node.current {
+  fill: #1e7e34;
+  stroke: #155724;
+  stroke-width: 3px;
+  filter: drop-shadow(0 0 4px rgba(40, 167, 69, 0.6));
+}
+.revision-node.selected {
+  stroke: #ffc107;
+  stroke-width: 3px;
+}
+.current-indicator {
+  fill: none;
+  stroke: #28a745;
+  stroke-width: 2px;
+  animation: pulse 2s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+.node-label {
+  fill: #dee2e6;
+  font-size: 12px;
+  font-weight: 500;
+  pointer-events: none;
+  user-select: none;
+}
+.zoom-controls {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 10;
+}
+.zoom-controls :deep(.btn) {
+  background-color: rgba(52, 58, 64, 0.9);
+  border-color: #6c757d;
+  color: #dee2e6;
+}
+.zoom-controls :deep(.btn:hover) {
+  background-color: rgba(73, 80, 87, 0.9);
+  border-color: #adb5bd;
+  color: #fff;
+}
+</style>

--- a/client-v3/src/components/show/config/script/ScriptEditor.vue
+++ b/client-v3/src/components/show/config/script/ScriptEditor.vue
@@ -63,7 +63,6 @@
         <BCol cols="1" />
       </BRow>
     </div>
-    <hr />
     <BRow class="script-row">
       <BCol cols="12">
         <template

--- a/client-v3/src/components/show/config/script/ScriptEditor.vue
+++ b/client-v3/src/components/show/config/script/ScriptEditor.vue
@@ -349,6 +349,7 @@ async function stopEditing(): Promise<void> {
   linePartCuts.value = [...scriptStore.cuts];
   sendObj({ OP: 'STOP_SCRIPT_EDIT', DATA: {} });
   scriptConfigStore.setCutMode(false);
+  await loadPage(currentPage.value);
 }
 
 async function loadPage(page: number): Promise<void> {

--- a/client-v3/src/components/show/config/script/ScriptEditor.vue
+++ b/client-v3/src/components/show/config/script/ScriptEditor.vue
@@ -1,0 +1,788 @@
+<template>
+  <BContainer v-if="loaded" class="mx-0 px-0 script-editor-container" fluid>
+    <div class="sticky-header" :style="{ top: navbarHeight + 'px' }">
+      <BRow class="script-row">
+        <BCol cols="2">
+          <BButton variant="success" @click="goToPageModal?.show()">Go to Page</BButton>
+        </BCol>
+        <BCol cols="2" style="text-align: right">
+          <BButton variant="success" :disabled="currentPage === 1" @click="decrPage">
+            Prev Page
+          </BButton>
+        </BCol>
+        <BCol cols="4">
+          <p>Current Page: {{ currentPage }}</p>
+        </BCol>
+        <BCol cols="2" style="text-align: left">
+          <BButton variant="success" @click="incrPage">Next Page</BButton>
+        </BCol>
+        <BCol cols="2">
+          <BButtonGroup v-if="systemStore.isScriptEditor">
+            <template v-if="!isEditor">
+              <BButton
+                variant="warning"
+                :disabled="!scriptConfigStore.editStatus.canRequestEdit"
+                @click="requestEdit"
+              >
+                Edit
+              </BButton>
+              <BButton
+                variant="warning"
+                :disabled="!scriptConfigStore.editStatus.canRequestEdit"
+                @click="requestCutEdit"
+              >
+                Cuts
+              </BButton>
+            </template>
+            <template v-else>
+              <BButton
+                variant="warning"
+                :disabled="savingInProgress || isAutoSaving"
+                @click="stopEditing"
+              >
+                Stop Editing
+              </BButton>
+              <BButton variant="success" :disabled="!canSave && !isAutoSaving" @click="saveScript">
+                Save
+              </BButton>
+              <BButton
+                v-if="canEdit && !scriptConfigStore.cutMode"
+                :variant="bulkEditMode ? 'info' : 'outline-info'"
+                @click="bulkEditMode ? exitBulkEditMode() : enterBulkEditMode()"
+              >
+                {{ bulkEditMode ? 'Exit Bulk Edit' : 'Bulk Edit' }}
+              </BButton>
+            </template>
+          </BButtonGroup>
+        </BCol>
+      </BRow>
+      <BRow class="script-row">
+        <BCol cols="1">Act</BCol>
+        <BCol cols="1">Scene</BCol>
+        <BCol>Line</BCol>
+        <BCol cols="1" />
+      </BRow>
+    </div>
+    <hr />
+    <BRow class="script-row">
+      <BCol cols="12">
+        <template
+          v-for="(line, index) in currentPageLines"
+          :key="`page_${currentPage}_line_${index}`"
+        >
+          <template v-if="!deletedLines.includes(index)">
+            <ScriptLineEditor
+              v-if="editingLines.has(`page_${currentPage}_line_${index}`)"
+              :line-index="index"
+              :current-edit-page="currentPage"
+              :acts="showStore.actList"
+              :scenes="showStore.sceneList"
+              :characters="showStore.characterList"
+              :character-groups="showStore.characterGroupList"
+              :model-value="line"
+              :previous-line="getPreviousLine(index)"
+              :next-line="getNextLine(index)"
+              :line-type="line.line_type"
+              :stage-direction-styles="scriptStore.stageDirectionStyles"
+              @update:model-value="onLineChange(index, $event)"
+              @done-editing="doneEditingLine(currentPage, index)"
+              @delete-line="deleteLine(currentPage, index)"
+            />
+            <ScriptLineViewer
+              v-else
+              :line-index="index"
+              :line="line"
+              :page="currentPageLines"
+              :acts="showStore.actList"
+              :scenes="showStore.sceneList"
+              :characters="showStore.characterList"
+              :character-groups="showStore.characterGroupList"
+              :previous-line="currentPageLines[index - 1] ?? null"
+              :can-edit="canEdit"
+              :line-part-cuts="linePartCuts"
+              :stage-direction-styles="scriptStore.stageDirectionStyles"
+              :stage-direction-style-overrides="userStore.stageDirectionStyleOverrides"
+              :bulk-edit-mode="bulkEditMode"
+              :is-bulk-start="isBulkStart(index)"
+              :is-bulk-end="isBulkEnd(index)"
+              @edit-line="beginEditingLine(currentPage, index)"
+              @cut-line-part="cutLinePart"
+              @insert-dialogue="insertLineAt(currentPage, index, LINE_TYPES.DIALOGUE)"
+              @insert-stage-direction="insertLineAt(currentPage, index, LINE_TYPES.STAGE_DIRECTION)"
+              @insert-cue-line="insertLineAt(currentPage, index, LINE_TYPES.CUE_LINE)"
+              @insert-spacing="insertLineAt(currentPage, index, LINE_TYPES.SPACING)"
+              @delete-line="deleteLine(currentPage, index)"
+              @set-bulk-start="onSetBulkStart(index)"
+              @set-bulk-end="onSetBulkEnd(index)"
+            />
+          </template>
+        </template>
+      </BCol>
+    </BRow>
+    <BRow class="script-row pt-1">
+      <BCol cols="10" class="ms-auto">
+        <BButtonGroup v-show="canEdit && !scriptConfigStore.cutMode" style="float: right">
+          <BDropdown
+            split
+            text="Add Dialogue"
+            variant="primary"
+            end
+            boundary="window"
+            @click="addNewLine(LINE_TYPES.DIALOGUE)"
+          >
+            <BDropdownItem @click="addNewLine(LINE_TYPES.STAGE_DIRECTION)"
+              >Add Stage Direction</BDropdownItem
+            >
+            <BDropdownItem @click="addNewLine(LINE_TYPES.CUE_LINE)">Add Cue Line</BDropdownItem>
+            <BDropdownItem @click="addNewLine(LINE_TYPES.SPACING)">Add Spacing</BDropdownItem>
+          </BDropdown>
+        </BButtonGroup>
+      </BCol>
+    </BRow>
+
+    <!-- Save modal -->
+    <BModal
+      ref="saveModal"
+      title="Saving Script"
+      size="md"
+      :hide-header-close="savingInProgress"
+      :hide-footer="savingInProgress"
+      :no-close-on-backdrop="savingInProgress"
+      :no-close-on-esc="savingInProgress"
+      ok-only
+    >
+      <div>
+        <b v-if="savingInProgress">Saving page {{ curSavePage }} of {{ totalSavePages }}</b>
+        <template v-else>
+          <b v-if="saveError">Could not save script changes.</b>
+          <b v-else>Finished saving script.</b>
+        </template>
+      </div>
+      <BProgress
+        :value="curSavePage"
+        :max="totalSavePages ?? 0"
+        :variant="saveProgressVariant"
+        show-value
+        :animated="savingInProgress"
+      />
+    </BModal>
+
+    <BulkActSceneModal
+      ref="bulkModal"
+      :previous-line-of-start="previousLineOfStart"
+      :next-line-of-end="nextLineOfEnd"
+      :acts="showStore.actList"
+      :scenes="showStore.sceneList"
+      @apply="onBulkApply"
+    />
+
+    <!-- Go-to-page modal -->
+    <BModal
+      ref="goToPageModal"
+      title="Go to Page"
+      size="sm"
+      :hide-header-close="changingPage"
+      :hide-footer="changingPage"
+      :no-close-on-backdrop="changingPage"
+      :no-close-on-esc="changingPage"
+      @ok.prevent="goToPage"
+    >
+      <BForm @submit.stop.prevent="">
+        <BFormGroup label="Page" label-for="page-input" label-cols="auto">
+          <BFormInput id="page-input" v-model.number="pageInputNo" type="number" :min="1" />
+        </BFormGroup>
+      </BForm>
+    </BModal>
+  </BContainer>
+
+  <BContainer v-else class="mx-0 px-0 script-editor-container" fluid>
+    <BRow>
+      <BCol class="text-center py-5"><BSpinner label="Loading" /></BCol>
+    </BRow>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
+import type { BModal } from 'bootstrap-vue-next';
+import log from 'loglevel';
+import { LINE_TYPES } from '@/constants/lineTypes';
+import { useShowStore } from '@/stores/show';
+import { useSystemStore } from '@/stores/system';
+import { useScriptStore } from '@/stores/script';
+import { useScriptConfigStore, computePageStatus } from '@/stores/scriptConfig';
+import { useUserStore } from '@/stores/user';
+import { useWebSocket } from '@/composables/useWebSocket';
+import { useWebSocketStore } from '@/stores/websocket';
+import { useConfirm } from '@/composables/useConfirm';
+import { toast } from '@/js/toast';
+import ScriptLineEditor from './ScriptLineEditor.vue';
+import ScriptLineViewer from './ScriptLineViewer.vue';
+import BulkActSceneModal from './BulkActSceneModal.vue';
+import type { ScriptLine } from '@/types/api/script';
+
+const MRU_LOOK_BACK = 4;
+
+const showStore = useShowStore();
+const systemStore = useSystemStore();
+const scriptStore = useScriptStore();
+const scriptConfigStore = useScriptConfigStore();
+const userStore = useUserStore();
+const { sendObj } = useWebSocket();
+const wsStore = useWebSocketStore();
+const { confirm } = useConfirm();
+
+const loaded = ref(false);
+const currentPage = ref(1);
+const navbarHeight = ref(56);
+const editingLines = ref(new Set<string>());
+const latestAddedLine = ref<string | null>(null);
+const linePartCuts = ref<number[]>([]);
+const savingInProgress = ref(false);
+const saveError = ref(false);
+const curSavePage = ref(0);
+const totalSavePages = ref<number | null>(null);
+const changingPage = ref(false);
+const isAutoSaving = ref(false);
+const autoSaveInterval = ref<ReturnType<typeof setInterval> | null>(null);
+const bulkEditMode = ref(false);
+const bulkEditStart = ref<{ page: number; lineIndex: number } | null>(null);
+const bulkEditEnd = ref<{ page: number; lineIndex: number } | null>(null);
+const previousLineOfStart = ref<ScriptLine | null>(null);
+const nextLineOfEnd = ref<ScriptLine | null>(null);
+const pageInputNo = ref(1);
+
+const saveModal = ref<InstanceType<typeof BModal>>();
+const goToPageModal = ref<InstanceType<typeof BModal>>();
+const bulkModal = ref<InstanceType<typeof BulkActSceneModal>>();
+
+const currentPageLines = computed(() => scriptConfigStore.getTmpPage(currentPage.value));
+const deletedLines = computed(() => scriptConfigStore.getDeletedLines(currentPage.value));
+
+const isEditor = computed(
+  () =>
+    wsStore.internalUUID !== null &&
+    wsStore.internalUUID === scriptConfigStore.editStatus.currentEditor
+);
+const canEdit = computed(() => isEditor.value && !scriptConfigStore.cutMode);
+
+const saveProgressVariant = computed(() => {
+  if (savingInProgress.value) return 'primary';
+  return saveError.value ? 'danger' : 'success';
+});
+
+const pagesWithOpenEdits = computed(() =>
+  [...editingLines.value].map((x) => parseInt(x.split('_')[1], 10))
+);
+
+const scriptChanges = computed<boolean>(() => {
+  if (scriptConfigStore.cutMode) {
+    return JSON.stringify(linePartCuts.value) !== JSON.stringify(scriptStore.cuts);
+  }
+  return Object.keys(scriptConfigStore.tmpScript).some((pageStr) => {
+    const actual = scriptStore.getScriptPage(pageStr);
+    const tmp = scriptConfigStore.getTmpPage(pageStr);
+    const deleted = scriptConfigStore.getDeletedLines(pageStr);
+    const inserted = scriptConfigStore.getInsertedLines(pageStr);
+    if (deleted.length > 0 || inserted.length > 0) return true;
+    if (actual.length !== tmp.length) return true;
+    return JSON.stringify(actual) !== JSON.stringify(tmp);
+  });
+});
+
+const canSave = computed(() => {
+  if (scriptConfigStore.cutMode) return scriptChanges.value;
+  return scriptChanges.value && editingLines.value.size === 0;
+});
+
+// Previous/next line helpers (synchronous — adjacent pages preloaded)
+function getPreviousLine(lineIndex: number): ScriptLine | null {
+  const deletedOnPage = scriptConfigStore.getDeletedLines(currentPage.value);
+  const pageLines = scriptConfigStore.getTmpPage(currentPage.value);
+  for (let i = lineIndex - 1; i >= 0; i--) {
+    if (!deletedOnPage.includes(i)) return pageLines[i];
+  }
+  if (currentPage.value > 1) {
+    const prevLines = scriptConfigStore.getTmpPage(currentPage.value - 1);
+    const deletedOnPrev = scriptConfigStore.getDeletedLines(currentPage.value - 1);
+    for (let i = prevLines.length - 1; i >= 0; i--) {
+      if (!deletedOnPrev.includes(i)) return prevLines[i];
+    }
+  }
+  return null;
+}
+
+function getNextLine(lineIndex: number): ScriptLine | null {
+  const deletedOnPage = scriptConfigStore.getDeletedLines(currentPage.value);
+  const pageLines = scriptConfigStore.getTmpPage(currentPage.value);
+  for (let i = lineIndex + 1; i < pageLines.length; i++) {
+    if (!deletedOnPage.includes(i)) return pageLines[i];
+  }
+  // Check next preloaded page
+  const nextPageLines = scriptConfigStore.getTmpPage(currentPage.value + 1);
+  const deletedOnNext = scriptConfigStore.getDeletedLines(currentPage.value + 1);
+  for (let i = 0; i < nextPageLines.length; i++) {
+    if (!deletedOnNext.includes(i)) return nextPageLines[i];
+  }
+  return null;
+}
+
+function requestEdit(): void {
+  sendObj({ OP: 'REQUEST_SCRIPT_EDIT', DATA: {} });
+}
+
+function requestCutEdit(): void {
+  scriptConfigStore.setCutMode(true);
+  sendObj({ OP: 'REQUEST_SCRIPT_EDIT', DATA: {} });
+}
+
+async function stopEditing(): Promise<void> {
+  if (scriptChanges.value) {
+    const ok = await confirm(
+      'Are you sure you want to stop editing the script? This will cause all unsaved changes to be lost.'
+    );
+    if (!ok) return;
+  }
+  editingLines.value.clear();
+  exitBulkEditMode();
+  scriptConfigStore.emptyScript();
+  linePartCuts.value = [...scriptStore.cuts];
+  sendObj({ OP: 'STOP_SCRIPT_EDIT', DATA: {} });
+  scriptConfigStore.setCutMode(false);
+}
+
+async function loadPage(page: number): Promise<void> {
+  if (!scriptConfigStore.tmpScript[String(page)]) {
+    await scriptStore.loadScriptPage(page);
+    scriptConfigStore.addPage(page, scriptStore.getScriptPage(page));
+  }
+}
+
+async function decrPage(): Promise<void> {
+  if (currentPage.value <= 1) return;
+  const targetPage = currentPage.value - 1;
+  await loadPage(targetPage);
+  if (currentPageLines.value.length === 0) {
+    scriptConfigStore.removePage(currentPage.value);
+  }
+  currentPage.value--;
+  // Preload page before
+  if (currentPage.value > 1) {
+    await loadPage(currentPage.value - 1);
+  }
+}
+
+async function incrPage(): Promise<void> {
+  currentPage.value++;
+  await loadPage(currentPage.value);
+  // Preload next page
+  await loadPage(currentPage.value + 1);
+}
+
+async function goToPageInner(page: number): Promise<void> {
+  const lookBackStart = Math.max(1, page - MRU_LOOK_BACK);
+  for (let p = lookBackStart; p < page; p++) {
+    await loadPage(p);
+  }
+  await loadPage(page);
+  currentPage.value = page;
+  await loadPage(page + 1);
+}
+
+async function goToPage(): Promise<void> {
+  if (!pageInputNo.value || pageInputNo.value < 1) return;
+  changingPage.value = true;
+  await goToPageInner(pageInputNo.value);
+  changingPage.value = false;
+  goToPageModal.value?.hide();
+}
+
+function blankLine(lineType: number): ScriptLine {
+  return {
+    id: null,
+    act_id: null,
+    scene_id: null,
+    page: currentPage.value,
+    line_type: lineType,
+    line_parts:
+      lineType === LINE_TYPES.DIALOGUE || lineType === LINE_TYPES.STAGE_DIRECTION ? [] : [],
+    stage_direction_style_id: null,
+  };
+}
+
+async function addNewLine(lineType: number): Promise<void> {
+  const line = blankLine(lineType);
+  scriptConfigStore.addBlankLine(currentPage.value, line);
+  const pageLines = scriptConfigStore.getTmpPage(currentPage.value);
+  const lineIndex = pageLines.length - 1;
+  const lineIdent = `page_${currentPage.value}_line_${lineIndex}`;
+  editingLines.value.add(lineIdent);
+  latestAddedLine.value = lineIdent;
+  const prev = getPreviousLine(lineIndex);
+  if (prev) {
+    scriptConfigStore.setLine(currentPage.value, lineIndex, {
+      ...pageLines[lineIndex],
+      act_id: prev.act_id,
+      scene_id: prev.scene_id,
+    });
+  }
+}
+
+async function insertLineAt(pageIndex: number, lineIndex: number, lineType: number): Promise<void> {
+  const pageLines = scriptConfigStore.getTmpPage(pageIndex);
+  if (pageLines.length - 1 === lineIndex) {
+    await addNewLine(lineType);
+    return;
+  }
+  const newLineIndex = lineIndex + 1;
+  const line = blankLine(lineType);
+  scriptConfigStore.insertBlankLine(pageIndex, newLineIndex, line);
+
+  // Shift all open edit indices that are >= newLineIndex up by 1
+  const shifted = new Set<string>();
+  editingLines.value.forEach((ident) => {
+    const parts = ident.split('_');
+    const ep = parseInt(parts[1], 10);
+    const ei = parseInt(parts[3], 10);
+    if (ep === pageIndex && ei >= newLineIndex) {
+      shifted.add(`page_${ep}_line_${ei + 1}`);
+    } else {
+      shifted.add(ident);
+    }
+  });
+  editingLines.value = shifted;
+
+  const newIdent = `page_${currentPage.value}_line_${newLineIndex}`;
+  editingLines.value.add(newIdent);
+
+  const prev = getPreviousLine(newLineIndex);
+  if (prev) {
+    const updatedLines = scriptConfigStore.getTmpPage(pageIndex);
+    scriptConfigStore.setLine(pageIndex, newLineIndex, {
+      ...updatedLines[newLineIndex],
+      act_id: prev.act_id,
+      scene_id: prev.scene_id,
+    });
+  }
+}
+
+function onLineChange(lineIndex: number, line: ScriptLine): void {
+  scriptConfigStore.setLine(currentPage.value, lineIndex, line);
+}
+
+function beginEditingLine(pageIndex: number, lineIndex: number): void {
+  editingLines.value.add(`page_${pageIndex}_line_${lineIndex}`);
+}
+
+function doneEditingLine(pageIndex: number, lineIndex: number): void {
+  const lineIdent = `page_${pageIndex}_line_${lineIndex}`;
+  editingLines.value.delete(lineIdent);
+  if (latestAddedLine.value === lineIdent) {
+    addNewLine(LINE_TYPES.DIALOGUE);
+  }
+}
+
+function deleteLine(pageIndex: number, lineIndex: number): void {
+  const lineIdent = `page_${pageIndex}_line_${lineIndex}`;
+  if (latestAddedLine.value === lineIdent) latestAddedLine.value = null;
+  scriptConfigStore.deleteLine(pageIndex, lineIndex);
+  doneEditingLine(pageIndex, lineIndex);
+
+  const shifted = new Set<string>();
+  editingLines.value.forEach((ident) => {
+    const parts = ident.split('_');
+    const ep = parseInt(parts[1], 10);
+    const ei = parseInt(parts[3], 10);
+    if (ep === pageIndex && ei >= lineIndex) {
+      shifted.add(`page_${ep}_line_${ei - 1}`);
+    } else {
+      shifted.add(ident);
+    }
+  });
+  editingLines.value = shifted;
+
+  if (latestAddedLine.value) {
+    const parts = latestAddedLine.value.split('_');
+    const ep = parseInt(parts[1], 10);
+    const ei = parseInt(parts[3], 10);
+    if (ep === pageIndex && ei >= lineIndex) {
+      latestAddedLine.value = `page_${pageIndex}_line_${ei - 1}`;
+    }
+  }
+}
+
+function cutLinePart(linePartId: number): void {
+  const idx = linePartCuts.value.indexOf(linePartId);
+  if (idx === -1) linePartCuts.value.push(linePartId);
+  else linePartCuts.value.splice(idx, 1);
+}
+
+async function saveScript(): Promise<void> {
+  if (scriptConfigStore.cutMode) {
+    savingInProgress.value = true;
+    await scriptStore.saveCuts(linePartCuts.value);
+    linePartCuts.value = [...scriptStore.cuts];
+    setupAutoSave();
+    savingInProgress.value = false;
+    return;
+  }
+
+  if (!scriptChanges.value) {
+    toast.warning('No changes to save!');
+    return;
+  }
+
+  savingInProgress.value = true;
+  saveError.value = false;
+  await scriptStore.getMaxPage();
+  const tmpPageKeys = Object.keys(scriptConfigStore.tmpScript).map((x) => parseInt(x, 10));
+  const maxPage = Math.max(scriptStore.maxPage, ...tmpPageKeys, 0);
+  totalSavePages.value = maxPage;
+  curSavePage.value = 0;
+  saveModal.value?.show();
+
+  for (let pageNo = 1; pageNo <= maxPage; pageNo++) {
+    curSavePage.value = pageNo;
+    const tmpPage = scriptConfigStore.getTmpPage(pageNo);
+    if (tmpPage.length === 0) continue;
+
+    const actualPage = scriptStore.getScriptPage(pageNo);
+    let ok: boolean;
+
+    if (actualPage.length === 0) {
+      ok = await scriptStore.saveNewPage(
+        pageNo,
+        tmpPage.filter((_, i) => !scriptConfigStore.getDeletedLines(pageNo).includes(i))
+      );
+    } else {
+      const status = computePageStatus(
+        actualPage,
+        tmpPage,
+        scriptConfigStore.getDeletedLines(pageNo),
+        scriptConfigStore.getInsertedLines(pageNo)
+      );
+      const hasChanges =
+        status.added.length > 0 ||
+        status.updated.length > 0 ||
+        status.deleted.length > 0 ||
+        status.inserted.length > 0;
+      if (!hasChanges) continue;
+
+      ok = await scriptStore.saveChangedPage(pageNo, { page: tmpPage, status });
+    }
+
+    if (ok) {
+      await scriptStore.loadScriptPage(pageNo);
+      scriptConfigStore.addPage(pageNo, scriptStore.getScriptPage(pageNo));
+      scriptConfigStore.resetTracking(pageNo);
+    } else {
+      toast.error('Unable to save script. Please try again.');
+      saveError.value = true;
+      break;
+    }
+  }
+
+  savingInProgress.value = false;
+  setupAutoSave();
+  await scriptStore.getMaxPage();
+}
+
+function setupAutoSave(): void {
+  const settings = userStore.userSettings as {
+    enable_script_auto_save?: boolean;
+    script_auto_save_interval?: number;
+  };
+  const intervalMs = Math.max((settings.script_auto_save_interval ?? 5) * 1000 * 60, 60000);
+
+  if (!isEditor.value && autoSaveInterval.value != null) {
+    clearInterval(autoSaveInterval.value);
+    autoSaveInterval.value = null;
+    return;
+  }
+
+  if (isEditor.value) {
+    if (autoSaveInterval.value != null) clearInterval(autoSaveInterval.value);
+    if (settings.enable_script_auto_save) {
+      autoSaveInterval.value = setInterval(autosave, intervalMs);
+    } else {
+      autoSaveInterval.value = null;
+    }
+  }
+}
+
+async function autosave(): Promise<void> {
+  if (isAutoSaving.value) return;
+  isAutoSaving.value = true;
+  toast.info('Performing autosave...');
+  try {
+    await saveScript();
+    toast.success('Autosave successful');
+  } catch {
+    toast.error('Autosave failed');
+  } finally {
+    isAutoSaving.value = false;
+  }
+}
+
+function calculateNavbarHeight(): void {
+  const navbar = document.querySelector('.navbar');
+  navbarHeight.value = navbar ? (navbar as HTMLElement).offsetHeight : 56;
+}
+
+function enterBulkEditMode(): void {
+  bulkEditMode.value = true;
+  bulkEditStart.value = null;
+  bulkEditEnd.value = null;
+}
+
+function exitBulkEditMode(): void {
+  bulkEditMode.value = false;
+  bulkEditStart.value = null;
+  bulkEditEnd.value = null;
+  previousLineOfStart.value = null;
+  nextLineOfEnd.value = null;
+}
+
+function onSetBulkStart(index: number): void {
+  bulkEditStart.value = { page: currentPage.value, lineIndex: index };
+  bulkEditEnd.value = null;
+}
+
+function onSetBulkEnd(index: number): void {
+  if (bulkEditStart.value) {
+    const { page: startPage, lineIndex: startIndex } = bulkEditStart.value;
+    if (startPage === currentPage.value && index <= startIndex) {
+      toast.error('End line must come after start line');
+      return;
+    }
+    if (currentPage.value < startPage) {
+      toast.error('End line must come after start line');
+      return;
+    }
+  }
+  bulkEditEnd.value = { page: currentPage.value, lineIndex: index };
+}
+
+function isBulkStart(index: number): boolean {
+  return (
+    bulkEditStart.value != null &&
+    bulkEditStart.value.page === currentPage.value &&
+    bulkEditStart.value.lineIndex === index
+  );
+}
+
+function isBulkEnd(index: number): boolean {
+  return (
+    bulkEditEnd.value != null &&
+    bulkEditEnd.value.page === currentPage.value &&
+    bulkEditEnd.value.lineIndex === index
+  );
+}
+
+async function loadBoundaryLines(): Promise<void> {
+  if (!bulkEditStart.value || !bulkEditEnd.value) return;
+  const { page: startPage, lineIndex: startIndex } = bulkEditStart.value;
+  const { page: endPage, lineIndex: endIndex } = bulkEditEnd.value;
+
+  if (startIndex === 0 && startPage > 1) await loadPage(startPage - 1);
+  const endPageLines = scriptConfigStore.getTmpPage(endPage);
+  if (endLines_isLast(endPageLines, endIndex)) await loadPage(endPage + 1);
+
+  const startPageLines = scriptConfigStore.getTmpPage(startPage);
+  previousLineOfStart.value =
+    startIndex > 0
+      ? (startPageLines[startIndex - 1] ?? null)
+      : startPage > 1
+        ? (scriptConfigStore.getTmpPage(startPage - 1).slice(-1)[0] ?? null)
+        : null;
+
+  nextLineOfEnd.value =
+    endIndex < endPageLines.length - 1
+      ? (endPageLines[endIndex + 1] ?? null)
+      : (scriptConfigStore.getTmpPage(endPage + 1)[0] ?? null);
+}
+
+function endLines_isLast(lines: ScriptLine[], index: number): boolean {
+  return index === lines.length - 1;
+}
+
+async function onBulkApply({ actId, sceneId }: { actId: number; sceneId: number }): Promise<void> {
+  if (!bulkEditStart.value || !bulkEditEnd.value) return;
+  const { page: startPage, lineIndex: startIndex } = bulkEditStart.value;
+  const { page: endPage, lineIndex: endIndex } = bulkEditEnd.value;
+
+  for (let p = startPage; p <= endPage; p++) {
+    await loadPage(p);
+    const pageLines = scriptConfigStore.getTmpPage(p);
+    const fromIdx = p === startPage ? startIndex : 0;
+    const toIdx = p === endPage ? endIndex : pageLines.length - 1;
+    const deletedOnPage = scriptConfigStore.getDeletedLines(p);
+    for (let i = fromIdx; i <= toIdx; i++) {
+      if (deletedOnPage.includes(i)) continue;
+      scriptConfigStore.setLine(p, i, { ...pageLines[i], act_id: actId, scene_id: sceneId });
+    }
+  }
+
+  bulkModal.value?.hide();
+  exitBulkEditMode();
+}
+
+watch(bulkEditEnd, async (val) => {
+  if (val != null) {
+    await loadBoundaryLines();
+    bulkModal.value?.show();
+  }
+});
+
+watch(isEditor, () => setupAutoSave());
+watch(
+  () => userStore.userSettings,
+  () => setupAutoSave()
+);
+
+watch(currentPage, (val) => {
+  localStorage.setItem('scriptEditPage', val.toString());
+});
+
+onMounted(async () => {
+  window.addEventListener('resize', calculateNavbarHeight);
+  calculateNavbarHeight();
+
+  await Promise.all([
+    showStore.getActList(),
+    showStore.getSceneList(),
+    showStore.getCharacterList(),
+    showStore.getCharacterGroupList(),
+    scriptStore.getStageDirectionStyles(),
+    scriptConfigStore.getScriptConfigStatus(),
+    scriptStore.getCuts(),
+  ]);
+
+  linePartCuts.value = [...scriptStore.cuts];
+
+  const storedPage = localStorage.getItem('scriptEditPage');
+  const startPage = storedPage != null ? parseInt(storedPage, 10) : 1;
+  await goToPageInner(startPage);
+
+  loaded.value = true;
+  setupAutoSave();
+});
+
+onUnmounted(() => {
+  window.removeEventListener('resize', calculateNavbarHeight);
+  if (autoSaveInterval.value != null) clearInterval(autoSaveInterval.value);
+});
+</script>
+
+<style scoped>
+.script-editor-container {
+  position: relative;
+}
+.sticky-header {
+  position: sticky;
+  z-index: 100;
+  padding: 10px 0;
+  border-bottom: 1px solid #dee2e6;
+  background: var(--body-background);
+}
+</style>

--- a/client-v3/src/components/show/config/script/ScriptLineEditor.vue
+++ b/client-v3/src/components/show/config/script/ScriptLineEditor.vue
@@ -122,7 +122,7 @@ const emit = defineEmits<{
 const showStore = useShowStore();
 const systemStore = useSystemStore();
 
-const state = ref<ScriptLine>(structuredClone(props.modelValue));
+const state = ref<ScriptLine>(JSON.parse(JSON.stringify(props.modelValue)));
 
 const scriptMode = computed(() => systemStore.currentShow?.script_mode ?? 0);
 

--- a/client-v3/src/components/show/config/script/ScriptLineEditor.vue
+++ b/client-v3/src/components/show/config/script/ScriptLineEditor.vue
@@ -1,0 +1,245 @@
+<template>
+  <BRow>
+    <BCol cols="2">
+      <BRow>
+        <BCol cols="6">
+          <BFormGroup label-size="sm" label=" ">
+            <BFormSelect
+              v-model="state.act_id"
+              :options="actOptions"
+              :state="actState"
+              @update:model-value="onStateChange"
+            />
+          </BFormGroup>
+        </BCol>
+        <BCol cols="6">
+          <BFormGroup label-size="sm" label=" ">
+            <BFormSelect
+              v-model="state.scene_id"
+              :options="sceneOptions"
+              :state="sceneState"
+              @update:model-value="onStateChange"
+            />
+          </BFormGroup>
+        </BCol>
+      </BRow>
+      <BRow>
+        <BCol style="align-content: center">
+          <BButtonGroup>
+            <BButton variant="success" :disabled="!lineValid" @click="$emit('doneEditing')">
+              Done
+            </BButton>
+            <BButton variant="danger" @click.stop.prevent="$emit('deleteLine')">Delete</BButton>
+          </BButtonGroup>
+        </BCol>
+      </BRow>
+    </BCol>
+
+    <template v-if="lineType === LINE_TYPES.DIALOGUE || lineType === LINE_TYPES.STAGE_DIRECTION">
+      <template v-if="state.line_parts.length > 0">
+        <ScriptLinePart
+          v-for="(part, index) in state.line_parts"
+          :key="`line_${lineIndex}_part_${index}`"
+          :model-value="state.line_parts[index]"
+          :focus-input="index === 0"
+          :characters="characters"
+          :character-groups="characterGroups"
+          :show-add-button="
+            index === state.line_parts.length - 1 &&
+            lineType === LINE_TYPES.DIALOGUE &&
+            scriptMode === 1
+          "
+          :enable-add-button="state.line_parts.length < 4 && lineType === LINE_TYPES.DIALOGUE"
+          :line-type="lineType"
+          :line-parts="state.line_parts"
+          :stage-direction-styles="
+            lineType === LINE_TYPES.STAGE_DIRECTION ? stageDirectionStyles : []
+          "
+          :stage-direction-style-id="state.stage_direction_style_id"
+          @update:model-value="onPartUpdate(index, $event)"
+          @add-line-part="addLinePart"
+          @try-finish-line="tryFinishLine"
+          @stage-direction-style-change="onStageDirectionStyleChange"
+        />
+      </template>
+      <BCol v-else cols="10" style="text-align: right">
+        <BButton v-b-tooltip.hover.top="'Add line part'" @click="addLinePart">+</BButton>
+      </BCol>
+    </template>
+    <template v-else>
+      <BCol>
+        <BAlert variant="secondary" :model-value="true">
+          <p class="text-muted small" style="margin: 0">
+            <template v-if="lineType === LINE_TYPES.CUE_LINE"
+              >Cue Lines have no editable content.</template
+            >
+            <template v-else-if="lineType === LINE_TYPES.SPACING"
+              >Spacing Lines have no editable content.</template
+            >
+            <template v-else>This line type is not recognized.</template>
+          </p>
+        </BAlert>
+      </BCol>
+    </template>
+  </BRow>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { useVuelidate } from '@vuelidate/core';
+import { required } from '@vuelidate/validators';
+import { LINE_TYPES } from '@/constants/lineTypes';
+import { useShowStore } from '@/stores/show';
+import { useSystemStore } from '@/stores/system';
+import ScriptLinePart from './ScriptLinePart.vue';
+import type {
+  ScriptLine,
+  ScriptLinePart as ScriptLinePartType,
+  StageDirectionStyle,
+} from '@/types/api/script';
+import type { Act, Scene, Character, CharacterGroup } from '@/types/api/show';
+
+const props = defineProps<{
+  lineIndex: number;
+  currentEditPage: number;
+  acts: Act[];
+  scenes: Scene[];
+  characters: Character[];
+  characterGroups: CharacterGroup[];
+  previousLine: ScriptLine | null;
+  nextLine: ScriptLine | null;
+  lineType: number;
+  stageDirectionStyles: StageDirectionStyle[];
+  modelValue: ScriptLine;
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [line: ScriptLine];
+  doneEditing: [];
+  deleteLine: [];
+}>();
+
+const showStore = useShowStore();
+const systemStore = useSystemStore();
+
+const state = ref<ScriptLine>(structuredClone(props.modelValue));
+
+const scriptMode = computed(() => systemStore.currentShow?.script_mode ?? 0);
+
+const blankLinePart = (): ScriptLinePartType => ({
+  id: null,
+  line_id: state.value.id,
+  part_index: state.value.line_parts.length,
+  character_id: null,
+  character_group_id: null,
+  line_text: '',
+});
+
+const validActs = computed<Act[]>(() => {
+  let startAct = props.acts.find((a) => a.previous_act == null) ?? null;
+  if (props.previousLine) {
+    startAct = props.acts.find((a) => a.id === props.previousLine!.act_id) ?? startAct;
+  }
+  const result: Act[] = [];
+  let cur = startAct;
+  while (cur) {
+    result.push(cur);
+    if (props.nextLine && props.nextLine.act_id === cur.id) break;
+    cur = cur.next_act != null ? (props.acts.find((a) => a.id === cur!.next_act) ?? null) : null;
+  }
+  return result;
+});
+
+const actOptions = computed(() => [
+  { value: null, text: 'N/A', disabled: true },
+  ...validActs.value.map((a) => ({ value: a.id, text: a.name })),
+]);
+
+const validScenes = computed<Scene[]>(() => {
+  if (state.value.act_id == null) return [];
+  const actScenes = props.scenes.filter((s) => s.act === state.value.act_id);
+  let startScene = actScenes.find((s) => s.previous_scene == null) ?? null;
+  if (props.previousLine && props.previousLine.act_id === state.value.act_id) {
+    startScene = actScenes.find((s) => s.id === props.previousLine!.scene_id) ?? startScene;
+  }
+  const result: Scene[] = [];
+  let cur = startScene;
+  while (cur) {
+    result.push(cur);
+    if (props.nextLine && props.nextLine.scene_id === cur.id) break;
+    cur = cur.next_scene != null ? (actScenes.find((s) => s.id === cur!.next_scene) ?? null) : null;
+  }
+  return result;
+});
+
+const sceneOptions = computed(() => [
+  { value: null, text: 'N/A', disabled: true },
+  ...validScenes.value.map((s) => ({ value: s.id, text: s.name })),
+]);
+
+const rules = computed(() => ({
+  act_id: { required },
+  scene_id: { required },
+}));
+
+const v$ = useVuelidate(rules, state);
+
+const actState = computed<boolean | null>(() => {
+  const f = v$.value.act_id;
+  return f.$dirty ? !f.$error : null;
+});
+const sceneState = computed<boolean | null>(() => {
+  const f = v$.value.scene_id;
+  return f.$dirty ? !f.$error : null;
+});
+
+const lineValid = computed(
+  () => !v$.value.$error && state.value.act_id != null && state.value.scene_id != null
+);
+
+function onStateChange(): void {
+  v$.value.$touch();
+  emit('update:modelValue', { ...state.value });
+}
+
+function onPartUpdate(index: number, part: ScriptLinePartType): void {
+  state.value.line_parts[index] = part;
+  onStateChange();
+}
+
+function addLinePart(): void {
+  const blank = blankLinePart();
+  blank.part_index = state.value.line_parts.length;
+  if (props.lineType === LINE_TYPES.DIALOGUE && props.previousLine) {
+    const newIdx = state.value.line_parts.length;
+    const prevPart = props.previousLine.line_parts[newIdx];
+    if (prevPart) {
+      if (prevPart.character_id != null) blank.character_id = prevPart.character_id;
+      else if (prevPart.character_group_id != null)
+        blank.character_group_id = prevPart.character_group_id;
+    }
+  }
+  state.value.line_parts.push(blank);
+  onStateChange();
+}
+
+function onStageDirectionStyleChange(styleId: number | null): void {
+  state.value.stage_direction_style_id = styleId;
+  onStateChange();
+}
+
+function tryFinishLine(): void {
+  v$.value.$touch();
+  if (lineValid.value) emit('doneEditing');
+}
+
+onMounted(() => {
+  v$.value.$touch();
+  if (
+    state.value.line_parts.length === 0 &&
+    (props.lineType === LINE_TYPES.DIALOGUE || props.lineType === LINE_TYPES.STAGE_DIRECTION)
+  ) {
+    addLinePart();
+  }
+});
+</script>

--- a/client-v3/src/components/show/config/script/ScriptLinePart.vue
+++ b/client-v3/src/components/show/config/script/ScriptLinePart.vue
@@ -1,0 +1,254 @@
+<template>
+  <BCol>
+    <BRow v-if="lineType === LINE_TYPES.DIALOGUE || lineType === LINE_TYPES.STAGE_DIRECTION">
+      <template v-if="userSettings.character_combined_dropdown">
+        <BCol>
+          <BFormGroup label-size="sm" label="Character / Character Group">
+            <BFormSelect
+              v-model="combinedValue"
+              :options="combinedOptions"
+              :state="combinedState"
+              @update:model-value="onStateChange"
+            />
+          </BFormGroup>
+        </BCol>
+      </template>
+      <template v-else>
+        <BCol v-show="state.character_group_id == null">
+          <BFormGroup label-size="sm" label="Character">
+            <BFormSelect
+              v-model="state.character_id"
+              :options="characterOptions"
+              :state="characterState"
+              @update:model-value="onStateChange"
+            />
+          </BFormGroup>
+        </BCol>
+        <BCol v-show="state.character_id == null">
+          <BFormGroup label-size="sm" label="Character Group">
+            <BFormSelect
+              v-model="state.character_group_id"
+              :options="characterGroupOptions"
+              :state="characterGroupState"
+              @update:model-value="onStateChange"
+            />
+          </BFormGroup>
+        </BCol>
+      </template>
+      <BCol
+        v-if="lineType === LINE_TYPES.STAGE_DIRECTION && stageDirectionStyles.length > 0"
+        cols="3"
+      >
+        <BFormGroup label-size="sm" label="Style">
+          <BFormSelect
+            :model-value="stageDirectionStyleId"
+            :options="stageDirectionStyleOptions"
+            @update:model-value="$emit('stage-direction-style-change', $event)"
+          />
+        </BFormGroup>
+      </BCol>
+    </BRow>
+    <BRow>
+      <BCol style="display: inline-flex">
+        <BFormInput
+          ref="partInputRef"
+          v-model="state.line_text"
+          :state="lineTextState"
+          @update:model-value="onStateChange"
+          @keydown.enter="handleEnterPress"
+        />
+        <BButton
+          v-if="showAddButton && lineType === LINE_TYPES.DIALOGUE"
+          v-b-tooltip.hover.top="'Add line part'"
+          :disabled="!enableAddButton"
+          style="margin-left: 0.5em; float: right"
+          @click="$emit('add-line-part')"
+        >
+          +
+        </BButton>
+      </BCol>
+    </BRow>
+  </BCol>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, nextTick } from 'vue';
+import { useVuelidate } from '@vuelidate/core';
+import { required } from '@vuelidate/validators';
+import { LINE_TYPES } from '@/constants/lineTypes';
+import { useShowStore } from '@/stores/show';
+import { useScriptConfigStore } from '@/stores/scriptConfig';
+import { useUserStore } from '@/stores/user';
+import {
+  buildMruCharacterOptions,
+  buildMruCharacterGroupOptions,
+  buildCombinedCharacterOptions,
+  type CombinedSelectOption,
+} from '@/js/mruSortUtils';
+import type { ScriptLinePart } from '@/types/api/script';
+import type { Character, CharacterGroup } from '@/types/api/show';
+import type { StageDirectionStyle } from '@/types/api/script';
+
+const props = defineProps<{
+  focusInput: boolean;
+  characters: Character[];
+  characterGroups: CharacterGroup[];
+  showAddButton: boolean;
+  enableAddButton: boolean;
+  lineType: number;
+  lineParts: ScriptLinePart[];
+  stageDirectionStyles?: StageDirectionStyle[];
+  stageDirectionStyleId?: number | null;
+  modelValue: ScriptLinePart;
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [part: ScriptLinePart];
+  'add-line-part': [];
+  'try-finish-line': [];
+  'stage-direction-style-change': [id: number | null];
+}>();
+
+const showStore = useShowStore();
+const scriptConfigStore = useScriptConfigStore();
+const userStore = useUserStore();
+
+const partInputRef = ref<HTMLInputElement | null>(null);
+
+const state = ref<ScriptLinePart>({ ...props.modelValue });
+
+const userSettings = computed(
+  () =>
+    userStore.userSettings as {
+      character_mru_sort?: boolean;
+      character_combined_dropdown?: boolean;
+    }
+);
+
+const tmpScript = computed(() => scriptConfigStore.tmpScript);
+
+const characterOptions = computed(() => {
+  if (userSettings.value.character_mru_sort) {
+    const sorted = buildMruCharacterOptions(props.characters, tmpScript.value);
+    if (sorted) return sorted;
+  }
+  return [
+    { value: null, text: 'N/A' },
+    ...props.characters.map((c) => ({ value: c.id, text: c.name })),
+  ];
+});
+
+const characterGroupOptions = computed(() => {
+  if (userSettings.value.character_mru_sort) {
+    const sorted = buildMruCharacterGroupOptions(props.characterGroups, tmpScript.value);
+    if (sorted) return sorted;
+  }
+  return [
+    { value: null, text: 'N/A' },
+    ...props.characterGroups.map((g) => ({ value: g.id, text: g.name })),
+  ];
+});
+
+const stageDirectionStyleOptions = computed<{ value: number | null; text: string }[]>(() => [
+  { value: null, text: 'N/A' },
+  ...(props.stageDirectionStyles ?? []).map((s) => ({ value: s.id, text: s.description })),
+]);
+
+const combinedOptions = computed<CombinedSelectOption[]>(() =>
+  buildCombinedCharacterOptions(
+    props.characters,
+    props.characterGroups,
+    tmpScript.value,
+    !!userSettings.value.character_mru_sort
+  )
+);
+
+const combinedValue = computed<string | null>({
+  get() {
+    if (state.value.character_id != null) return `c:${state.value.character_id}`;
+    if (state.value.character_group_id != null) return `g:${state.value.character_group_id}`;
+    return null;
+  },
+  set(val: string | null) {
+    if (val == null) {
+      state.value.character_id = null;
+      state.value.character_group_id = null;
+    } else if (val.startsWith('c:')) {
+      state.value.character_id = parseInt(val.slice(2), 10);
+      state.value.character_group_id = null;
+    } else if (val.startsWith('g:')) {
+      state.value.character_id = null;
+      state.value.character_group_id = parseInt(val.slice(2), 10);
+    }
+    v$.value.$touch();
+  },
+});
+
+const isCharacterRequired = computed(
+  () => props.lineType === LINE_TYPES.DIALOGUE && state.value.character_group_id == null
+);
+const isCharacterGroupRequired = computed(
+  () => props.lineType === LINE_TYPES.DIALOGUE && state.value.character_id == null
+);
+const isLineTextRequired = computed(
+  () => props.lineParts.length <= 1 || !props.lineParts.some((x) => x.line_text !== '')
+);
+
+const rules = computed(() => ({
+  character_id: isCharacterRequired.value ? { required } : {},
+  character_group_id: isCharacterGroupRequired.value ? { required } : {},
+  line_text: isLineTextRequired.value ? { required } : {},
+}));
+
+const v$ = useVuelidate(rules, state);
+
+const characterState = computed<boolean | null>(() => {
+  const f = v$.value.character_id;
+  return f.$dirty ? !f.$error : null;
+});
+
+const characterGroupState = computed<boolean | null>(() => {
+  const f = v$.value.character_group_id;
+  return f.$dirty ? !f.$error : null;
+});
+
+const lineTextState = computed<boolean | null>(() => {
+  const f = v$.value.line_text;
+  return f.$dirty ? !f.$error : null;
+});
+
+const combinedState = computed<boolean | null>(() => {
+  const cF = v$.value.character_id;
+  const gF = v$.value.character_group_id;
+  if (!cF.$dirty && !gF.$dirty) return null;
+  return !(cF.$error && gF.$error);
+});
+
+function onStateChange(): void {
+  v$.value.$touch();
+  emit('update:modelValue', { ...state.value });
+  nextTick(() => partInputRef.value?.focus());
+}
+
+function handleEnterPress(): void {
+  v$.value.$touch();
+  emit('try-finish-line');
+}
+
+onMounted(() => {
+  v$.value.$touch();
+  if (props.focusInput) {
+    requestAnimationFrame(() => {
+      nextTick(() => partInputRef.value?.focus());
+    });
+  }
+});
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    state.value = { ...val };
+  },
+  { deep: true }
+);
+</script>

--- a/client-v3/src/components/show/config/script/ScriptLineViewer.vue
+++ b/client-v3/src/components/show/config/script/ScriptLineViewer.vue
@@ -1,0 +1,308 @@
+<template>
+  <BRow
+    :class="{
+      'stage-direction': line.line_type === LINE_TYPES.STAGE_DIRECTION,
+      'heading-padding': line.line_type === LINE_TYPES.DIALOGUE && needsHeadingsAll,
+    }"
+  >
+    <BCol cols="1">
+      <p v-if="showActSceneLabel" class="viewable-line">{{ actLabel }}</p>
+    </BCol>
+    <BCol cols="1">
+      <p v-if="showActSceneLabel" class="viewable-line">{{ sceneLabel }}</p>
+    </BCol>
+
+    <!-- Dialogue -->
+    <template v-if="line.line_type === LINE_TYPES.DIALOGUE">
+      <BCol>
+        <BRow v-if="needsHeadingsAny">
+          <BCol
+            v-for="(part, index) in line.line_parts"
+            :key="`heading_${lineIndex}_part_${index}`"
+            :style="headingStyle"
+          >
+            <template v-if="needsHeadings[index]">
+              <b>
+                <template v-if="part.character_id != null">
+                  {{ characters.find((c) => c.id === part.character_id)?.name }}
+                </template>
+                <template v-else>
+                  {{ characterGroups.find((g) => g.id === part.character_group_id)?.name }}
+                </template>
+              </b>
+            </template>
+            <b v-else>&nbsp;</b>
+          </BCol>
+        </BRow>
+        <BRow>
+          <BCol
+            v-for="(part, index) in line.line_parts"
+            :key="`line_${lineIndex}_part_${index}`"
+            :style="dialogueStyle"
+          >
+            <p
+              v-if="!canEdit || !isCutMode"
+              class="viewable-line"
+              :class="{ 'cut-line-part': linePartCuts.indexOf(part.id) !== -1 }"
+            >
+              {{ part.line_text }}
+            </p>
+            <a
+              v-else
+              class="viewable-line-cut"
+              :class="{ 'cut-line-part': linePartCuts.indexOf(part.id) !== -1 }"
+              @click.stop="cutLinePart(index)"
+            >
+              {{ part.line_text }}
+            </a>
+          </BCol>
+        </BRow>
+      </BCol>
+    </template>
+
+    <!-- Stage direction -->
+    <template v-else-if="line.line_type === LINE_TYPES.STAGE_DIRECTION">
+      <BCol :style="{ textAlign: textAlign }">
+        <BRow v-if="isTaggedStageDirection && needsHeadingsAny" style="margin-bottom: 1rem">
+          <BCol :style="headingStyle">
+            <b>{{ taggedStageDirectionHeadingName }}</b>
+          </BCol>
+        </BRow>
+        <i
+          v-if="!canEdit || !isCutMode"
+          class="viewable-line"
+          :style="stageDirectionStylingWithCuts"
+        >
+          {{ formatStageDirectionText(line.line_parts[0]?.line_text) }}
+        </i>
+        <a
+          v-else
+          class="viewable-line-cut"
+          :style="stageDirectionStylingWithCuts"
+          @click.stop="cutLinePart(0)"
+        >
+          {{ formatStageDirectionText(line.line_parts[0]?.line_text) }}
+        </a>
+      </BCol>
+    </template>
+
+    <!-- Cue line -->
+    <template v-else-if="line.line_type === LINE_TYPES.CUE_LINE">
+      <BCol style="text-align: center">
+        <BAlert variant="secondary" :model-value="true">
+          <p class="text-muted small" style="margin: 0">Cue Line</p>
+        </BAlert>
+      </BCol>
+    </template>
+
+    <!-- Spacing -->
+    <template v-else-if="line.line_type === LINE_TYPES.SPACING">
+      <BCol style="text-align: center">
+        <BAlert variant="secondary" :model-value="true">
+          <p class="text-muted small" style="margin: 0">Spacing Line</p>
+        </BAlert>
+      </BCol>
+    </template>
+
+    <BCol cols="1" align-self="end">
+      <BButtonGroup v-if="bulkEditMode && canEdit && !isCutMode">
+        <BButton
+          size="sm"
+          :variant="isBulkStart ? 'success' : 'outline-secondary'"
+          @click.stop="$emit('set-bulk-start')"
+        >
+          Start
+        </BButton>
+        <BButton
+          size="sm"
+          :variant="isBulkEnd ? 'success' : 'outline-secondary'"
+          @click.stop="$emit('set-bulk-end')"
+        >
+          End
+        </BButton>
+      </BButtonGroup>
+      <BDropdown
+        v-else-if="canEdit && !isCutMode"
+        split
+        text="Edit"
+        end
+        boundary="window"
+        style="padding: 0"
+        variant="link"
+        @click.prevent.stop="$emit('editLine')"
+      >
+        <BDropdownItem @click.prevent.stop="$emit('insertDialogue')">Insert Dialogue</BDropdownItem>
+        <BDropdownItem @click.prevent.stop="$emit('insertStageDirection')"
+          >Insert Stage Direction</BDropdownItem
+        >
+        <BDropdownItem @click.prevent.stop="$emit('insertCueLine')">Insert Cue Line</BDropdownItem>
+        <BDropdownItem @click.prevent.stop="$emit('insertSpacing')">Insert Spacing</BDropdownItem>
+        <BDropdownItem variant="danger" @click.prevent.stop="$emit('deleteLine')"
+          >Delete</BDropdownItem
+        >
+      </BDropdown>
+    </BCol>
+  </BRow>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { LINE_TYPES } from '@/constants/lineTypes';
+import { useScriptConfigStore } from '@/stores/scriptConfig';
+import { useUserStore } from '@/stores/user';
+import { useScriptDisplay } from '@/composables/useScriptDisplay';
+import { toast } from '@/js/toast';
+import type { ScriptLine, StageDirectionStyle } from '@/types/api/script';
+import type { Act, Scene, Character, CharacterGroup } from '@/types/api/show';
+
+const props = defineProps<{
+  line: ScriptLine;
+  lineIndex: number;
+  page: ScriptLine[];
+  previousLine: ScriptLine | null;
+  acts: Act[];
+  scenes: Scene[];
+  characters: Character[];
+  characterGroups: CharacterGroup[];
+  canEdit: boolean;
+  linePartCuts: (number | null)[];
+  stageDirectionStyles: StageDirectionStyle[];
+  stageDirectionStyleOverrides: StageDirectionStyle[];
+  bulkEditMode?: boolean;
+  isBulkStart?: boolean;
+  isBulkEnd?: boolean;
+}>();
+
+const emit = defineEmits<{
+  editLine: [];
+  cutLinePart: [partId: number];
+  insertDialogue: [];
+  insertStageDirection: [];
+  insertCueLine: [];
+  insertSpacing: [];
+  deleteLine: [];
+  'set-bulk-start': [];
+  'set-bulk-end': [];
+}>();
+
+const scriptConfigStore = useScriptConfigStore();
+const userStore = useUserStore();
+const { getStageDirectionStyle, stageDirectionStyling, scriptTextAlign } = useScriptDisplay();
+
+const isCutMode = computed(() => scriptConfigStore.cutMode);
+const textAlign = computed(() =>
+  scriptTextAlign(userStore.userSettings as Record<string, unknown>)
+);
+const headingStyle = computed(() => ({ textAlign: textAlign.value }));
+const dialogueStyle = computed(() => ({ textAlign: textAlign.value }));
+
+const showActSceneLabel = computed<boolean>(() => {
+  if (!props.previousLine) return true;
+  return !(
+    props.previousLine.act_id === props.line.act_id &&
+    props.previousLine.scene_id === props.line.scene_id
+  );
+});
+
+const actLabel = computed<string | null>(
+  () => props.acts.find((a) => a.id === props.line.act_id)?.name ?? null
+);
+const sceneLabel = computed<string | null>(
+  () => props.scenes.find((s) => s.id === props.line.scene_id)?.name ?? null
+);
+
+const needsHeadings = computed<boolean[]>(() => {
+  let prev = props.previousLine;
+  let prevIdx = props.lineIndex - 1;
+  while (
+    prev != null &&
+    prev.line_type === LINE_TYPES.STAGE_DIRECTION &&
+    prev.line_parts[0]?.character_id == null &&
+    prev.line_parts[0]?.character_group_id == null
+  ) {
+    if (prevIdx === 0) break;
+    prevIdx -= 1;
+    prev = props.page[prevIdx] ?? null;
+  }
+
+  return props.line.line_parts.map((part) => {
+    if (!prev || prev.line_parts.length !== props.line.line_parts.length) return true;
+    const match = prev.line_parts.find((p) => p.part_index === part.part_index);
+    if (!match) return true;
+    return !(
+      match.character_id === part.character_id &&
+      match.character_group_id === part.character_group_id
+    );
+  });
+});
+
+const needsHeadingsAny = computed(() => needsHeadings.value.some((x) => x));
+const needsHeadingsAll = computed(() => needsHeadings.value.every((x) => x));
+
+const isTaggedStageDirection = computed<boolean>(() => {
+  const part = props.line.line_parts?.[0];
+  return (
+    props.line.line_type === LINE_TYPES.STAGE_DIRECTION &&
+    (part?.character_id != null || part?.character_group_id != null)
+  );
+});
+
+const taggedStageDirectionHeadingName = computed<string>(() => {
+  const part = props.line.line_parts?.[0];
+  if (!part) return '';
+  if (part.character_id != null)
+    return props.characters.find((c) => c.id === part.character_id)?.name ?? '';
+  return props.characterGroups.find((g) => g.id === part.character_group_id)?.name ?? '';
+});
+
+const currentStyle = computed(() =>
+  getStageDirectionStyle(props.line, props.stageDirectionStyles, props.stageDirectionStyleOverrides)
+);
+
+const stageDirectionStylingWithCuts = computed<Record<string, string>>(() => {
+  const base = stageDirectionStyling(currentStyle.value);
+  const firstPartId = props.line.line_parts[0]?.id;
+  if (firstPartId != null && props.linePartCuts.indexOf(firstPartId) !== -1) {
+    const existing = base['text-decoration-line'];
+    base['text-decoration-line'] =
+      existing && existing !== 'none' ? `${existing} line-through` : 'line-through';
+  }
+  return base;
+});
+
+function formatStageDirectionText(text: string | null | undefined): string {
+  if (text == null) return '';
+  if (currentStyle.value?.text_format === 'upper') return text.toUpperCase();
+  if (currentStyle.value?.text_format === 'lower') return text.toLowerCase();
+  return text;
+}
+
+function cutLinePart(partIndex: number): void {
+  const part = props.line.line_parts[partIndex];
+  if (part?.id != null && part.line_id != null) {
+    emit('cutLinePart', part.id);
+    return;
+  }
+  toast.error('Unable to cut line part');
+}
+</script>
+
+<style scoped>
+.viewable-line {
+  margin: 0;
+}
+.viewable-line-cut {
+  margin: 0;
+  cursor: pointer;
+}
+.stage-direction {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+.heading-padding {
+  margin-top: 0.5rem;
+}
+.cut-line-part {
+  text-decoration: line-through;
+}
+</style>

--- a/client-v3/src/components/show/config/script/ScriptRevisions.vue
+++ b/client-v3/src/components/show/config/script/ScriptRevisions.vue
@@ -1,0 +1,363 @@
+<template>
+  <div>
+    <BCard class="mb-3" :class="{ 'collapsed-card': !graphCollapsed }" header-tag="header">
+      <template #header>
+        <div class="d-flex justify-content-between align-items-center">
+          <h6 class="mb-0">Revision Branch Graph</h6>
+          <BButton size="sm" variant="secondary" @click="graphCollapsed = !graphCollapsed">
+            {{ graphCollapsed ? '▼' : '▲' }}
+          </BButton>
+        </div>
+      </template>
+      <BCollapse v-model="graphCollapsed">
+        <RevisionGraph
+          :revisions="showStore.scriptRevisions"
+          :current-revision-id="showStore.currentRevision"
+          :selected-revision-id="selectedRevisionId"
+          @node-click="handleNodeClick"
+        />
+      </BCollapse>
+    </BCard>
+
+    <BTable :items="showStore.scriptRevisions" :fields="revisionColumns" show-empty>
+      <template #cell(current)="data">
+        <span v-if="data.item.id === showStore.currentRevision" class="text-success">✓</span>
+        <BButton
+          v-else-if="systemStore.isScriptEditor"
+          size="sm"
+          variant="warning"
+          :disabled="
+            !canChangeRevisions ||
+            submittingLoadRevision ||
+            submittingNewRevision ||
+            deletingRevision
+          "
+          @click="loadRevision(data.item)"
+        >
+          Load
+        </BButton>
+      </template>
+      <template #cell(previous_revision_id)="data">
+        <span v-if="data.item.previous_revision_id != null">
+          {{
+            showStore.scriptRevisions.find((r) => r.id === data.item.previous_revision_id)
+              ?.revision ?? 'N/A'
+          }}
+        </span>
+        <span v-else>N/A</span>
+      </template>
+      <template #cell(btn)="data">
+        <BButtonGroup v-if="systemStore.isScriptEditor && data.item.revision !== 1">
+          <BButton
+            variant="danger"
+            size="sm"
+            :disabled="
+              !canChangeRevisions ||
+              submittingLoadRevision ||
+              submittingNewRevision ||
+              deletingRevision
+            "
+            @click="deleteRevision(data.item)"
+          >
+            Delete
+          </BButton>
+        </BButtonGroup>
+      </template>
+      <template #custom-foot>
+        <BTr>
+          <BTd>
+            <BButton
+              v-if="systemStore.isScriptEditor"
+              variant="outline-success"
+              :disabled="
+                !canChangeRevisions ||
+                submittingLoadRevision ||
+                submittingNewRevision ||
+                deletingRevision
+              "
+              @click="newRevisionModal?.show()"
+            >
+              New Revision
+            </BButton>
+          </BTd>
+          <BTd /><BTd /><BTd /><BTd /><BTd /><BTd />
+        </BTr>
+      </template>
+    </BTable>
+
+    <BModal
+      ref="newRevisionModal"
+      title="Add New Revision"
+      :ok-disabled="vNew$.description.$invalid || submittingNewRevision"
+      @show="resetNewRevForm"
+      @hidden="resetNewRevForm"
+      @ok.prevent="onSubmitNewRev"
+    >
+      <BAlert variant="info" :model-value="true">
+        This will create a new revision of the script based on the current revision, and set it as
+        the new current revision.
+      </BAlert>
+      <BForm @submit.stop.prevent="onSubmitNewRev">
+        <BFormGroup label="Description" label-for="new-rev-description">
+          <BFormInput
+            id="new-rev-description"
+            v-model="newRevForm.description"
+            :state="validationState(vNew$.description)"
+          />
+          <BFormInvalidFeedback>{{ vNew$.description.$errors[0]?.$message }}</BFormInvalidFeedback>
+        </BFormGroup>
+      </BForm>
+    </BModal>
+
+    <RevisionDetailModal
+      ref="revisionDetailModal"
+      :revision="selectedRevision"
+      :revisions="showStore.scriptRevisions"
+      :current-revision-id="showStore.currentRevision"
+      :can-edit="systemStore.isScriptEditor && canChangeRevisions"
+      :submitting="modalSubmitting"
+      @load-revision="handleModalLoadRevision"
+      @create-from="handleModalCreateFrom"
+      @close="revisionDetailModal?.hide()"
+      @hidden="handleModalHidden"
+    />
+
+    <BModal
+      ref="branchModal"
+      title="Create Revision Branch"
+      :ok-disabled="vBranch$.description.$invalid || submittingBranch"
+      @show="setupBranchForm"
+      @hidden="resetBranchForm"
+      @ok.prevent="onSubmitBranch"
+    >
+      <BAlert :variant="branchForm.isCurrentRevision ? 'info' : 'warning'" :model-value="true">
+        <span v-if="branchForm.isCurrentRevision">
+          This will create a new revision based on revision {{ branchForm.sourceRevision }}
+          (current revision) and set it as the new current revision.
+        </span>
+        <span v-else>
+          This will create a new branch from revision {{ branchForm.sourceRevision }}. The new
+          revision will NOT be set as current.
+        </span>
+      </BAlert>
+      <BForm @submit.stop.prevent="onSubmitBranch">
+        <BFormGroup label="Description" label-for="branch-description">
+          <BFormInput
+            id="branch-description"
+            v-model="branchForm.description"
+            :state="validationState(vBranch$.description)"
+          />
+          <BFormInvalidFeedback>{{
+            vBranch$.description.$errors[0]?.$message
+          }}</BFormInvalidFeedback>
+        </BFormGroup>
+      </BForm>
+    </BModal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue';
+import type { BModal } from 'bootstrap-vue-next';
+import { useVuelidate } from '@vuelidate/core';
+import { required } from '@vuelidate/validators';
+import log from 'loglevel';
+import { useShowStore } from '@/stores/show';
+import { useSystemStore } from '@/stores/system';
+import { useWebSocketStore } from '@/stores/websocket';
+import { useScriptConfigStore } from '@/stores/scriptConfig';
+import { useConfirm } from '@/composables/useConfirm';
+import { useFormValidation } from '@/composables/useFormValidation';
+import type { ScriptRevision } from '@/types/api/script';
+import RevisionGraph from './RevisionGraph.vue';
+import RevisionDetailModal from './RevisionDetailModal.vue';
+
+const showStore = useShowStore();
+const systemStore = useSystemStore();
+const wsStore = useWebSocketStore();
+const scriptConfigStore = useScriptConfigStore();
+const { confirm } = useConfirm();
+const { validationState } = useFormValidation();
+
+const revisionColumns = [
+  { key: 'current', label: 'Current' },
+  { key: 'revision', label: 'Revision' },
+  { key: 'created_at', label: 'Created At' },
+  { key: 'edited_at', label: 'Edited At' },
+  { key: 'description', label: 'Description' },
+  { key: 'previous_revision_id', label: 'Previous Revision' },
+  { key: 'btn', label: '' },
+];
+
+const graphCollapsed = ref<boolean>(localStorage.getItem('revisionGraphCollapsed') === 'true');
+watch(graphCollapsed, (val) => {
+  localStorage.setItem('revisionGraphCollapsed', String(val));
+});
+
+const selectedRevisionId = ref<number | null>(null);
+const selectedRevision = ref<ScriptRevision | null>(null);
+const modalSubmitting = ref<boolean | string>(false);
+
+const submittingNewRevision = ref(false);
+const submittingBranch = ref(false);
+const submittingLoadRevision = ref(false);
+const deletingRevision = ref(false);
+
+const newRevisionModal = ref<InstanceType<typeof BModal>>();
+const revisionDetailModal = ref<InstanceType<typeof RevisionDetailModal>>();
+const branchModal = ref<InstanceType<typeof BModal>>();
+
+const newRevForm = ref({ description: '' });
+const branchForm = ref({
+  description: '',
+  sourceRevisionId: null as number | null,
+  sourceRevision: null as number | null,
+  isCurrentRevision: false,
+});
+
+const vNew$ = useVuelidate({ description: { required } }, newRevForm);
+const vBranch$ = useVuelidate({ description: { required } }, branchForm);
+
+const canChangeRevisions = computed(
+  () =>
+    !wsStore.internalUUID ||
+    scriptConfigStore.editStatus.currentEditor == null ||
+    scriptConfigStore.editStatus.currentEditor === wsStore.internalUUID
+);
+
+function resetNewRevForm(): void {
+  newRevForm.value = { description: '' };
+  submittingNewRevision.value = false;
+  vNew$.value.$reset();
+}
+
+async function onSubmitNewRev(): Promise<void> {
+  const valid = await vNew$.value.$validate();
+  if (!valid || submittingNewRevision.value) return;
+  submittingNewRevision.value = true;
+  try {
+    await showStore.addScriptRevision({ description: newRevForm.value.description });
+    newRevisionModal.value?.hide();
+  } catch (e) {
+    log.error('Error submitting new revision:', e);
+  } finally {
+    submittingNewRevision.value = false;
+  }
+}
+
+async function loadRevision(item: ScriptRevision): Promise<void> {
+  if (submittingLoadRevision.value) return;
+  const ok = await confirm(`Are you sure you want to load revision ${item.revision}?`);
+  if (!ok) return;
+  submittingLoadRevision.value = true;
+  try {
+    await showStore.loadScriptRevision(item.id);
+  } catch (e) {
+    log.error('Error loading revision:', e);
+  } finally {
+    submittingLoadRevision.value = false;
+  }
+}
+
+async function deleteRevision(item: ScriptRevision): Promise<void> {
+  if (deletingRevision.value) return;
+  let msg = `Are you sure you want to delete revision ${item.revision}?`;
+  if (showStore.currentRevision === item.id) {
+    msg += ' This will load the previous revision, or first revision if this is not available.';
+  }
+  const ok = await confirm(msg, {
+    title: 'Delete Revision',
+    okVariant: 'danger',
+    okTitle: 'Delete',
+  });
+  if (!ok) return;
+  deletingRevision.value = true;
+  try {
+    await showStore.deleteScriptRevision(item.id);
+  } catch (e) {
+    log.error('Error deleting revision:', e);
+  } finally {
+    deletingRevision.value = false;
+  }
+}
+
+function handleNodeClick(revision: ScriptRevision): void {
+  selectedRevisionId.value = revision.id;
+  selectedRevision.value = revision;
+  revisionDetailModal.value?.show();
+}
+
+async function handleModalLoadRevision(revision: ScriptRevision): Promise<void> {
+  const ok = await confirm(`Are you sure you want to load revision ${revision.revision}?`);
+  if (!ok) return;
+  modalSubmitting.value = 'load';
+  try {
+    await showStore.loadScriptRevision(revision.id);
+    revisionDetailModal.value?.hide();
+  } catch (e) {
+    log.error('Error loading revision from modal:', e);
+  } finally {
+    modalSubmitting.value = false;
+  }
+}
+
+function handleModalCreateFrom(revision: ScriptRevision): void {
+  branchForm.value.sourceRevisionId = revision.id;
+  branchForm.value.sourceRevision = revision.revision;
+  branchForm.value.isCurrentRevision = revision.id === showStore.currentRevision;
+  branchModal.value?.show();
+}
+
+function setupBranchForm(): void {
+  branchForm.value.description = '';
+  submittingBranch.value = false;
+  vBranch$.value.$reset();
+}
+
+function resetBranchForm(): void {
+  branchForm.value = {
+    description: '',
+    sourceRevisionId: null,
+    sourceRevision: null,
+    isCurrentRevision: false,
+  };
+  submittingBranch.value = false;
+  vBranch$.value.$reset();
+}
+
+async function onSubmitBranch(): Promise<void> {
+  const valid = await vBranch$.value.$validate();
+  if (!valid || submittingBranch.value) return;
+  submittingBranch.value = true;
+  try {
+    await showStore.addScriptRevision({
+      description: branchForm.value.description,
+      parent_revision_id: branchForm.value.sourceRevisionId,
+      set_as_current: branchForm.value.isCurrentRevision,
+    });
+    branchModal.value?.hide();
+    revisionDetailModal.value?.hide();
+    resetBranchForm();
+  } catch (e) {
+    log.error('Error creating branch:', e);
+  } finally {
+    submittingBranch.value = false;
+  }
+}
+
+function handleModalHidden(): void {
+  selectedRevisionId.value = null;
+  selectedRevision.value = null;
+  modalSubmitting.value = false;
+}
+
+onMounted(async () => {
+  await scriptConfigStore.getScriptConfigStatus();
+});
+</script>
+
+<style scoped>
+.collapsed-card :deep(.card-body) {
+  padding: 0;
+}
+</style>

--- a/client-v3/src/components/show/config/script/StageDirectionStyles.vue
+++ b/client-v3/src/components/show/config/script/StageDirectionStyles.vue
@@ -385,7 +385,7 @@ async function importStyle(item: any): Promise<void> {
   }
 }
 
-// Inline style form sub-component
+// Inline style form sub-component using native Bootstrap HTML to avoid component import complexity
 const StyleForm = defineComponent({
   props: { modelValue: { type: Object, required: true } },
   emits: ['update:modelValue'],
@@ -395,23 +395,114 @@ const StyleForm = defineComponent({
     }
     return () => {
       const form = props.modelValue as StyleForm;
+      const previewStyle = formExampleCss(form);
+      const previewText = formatExampleText({
+        text_format: form.textFormat,
+        bold: form.bold,
+        italic: form.italic,
+        underline: form.underline,
+        text_colour: form.textColour,
+        enable_background_colour: form.enableBackgroundColour,
+        background_colour: form.backgroundColour,
+      });
       return h('div', [
         h('div', { class: 'mb-3' }, [
           h('h4', 'Example Stage Direction'),
+          h('i', { class: 'example-stage-direction', style: previewStyle }, previewText),
+        ]),
+        h('div', { class: 'mb-3' }, [
+          h('label', { class: 'form-label' }, 'Description'),
+          h('input', {
+            class: 'form-control',
+            type: 'text',
+            value: form.description,
+            onInput: (e: Event) => update('description', (e.target as HTMLInputElement).value),
+          }),
+        ]),
+        h('div', { class: 'mb-3' }, [
+          h('label', { class: 'form-label d-block' }, 'Default Styles'),
+          h('div', { class: 'btn-group' }, [
+            h(
+              'button',
+              {
+                class: ['btn', form.bold ? 'btn-primary' : 'btn-outline-primary'],
+                type: 'button',
+                onClick: () => update('bold', !form.bold),
+              },
+              'Bold'
+            ),
+            h(
+              'button',
+              {
+                class: ['btn', form.italic ? 'btn-primary' : 'btn-outline-primary'],
+                type: 'button',
+                onClick: () => update('italic', !form.italic),
+              },
+              'Italic'
+            ),
+            h(
+              'button',
+              {
+                class: ['btn', form.underline ? 'btn-primary' : 'btn-outline-primary'],
+                type: 'button',
+                onClick: () => update('underline', !form.underline),
+              },
+              'Underline'
+            ),
+          ]),
+        ]),
+        h('div', { class: 'mb-3' }, [
+          h('label', { class: 'form-label' }, 'Default Text Format'),
           h(
-            'i',
-            { class: 'example-stage-direction', style: formExampleCss(form) },
-            formatExampleText({
-              text_format: form.textFormat,
-              bold: form.bold,
-              italic: form.italic,
-              underline: form.underline,
-              text_colour: form.textColour,
-              enable_background_colour: form.enableBackgroundColour,
-              background_colour: form.backgroundColour,
-            })
+            'select',
+            {
+              class: 'form-select',
+              value: form.textFormat,
+              onChange: (e: Event) => update('textFormat', (e.target as HTMLSelectElement).value),
+            },
+            [
+              h('option', { value: 'default' }, 'Default'),
+              h('option', { value: 'upper' }, 'Uppercase'),
+              h('option', { value: 'lower' }, 'Lowercase'),
+            ]
           ),
         ]),
+        h('div', { class: 'mb-3' }, [
+          h('label', { class: 'form-label' }, 'Text Colour'),
+          h('input', {
+            class: 'form-control form-control-color',
+            type: 'color',
+            value: form.textColour,
+            onInput: (e: Event) => update('textColour', (e.target as HTMLInputElement).value),
+          }),
+        ]),
+        h('div', { class: 'mb-3 form-check form-switch' }, [
+          h('input', {
+            class: 'form-check-input',
+            type: 'checkbox',
+            id: 'style-bg-enable',
+            checked: form.enableBackgroundColour,
+            onChange: (e: Event) =>
+              update('enableBackgroundColour', (e.target as HTMLInputElement).checked),
+          }),
+          h(
+            'label',
+            { class: 'form-check-label', for: 'style-bg-enable' },
+            'Enable Background Colour'
+          ),
+        ]),
+        form.enableBackgroundColour
+          ? h('div', { class: 'mb-3' }, [
+              h('label', { class: 'form-label' }, 'Background Colour'),
+              h('input', {
+                class: 'form-control form-control-color',
+                type: 'color',
+                value: form.backgroundColour,
+                onInput: (e: Event) =>
+                  update('backgroundColour', (e.target as HTMLInputElement).value),
+              }),
+            ])
+          : null,
       ]);
     };
   },

--- a/client-v3/src/components/show/config/script/StageDirectionStyles.vue
+++ b/client-v3/src/components/show/config/script/StageDirectionStyles.vue
@@ -1,0 +1,430 @@
+<template>
+  <BContainer class="mx-0" fluid>
+    <BRow>
+      <BCol>
+        <BTable
+          :items="scriptStore.stageDirectionStyles"
+          :fields="columns"
+          :per-page="rowsPerPage"
+          :current-page="currentPage"
+          show-empty
+        >
+          <template #head(btn)>
+            <div class="d-flex gap-2">
+              <BButton
+                v-if="systemStore.isScriptEditor"
+                variant="outline-success"
+                @click="newModal?.show()"
+              >
+                New Style
+              </BButton>
+              <BButton
+                v-if="systemStore.isScriptEditor"
+                variant="outline-info"
+                @click="openImportModal"
+              >
+                Import Style
+              </BButton>
+            </div>
+          </template>
+          <template #cell(example)="data">
+            <i class="example-stage-direction" :style="exampleCss(data.item)">
+              {{ formatExampleText(data.item) }}
+            </i>
+          </template>
+          <template #cell(btn)="data">
+            <BButtonGroup v-if="systemStore.isScriptEditor">
+              <BButton
+                variant="warning"
+                size="sm"
+                :disabled="isSubmittingEdit || isDeleting"
+                @click="openEditForm(data.item)"
+              >
+                Edit
+              </BButton>
+              <BButton
+                variant="danger"
+                size="sm"
+                :disabled="isSubmittingEdit || isDeleting"
+                @click="deleteStyle(data.item)"
+              >
+                Delete
+              </BButton>
+            </BButtonGroup>
+          </template>
+        </BTable>
+        <BPagination
+          v-if="scriptStore.stageDirectionStyles.length > rowsPerPage"
+          v-model="currentPage"
+          :total-rows="scriptStore.stageDirectionStyles.length"
+          :per-page="rowsPerPage"
+        />
+      </BCol>
+    </BRow>
+
+    <!-- New Style Modal -->
+    <BModal
+      ref="newModal"
+      title="Add New Style"
+      size="lg"
+      :ok-disabled="isSubmittingNew"
+      @show="resetNewForm"
+      @hidden="resetNewForm"
+      @ok.prevent="onSubmitNew"
+    >
+      <StyleForm v-model="newForm" />
+    </BModal>
+
+    <!-- Edit Style Modal -->
+    <BModal
+      ref="editModal"
+      title="Edit Style"
+      size="lg"
+      :ok-disabled="isSubmittingEdit"
+      @hidden="resetEditForm"
+      @ok.prevent="onSubmitEdit"
+    >
+      <StyleForm v-model="editForm" />
+    </BModal>
+
+    <!-- Import Modal -->
+    <BModal
+      ref="importModal"
+      title="Import Stage Direction Style"
+      size="xl"
+      ok-only
+      ok-title="Close"
+      @hidden="resetImportState"
+    >
+      <div v-if="isLoadingImport" class="text-center py-3">
+        <BSpinner />
+      </div>
+      <div v-else-if="importStyleGroups.length === 0" class="text-muted text-center py-3">
+        No styles available to import from other shows.
+      </div>
+      <div v-else>
+        <BCard v-for="show in importStyleGroups" :key="show.id" no-body class="mb-2">
+          <BCardHeader class="section-card-header" role="button" @click="toggleImportShow(show.id)">
+            <div class="d-flex justify-content-between align-items-center">
+              <span>{{ show.name }}</span>
+              <span>{{ styleGroupExpanded[show.id] ? '▲' : '▼' }}</span>
+            </div>
+          </BCardHeader>
+          <BCollapse :model-value="styleGroupExpanded[show.id]">
+            <BCardBody class="p-0">
+              <BTable :items="show.styles" :fields="importColumns" small show-empty class="mb-0">
+                <template #cell(example)="row">
+                  <i class="example-stage-direction" :style="exampleCss(row.item)">
+                    {{ formatExampleText(row.item) }}
+                  </i>
+                </template>
+                <template #cell(btn)="row">
+                  <BButton
+                    variant="outline-success"
+                    size="sm"
+                    :disabled="!!isImporting[row.item.id]"
+                    @click="importStyle(row.item)"
+                  >
+                    <BSpinner v-if="isImporting[row.item.id]" small />
+                    <span v-else>Import</span>
+                  </BButton>
+                </template>
+              </BTable>
+            </BCardBody>
+          </BCollapse>
+        </BCard>
+      </div>
+    </BModal>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, defineComponent, h } from 'vue';
+import type { BModal } from 'bootstrap-vue-next';
+import { useVuelidate } from '@vuelidate/core';
+import { required } from '@vuelidate/validators';
+import log from 'loglevel';
+import { useScriptStore } from '@/stores/script';
+import { useSystemStore } from '@/stores/system';
+import { useConfirm } from '@/composables/useConfirm';
+import { useFormValidation } from '@/composables/useFormValidation';
+import type { StageDirectionStyle } from '@/types/api/script';
+import { toast } from '@/js/toast';
+
+const scriptStore = useScriptStore();
+const systemStore = useSystemStore();
+const { confirm } = useConfirm();
+const { validationState } = useFormValidation();
+
+const rowsPerPage = 15;
+const currentPage = ref(1);
+const isSubmittingNew = ref(false);
+const isSubmittingEdit = ref(false);
+const isDeleting = ref(false);
+const importStyleGroups = ref<any[]>([]);
+const styleGroupExpanded = ref<Record<number, boolean>>({});
+const isLoadingImport = ref(false);
+const isImporting = ref<Record<number, boolean>>({});
+
+const newModal = ref<InstanceType<typeof BModal>>();
+const editModal = ref<InstanceType<typeof BModal>>();
+const importModal = ref<InstanceType<typeof BModal>>();
+
+interface StyleForm {
+  id?: number | null;
+  description: string;
+  bold: boolean;
+  italic: boolean;
+  underline: boolean;
+  textFormat: string;
+  textColour: string;
+  enableBackgroundColour: boolean;
+  backgroundColour: string;
+}
+
+function defaultStyleForm(): StyleForm {
+  return {
+    description: '',
+    bold: false,
+    italic: false,
+    underline: false,
+    textFormat: 'default',
+    textColour: '#FFFFFF',
+    enableBackgroundColour: false,
+    backgroundColour: '#000000',
+  };
+}
+
+const newForm = ref<StyleForm>(defaultStyleForm());
+const editForm = ref<StyleForm>({ ...defaultStyleForm(), id: null });
+
+const vNew$ = useVuelidate({ description: { required } }, newForm);
+const vEdit$ = useVuelidate({ description: { required } }, editForm);
+
+const columns = [
+  { key: 'description', label: 'Description' },
+  { key: 'example', label: 'Example Stage Direction' },
+  { key: 'btn', label: '' },
+];
+
+const importColumns = [
+  { key: 'description', label: 'Description' },
+  { key: 'example', label: 'Example Stage Direction' },
+  { key: 'btn', label: '' },
+];
+
+const exampleText = 'Your stage direction will look like this when formatted in the script!';
+
+function formatExampleText(item: any): string {
+  if (item.text_format === 'upper') return exampleText.toUpperCase();
+  if (item.text_format === 'lower') return exampleText.toLowerCase();
+  return exampleText;
+}
+
+function exampleCss(item: any): Record<string, string> {
+  const style: Record<string, string> = {
+    'font-weight': item.bold ? 'bold' : 'normal',
+    'font-style': item.italic ? 'italic' : 'normal',
+    'text-decoration-line': item.underline ? 'underline' : 'none',
+    color: item.text_colour ?? '',
+  };
+  if (item.enable_background_colour) style['background-color'] = item.background_colour ?? '';
+  return style;
+}
+
+function formExampleCss(form: StyleForm): Record<string, string> {
+  const style: Record<string, string> = {
+    'font-weight': form.bold ? 'bold' : 'normal',
+    'font-style': form.italic ? 'italic' : 'normal',
+    'text-decoration-line': form.underline ? 'underline' : 'none',
+    color: form.textColour,
+  };
+  if (form.enableBackgroundColour) style['background-color'] = form.backgroundColour;
+  return style;
+}
+
+function styleToPayload(form: StyleForm): Record<string, unknown> {
+  return {
+    ...(form.id != null ? { id: form.id } : {}),
+    description: form.description,
+    bold: form.bold,
+    italic: form.italic,
+    underline: form.underline,
+    textFormat: form.textFormat,
+    textColour: form.textColour,
+    enableBackgroundColour: form.enableBackgroundColour,
+    backgroundColour: form.backgroundColour,
+  };
+}
+
+function resetNewForm(): void {
+  newForm.value = defaultStyleForm();
+  isSubmittingNew.value = false;
+  vNew$.value.$reset();
+}
+
+function resetEditForm(): void {
+  editForm.value = { ...defaultStyleForm(), id: null };
+  isSubmittingEdit.value = false;
+  vEdit$.value.$reset();
+}
+
+async function onSubmitNew(): Promise<void> {
+  const valid = await vNew$.value.$validate();
+  if (!valid || isSubmittingNew.value) return;
+  isSubmittingNew.value = true;
+  try {
+    await scriptStore.addStageDirectionStyle(
+      styleToPayload(newForm.value) as Partial<StageDirectionStyle>
+    );
+    newModal.value?.hide();
+  } catch (e) {
+    log.error('Error adding stage direction style:', e);
+  } finally {
+    isSubmittingNew.value = false;
+  }
+}
+
+async function onSubmitEdit(): Promise<void> {
+  const valid = await vEdit$.value.$validate();
+  if (!valid || isSubmittingEdit.value) return;
+  isSubmittingEdit.value = true;
+  try {
+    await scriptStore.updateStageDirectionStyle(
+      styleToPayload(editForm.value) as Partial<StageDirectionStyle>
+    );
+    editModal.value?.hide();
+  } catch (e) {
+    log.error('Error updating stage direction style:', e);
+  } finally {
+    isSubmittingEdit.value = false;
+  }
+}
+
+function openEditForm(item: StageDirectionStyle): void {
+  editForm.value = {
+    id: item.id,
+    description: item.description ?? '',
+    bold: item.bold ?? false,
+    italic: item.italic ?? false,
+    underline: item.underline ?? false,
+    textFormat: item.text_format ?? 'default',
+    textColour: item.text_colour ?? '#FFFFFF',
+    enableBackgroundColour: item.enable_background_colour ?? false,
+    backgroundColour: item.background_colour ?? '#000000',
+  };
+  editModal.value?.show();
+}
+
+async function deleteStyle(item: StageDirectionStyle): Promise<void> {
+  if (isDeleting.value) return;
+  const ok = await confirm(`Are you sure you want to delete "${item.description}"?`, {
+    okVariant: 'danger',
+    okTitle: 'Delete',
+  });
+  if (!ok) return;
+  isDeleting.value = true;
+  try {
+    await scriptStore.deleteStageDirectionStyle(item.id);
+  } catch (e) {
+    log.error('Error deleting stage direction style:', e);
+  } finally {
+    isDeleting.value = false;
+  }
+}
+
+async function openImportModal(): Promise<void> {
+  importModal.value?.show();
+  isLoadingImport.value = true;
+  try {
+    const data = (await scriptStore.getImportableStyles()) as any;
+    importStyleGroups.value = data.style_groups ?? [];
+    const expanded: Record<number, boolean> = {};
+    importStyleGroups.value.forEach((group: any) => {
+      expanded[group.id] = true;
+    });
+    styleGroupExpanded.value = expanded;
+  } catch (e) {
+    log.error('Error fetching importable styles:', e);
+    toast.error('Failed to load styles for import');
+  } finally {
+    isLoadingImport.value = false;
+  }
+}
+
+function resetImportState(): void {
+  importStyleGroups.value = [];
+  styleGroupExpanded.value = {};
+  isLoadingImport.value = false;
+  isImporting.value = {};
+}
+
+function toggleImportShow(showId: number): void {
+  styleGroupExpanded.value[showId] = !styleGroupExpanded.value[showId];
+}
+
+async function importStyle(item: any): Promise<void> {
+  isImporting.value[item.id] = true;
+  try {
+    await scriptStore.addStageDirectionStyle({
+      description: item.description,
+      bold: item.bold,
+      italic: item.italic,
+      underline: item.underline,
+      text_format: item.text_format,
+      text_colour: item.text_colour,
+      enable_background_colour: item.enable_background_colour,
+      background_colour: item.background_colour,
+    });
+    toast.success(`Imported "${item.description}"`);
+  } catch (e) {
+    log.error('Error importing style:', e);
+    toast.error(`Failed to import "${item.description}"`);
+  } finally {
+    isImporting.value[item.id] = false;
+  }
+}
+
+// Inline style form sub-component
+const StyleForm = defineComponent({
+  props: { modelValue: { type: Object, required: true } },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    function update(field: string, value: unknown) {
+      emit('update:modelValue', { ...props.modelValue, [field]: value });
+    }
+    return () => {
+      const form = props.modelValue as StyleForm;
+      return h('div', [
+        h('div', { class: 'mb-3' }, [
+          h('h4', 'Example Stage Direction'),
+          h(
+            'i',
+            { class: 'example-stage-direction', style: formExampleCss(form) },
+            formatExampleText({
+              text_format: form.textFormat,
+              bold: form.bold,
+              italic: form.italic,
+              underline: form.underline,
+              text_colour: form.textColour,
+              enable_background_colour: form.enableBackgroundColour,
+              background_colour: form.backgroundColour,
+            })
+          ),
+        ]),
+      ]);
+    };
+  },
+});
+
+onMounted(async () => {
+  await scriptStore.getStageDirectionStyles();
+});
+</script>
+
+<style scoped>
+.example-stage-direction {
+  padding: 0.25rem 0.5rem;
+  display: inline-block;
+}
+</style>

--- a/client-v3/src/composables/useScriptDisplay.ts
+++ b/client-v3/src/composables/useScriptDisplay.ts
@@ -1,0 +1,37 @@
+import { LINE_TYPES } from '@/constants/lineTypes';
+import { TEXT_ALIGNMENT_CSS } from '@/constants/textAlignment';
+import type { TextAlignment } from '@/constants/textAlignment';
+import type { ScriptLine, StageDirectionStyle } from '@/types/api/script';
+
+export function useScriptDisplay() {
+  function getStageDirectionStyle(
+    line: ScriptLine,
+    styles: StageDirectionStyle[],
+    overrides: StageDirectionStyle[]
+  ): StageDirectionStyle | null {
+    if (line.line_type !== LINE_TYPES.STAGE_DIRECTION) return null;
+    const style = styles.find((s) => s.id === line.stage_direction_style_id) ?? null;
+    if (!style) return null;
+    const override = (overrides as any[]).find((o) => o.settings?.id === style.id);
+    return override ? override.settings : style;
+  }
+
+  function stageDirectionStyling(style: StageDirectionStyle | null): Record<string, string> {
+    if (!style) return { 'background-color': 'darkslateblue', 'font-style': 'italic' };
+    const result: Record<string, string> = {
+      'font-weight': style.bold ? 'bold' : 'normal',
+      'font-style': style.italic ? 'italic' : 'normal',
+      'text-decoration-line': style.underline ? 'underline' : 'none',
+      color: style.text_colour ?? '',
+    };
+    if (style.enable_background_colour) result['background-color'] = style.background_colour ?? '';
+    return result;
+  }
+
+  function scriptTextAlign(userSettings: Record<string, unknown>): string {
+    const alignment = (userSettings?.script_text_alignment as TextAlignment) ?? 2;
+    return TEXT_ALIGNMENT_CSS[alignment] || 'center';
+  }
+
+  return { getStageDirectionStyle, stageDirectionStyling, scriptTextAlign };
+}

--- a/client-v3/src/composables/useScriptNavigation.ts
+++ b/client-v3/src/composables/useScriptNavigation.ts
@@ -1,0 +1,56 @@
+import { LINE_TYPES } from '@/constants/lineTypes';
+import { isWholeLineCut } from '@/js/scriptUtils';
+import type { ScriptLine } from '@/types/api/script';
+
+export function useScriptNavigation() {
+  function checkIsUntaggedStageDirection(line: ScriptLine): boolean {
+    return (
+      line.line_type === LINE_TYPES.STAGE_DIRECTION &&
+      line.line_parts[0]?.character_id == null &&
+      line.line_parts[0]?.character_group_id == null
+    );
+  }
+
+  function needsHeadings(
+    line: ScriptLine,
+    previousLine: ScriptLine | null,
+    cuts: (number | null)[],
+    getPage: (page: number) => ScriptLine[]
+  ): boolean[] {
+    let prev: ScriptLine | null = previousLine;
+    while (prev != null && (checkIsUntaggedStageDirection(prev) || isWholeLineCut(prev, cuts))) {
+      const prevPage = getPage(prev.page ?? 0);
+      const idx = prevPage.indexOf(prev);
+      prev = idx > 0 ? prevPage[idx - 1] : null;
+    }
+
+    return line.line_parts.map((part) => {
+      if (prev == null || prev.line_parts.length !== line.line_parts.length) return true;
+      if (prev.act_id !== line.act_id || prev.scene_id !== line.scene_id) return true;
+      const match = prev.line_parts.find((p) => p.part_index === part.part_index);
+      if (!match) return true;
+      return !(
+        match.character_id === part.character_id &&
+        match.character_group_id === part.character_group_id
+      );
+    });
+  }
+
+  function needsActSceneLabel(
+    line: ScriptLine,
+    previousLine: ScriptLine | null,
+    cuts: (number | null)[],
+    getPage: (page: number) => ScriptLine[]
+  ): boolean {
+    let prev: ScriptLine | null = previousLine;
+    while (prev != null && isWholeLineCut(prev, cuts)) {
+      const prevPage = getPage(prev.page ?? 0);
+      const idx = prevPage.indexOf(prev);
+      prev = idx > 0 ? prevPage[idx - 1] : null;
+    }
+    if (prev == null) return true;
+    return !(prev.act_id === line.act_id && prev.scene_id === line.scene_id);
+  }
+
+  return { needsHeadings, needsActSceneLabel, checkIsUntaggedStageDirection };
+}

--- a/client-v3/src/js/mruSortUtils.ts
+++ b/client-v3/src/js/mruSortUtils.ts
@@ -1,0 +1,86 @@
+type NamedItem = { id: number; name: string };
+type LinePart = { character_id?: number | null; character_group_id?: number | null };
+type ScriptLine = { line_parts?: LinePart[] };
+type TmpScript = Record<string, ScriptLine[]>;
+export type SelectOption = { value: number | null; text: string };
+export type CombinedSelectOption =
+  | { value: null; text: string }
+  | { label: string; options: { value: string; text: string }[] };
+
+function countOccurrences(
+  tmpScript: TmpScript,
+  field: 'character_id' | 'character_group_id'
+): Record<number, number> {
+  const counts: Record<number, number> = {};
+  Object.values(tmpScript).forEach((page) => {
+    page.forEach((line) => {
+      (line.line_parts ?? []).forEach((part) => {
+        const id = part[field];
+        if (id != null) {
+          counts[id] = (counts[id] || 0) + 1;
+        }
+      });
+    });
+  });
+  return counts;
+}
+
+export function buildMruCharacterOptions(
+  characters: NamedItem[],
+  tmpScript: TmpScript
+): SelectOption[] | null {
+  const counts = countOccurrences(tmpScript, 'character_id');
+  if (Object.keys(counts).length === 0) return null;
+  const sorted = [...characters].sort((a, b) => (counts[b.id] || 0) - (counts[a.id] || 0));
+  return [{ value: null, text: 'N/A' }, ...sorted.map((c) => ({ value: c.id, text: c.name }))];
+}
+
+export function buildMruCharacterGroupOptions(
+  characterGroups: NamedItem[],
+  tmpScript: TmpScript
+): SelectOption[] | null {
+  const counts = countOccurrences(tmpScript, 'character_group_id');
+  if (Object.keys(counts).length === 0) return null;
+  const sorted = [...characterGroups].sort((a, b) => (counts[b.id] || 0) - (counts[a.id] || 0));
+  return [{ value: null, text: 'N/A' }, ...sorted.map((g) => ({ value: g.id, text: g.name }))];
+}
+
+export function buildCombinedCharacterOptions(
+  characters: NamedItem[],
+  characterGroups: NamedItem[],
+  tmpScript: TmpScript,
+  useMru: boolean
+): CombinedSelectOption[] {
+  let sortedChars = [...characters];
+  let sortedGroups = [...characterGroups];
+
+  if (useMru) {
+    const charCounts = countOccurrences(tmpScript, 'character_id');
+    if (Object.keys(charCounts).length > 0) {
+      sortedChars = [...characters].sort(
+        (a, b) => (charCounts[b.id] || 0) - (charCounts[a.id] || 0)
+      );
+    }
+    const groupCounts = countOccurrences(tmpScript, 'character_group_id');
+    if (Object.keys(groupCounts).length > 0) {
+      sortedGroups = [...characterGroups].sort(
+        (a, b) => (groupCounts[b.id] || 0) - (groupCounts[a.id] || 0)
+      );
+    }
+  }
+
+  const result: CombinedSelectOption[] = [{ value: null, text: 'N/A' }];
+  if (sortedChars.length > 0) {
+    result.push({
+      label: 'Characters',
+      options: sortedChars.map((c) => ({ value: `c:${c.id}`, text: c.name })),
+    });
+  }
+  if (sortedGroups.length > 0) {
+    result.push({
+      label: 'Character Groups',
+      options: sortedGroups.map((g) => ({ value: `g:${g.id}`, text: g.name })),
+    });
+  }
+  return result;
+}

--- a/client-v3/src/js/scriptUtils.ts
+++ b/client-v3/src/js/scriptUtils.ts
@@ -1,0 +1,21 @@
+import { LINE_TYPES } from '@/constants/lineTypes';
+import type { ScriptLine } from '@/types/api/script';
+
+export function isWholeLineCut(line: ScriptLine, cuts: (number | null)[]): boolean {
+  if (line.line_type === LINE_TYPES.CUE_LINE) {
+    return false;
+  }
+
+  if (line.line_type === LINE_TYPES.SPACING) {
+    return true;
+  }
+
+  return line.line_parts.every(
+    (linePart) =>
+      cuts.includes(linePart.id) ||
+      linePart.line_text == null ||
+      linePart.line_text.trim().length === 0
+  );
+}
+
+export default { isWholeLineCut };

--- a/client-v3/src/router/index.ts
+++ b/client-v3/src/router/index.ts
@@ -87,13 +87,13 @@ const router = createRouter({
         {
           name: 'show-config-script',
           path: 'script',
-          component: PlaceholderView,
+          component: () => import('@/views/show/config/ConfigScript.vue'),
           meta: { requiresAuth: true, requiresShowAccess: true },
         },
         {
           name: 'show-config-script-revisions',
           path: 'script-revisions',
-          component: PlaceholderView,
+          component: () => import('@/views/show/config/ConfigScriptRevisions.vue'),
           meta: { requiresAuth: true, requiresShowAccess: true },
         },
         {

--- a/client-v3/src/stores/script.ts
+++ b/client-v3/src/stores/script.ts
@@ -1,0 +1,198 @@
+import { defineStore } from 'pinia';
+import log from 'loglevel';
+import { makeURL } from '@/js/utils';
+import { toast } from '@/js/toast';
+import type {
+  ScriptLine,
+  StageDirectionStyle,
+  CompiledScript,
+  ScriptCut,
+} from '@/types/api/script';
+
+export const useScriptStore = defineStore('script', {
+  state: () => ({
+    script: {} as Record<string, ScriptLine[]>,
+    stageDirectionStyles: [] as StageDirectionStyle[],
+    compiledScripts: [] as CompiledScript[],
+    cuts: [] as ScriptCut[],
+    maxPage: 1,
+  }),
+
+  getters: {
+    getScriptPage:
+      (state) =>
+      (page: number | string): ScriptLine[] =>
+        state.script[String(page)] ?? [],
+    stageDirectionStyleById:
+      (state) =>
+      (id: number | null): StageDirectionStyle | null =>
+        id != null ? (state.stageDirectionStyles.find((s) => s.id === id) ?? null) : null,
+  },
+
+  actions: {
+    async loadScriptPage(page: number | string): Promise<void> {
+      const params = new URLSearchParams({ page: String(page) });
+      const response = await fetch(`${makeURL('/api/v1/show/script')}?${params}`);
+      if (response.ok) {
+        const data = await response.json();
+        this.script[String(data.page)] = data.lines;
+      } else {
+        log.error('Unable to load script page');
+      }
+    },
+
+    async saveNewPage(page: number, lines: ScriptLine[]): Promise<boolean> {
+      const params = new URLSearchParams({ page: String(page) });
+      const response = await fetch(`${makeURL('/api/v1/show/script')}?${params}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(lines),
+      });
+      return response.ok;
+    },
+
+    async saveChangedPage(
+      page: number,
+      payload: { page: ScriptLine[]; status: unknown }
+    ): Promise<boolean> {
+      const params = new URLSearchParams({ page: String(page) });
+      const response = await fetch(`${makeURL('/api/v1/show/script')}?${params}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      return response.ok;
+    },
+
+    async getMaxPage(): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/script/max_page'));
+      if (response.ok) {
+        const data = await response.json();
+        this.maxPage = data.max_page;
+      }
+    },
+
+    async getStageDirectionStyles(): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/script/stage_direction_styles'));
+      if (response.ok) {
+        const data = await response.json();
+        this.stageDirectionStyles = data.styles;
+      } else {
+        log.error('Unable to load stage direction styles');
+      }
+    },
+
+    async addStageDirectionStyle(style: Partial<StageDirectionStyle>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/script/stage_direction_styles'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(style),
+      });
+      if (response.ok) {
+        await this.getStageDirectionStyles();
+        toast.success('Added new stage direction style!');
+      } else {
+        toast.error('Unable to add new stage direction style');
+      }
+    },
+
+    async updateStageDirectionStyle(style: Partial<StageDirectionStyle>): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/script/stage_direction_styles'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(style),
+      });
+      if (response.ok) {
+        await this.getStageDirectionStyles();
+        toast.success('Updated stage direction style!');
+      } else {
+        toast.error('Unable to edit stage direction style');
+      }
+    },
+
+    async deleteStageDirectionStyle(id: number): Promise<void> {
+      const params = new URLSearchParams({ id: String(id) });
+      const response = await fetch(
+        `${makeURL('/api/v1/show/script/stage_direction_styles')}?${params}`,
+        { method: 'DELETE' }
+      );
+      if (response.ok) {
+        await this.getStageDirectionStyles();
+        toast.success('Deleted stage direction style!');
+      } else {
+        toast.error('Unable to delete stage direction style');
+      }
+    },
+
+    async getImportableStyles(): Promise<unknown> {
+      const response = await fetch(makeURL('/api/v1/show/script/stage_direction_styles/import'));
+      if (!response.ok) throw new Error('Failed to fetch importable styles');
+      return response.json();
+    },
+
+    async getCompiledScripts(): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/script/compiled_scripts'));
+      if (response.ok) {
+        const data = await response.json();
+        this.compiledScripts = data.scripts;
+      } else {
+        log.error('Unable to load compiled scripts');
+      }
+    },
+
+    async generateCompiledScript(revisionId: number): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/script/compiled_scripts'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ revision_id: revisionId }),
+      });
+      if (response.ok) {
+        await this.getCompiledScripts();
+        toast.success('Generated compiled script!');
+      } else {
+        toast.error('Unable to generate compiled script');
+      }
+    },
+
+    async deleteCompiledScript(revisionId: number): Promise<void> {
+      const params = new URLSearchParams({ revision_id: String(revisionId) });
+      const response = await fetch(`${makeURL('/api/v1/show/script/compiled_scripts')}?${params}`, {
+        method: 'DELETE',
+      });
+      if (response.ok) {
+        await this.getCompiledScripts();
+        toast.success('Deleted compiled script!');
+      } else {
+        toast.error('Unable to delete compiled script');
+      }
+    },
+
+    async getCuts(): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/script/cuts'));
+      if (response.ok) {
+        const data = await response.json();
+        this.cuts = data.cuts;
+      } else {
+        log.error('Unable to load script cuts');
+      }
+    },
+
+    async saveCuts(cuts: ScriptCut[]): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/script/cuts'), {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cuts }),
+      });
+      if (response.ok) {
+        await this.getCuts();
+        toast.success('Saved script cuts!');
+      } else {
+        toast.error('Unable to save script cuts');
+      }
+    },
+
+    clearScript(): void {
+      this.script = {};
+    },
+  },
+});

--- a/client-v3/src/stores/scriptConfig.test.ts
+++ b/client-v3/src/stores/scriptConfig.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import type { ScriptLine } from '@/types/api/script';
+import { computePageStatus } from './scriptConfig';
+
+function makeLine(id: number | null, numParts: number): ScriptLine {
+  return {
+    id,
+    act_id: 1,
+    scene_id: 1,
+    page: 1,
+    line_type: 1,
+    stage_direction_style_id: null,
+    line_parts: Array.from({ length: numParts }, (_, i) => ({
+      id: id != null ? 100 + i : null,
+      line_id: id,
+      part_index: i,
+      character_id: 1,
+      character_group_id: null,
+      line_text: `Part ${i}`,
+    })),
+  };
+}
+
+describe('computePageStatus', () => {
+  it('classifies an existing line whose line_parts grew as updated, not added', () => {
+    const saved = [makeLine(42, 1)];
+    const edited = [makeLine(42, 2)];
+
+    const status = computePageStatus(saved, edited, [], []);
+
+    expect(status.added).not.toContain(0);
+    expect(status.updated).toContain(0);
+    expect(status.deleted).toHaveLength(0);
+    expect(status.inserted).toHaveLength(0);
+  });
+
+  it('classifies a genuinely new line (id == null) as added', () => {
+    const saved: ScriptLine[] = [];
+    const edited = [makeLine(null, 1)];
+
+    const status = computePageStatus(saved, edited, [], []);
+
+    expect(status.added).toContain(0);
+    expect(status.updated).not.toContain(0);
+  });
+
+  it('classifies an existing line with a changed top-level field as updated', () => {
+    const saved = [makeLine(42, 1)];
+    const edited = [{ ...makeLine(42, 1), line_type: 2 }];
+
+    const status = computePageStatus(saved, edited, [], []);
+
+    expect(status.updated).toContain(0);
+    expect(status.added).not.toContain(0);
+  });
+
+  it('passes deleted line indices through to the deleted array', () => {
+    const saved = [makeLine(10, 1), makeLine(11, 1)];
+    const edited = [makeLine(10, 1), makeLine(11, 1)];
+
+    const status = computePageStatus(saved, edited, [1], []);
+
+    expect(status.deleted).toContain(1);
+    expect(status.added).toHaveLength(0);
+    expect(status.updated).toHaveLength(0);
+  });
+
+  it('passes inserted line indices through to the inserted array', () => {
+    const saved = [makeLine(10, 1)];
+    const newLine = makeLine(null, 1);
+    const edited = [makeLine(10, 1), newLine];
+
+    const status = computePageStatus(saved, edited, [], [1]);
+
+    expect(status.inserted).toContain(1);
+  });
+
+  it('handles a mixed page: one truly-new line and one existing line whose parts grew', () => {
+    const saved = [makeLine(42, 1)];
+    const edited = [makeLine(42, 2), makeLine(null, 1)];
+
+    const status = computePageStatus(saved, edited, [], []);
+
+    expect(status.updated).toContain(0);
+    expect(status.added).not.toContain(0);
+    expect(status.added).toContain(1);
+    expect(status.updated).not.toContain(1);
+  });
+
+  it('returns all empty arrays when actual and tmp pages are identical', () => {
+    const page = [makeLine(42, 2), makeLine(43, 1)];
+
+    const status = computePageStatus(page, JSON.parse(JSON.stringify(page)), [], []);
+
+    expect(status.added).toHaveLength(0);
+    expect(status.updated).toHaveLength(0);
+    expect(status.deleted).toHaveLength(0);
+    expect(status.inserted).toHaveLength(0);
+  });
+});

--- a/client-v3/src/stores/scriptConfig.ts
+++ b/client-v3/src/stores/scriptConfig.ts
@@ -69,7 +69,9 @@ export const useScriptConfigStore = defineStore('scriptConfig', {
 
   actions: {
     addPage(page: number, contents: ScriptLine[]): void {
-      this.tmpScript[String(page)] = structuredClone(contents);
+      // JSON round-trip instead of structuredClone — reactive Pinia arrays (Proxy objects)
+      // cannot be structuredCloned in some environments.
+      this.tmpScript[String(page)] = JSON.parse(JSON.stringify(contents));
       if (!this.deletedLines[String(page)]) this.deletedLines[String(page)] = [];
       if (!this.insertedLines[String(page)]) this.insertedLines[String(page)] = [];
     },
@@ -81,7 +83,7 @@ export const useScriptConfigStore = defineStore('scriptConfig', {
     },
 
     addBlankLine(page: number, line: ScriptLine): void {
-      const l = structuredClone(line);
+      const l = JSON.parse(JSON.stringify(line));
       l.page = page;
       this.tmpScript[String(page)].push(l);
     },
@@ -89,13 +91,13 @@ export const useScriptConfigStore = defineStore('scriptConfig', {
     insertBlankLine(page: number, lineIndex: number, line: ScriptLine): void {
       const pageStr = String(page);
       if (this.deletedLines[pageStr]?.includes(lineIndex)) {
-        const l = structuredClone(line);
+        const l = JSON.parse(JSON.stringify(line));
         l.page = page;
         l.id = this.tmpScript[pageStr][lineIndex].id;
         this.tmpScript[pageStr].splice(lineIndex, 1, l);
         this.deletedLines[pageStr].splice(this.deletedLines[pageStr].indexOf(lineIndex), 1);
       } else {
-        const l = structuredClone(line);
+        const l = JSON.parse(JSON.stringify(line));
         l.page = page;
         this.tmpScript[pageStr].splice(lineIndex, 0, l);
         if (!this.insertedLines[pageStr]) this.insertedLines[pageStr] = [];
@@ -144,8 +146,8 @@ export const useScriptConfigStore = defineStore('scriptConfig', {
       if (response.ok) {
         const data = await response.json();
         this.editStatus = {
-          canRequestEdit: data.can_request_edit,
-          currentEditor: data.current_editor,
+          canRequestEdit: data.canRequestEdit,
+          currentEditor: data.currentEditor,
         };
       } else {
         log.error('Unable to get script config status');

--- a/client-v3/src/stores/scriptConfig.ts
+++ b/client-v3/src/stores/scriptConfig.ts
@@ -1,0 +1,161 @@
+import { defineStore } from 'pinia';
+import { detailedDiff } from 'deep-object-diff';
+import log from 'loglevel';
+import { makeURL } from '@/js/utils';
+import { toast } from '@/js/toast';
+import type { ScriptLine, PageStatus } from '@/types/api/script';
+
+/**
+ * Computes the page status object (added/updated/deleted/inserted) to send to the PATCH endpoint.
+ *
+ * deepDiff.added fires on a line index whenever *any* nested property is new — including a new
+ * element in line_parts. Only lines with id == null are truly new; lines with an existing id that
+ * have nested additions must be treated as updates instead.
+ */
+export function computePageStatus(
+  actualScriptPage: ScriptLine[],
+  tmpScriptPage: ScriptLine[],
+  deletedLines: number[],
+  insertedLines: number[]
+): PageStatus {
+  const augmented: ScriptLine[] = JSON.parse(JSON.stringify(actualScriptPage));
+  JSON.parse(JSON.stringify(insertedLines))
+    .sort((a: number, b: number) => a - b)
+    .forEach((lineIndex: number) => {
+      augmented.splice(lineIndex, 0, JSON.parse(JSON.stringify(tmpScriptPage[lineIndex])));
+    });
+
+  const deepDiff = detailedDiff(augmented, tmpScriptPage);
+  const addedIndices = Object.keys(deepDiff.added).map((x) => parseInt(x, 10));
+  return {
+    added: addedIndices.filter((idx) => tmpScriptPage[idx]?.id == null),
+    updated: [
+      ...Object.keys(deepDiff.updated).map((x) => parseInt(x, 10)),
+      ...addedIndices.filter((idx) => tmpScriptPage[idx]?.id != null),
+    ],
+    deleted: [...deletedLines],
+    inserted: [...insertedLines],
+  };
+}
+
+interface EditStatus {
+  canRequestEdit: boolean;
+  currentEditor: string | null;
+}
+
+export const useScriptConfigStore = defineStore('scriptConfig', {
+  state: () => ({
+    tmpScript: {} as Record<string, ScriptLine[]>,
+    deletedLines: {} as Record<string, number[]>,
+    insertedLines: {} as Record<string, number[]>,
+    editStatus: { canRequestEdit: false, currentEditor: null } as EditStatus,
+    cutMode: false,
+  }),
+
+  getters: {
+    getTmpPage:
+      (state) =>
+      (page: number | string): ScriptLine[] =>
+        state.tmpScript[String(page)] ?? [],
+    getDeletedLines:
+      (state) =>
+      (page: number | string): number[] =>
+        state.deletedLines[String(page)] ?? [],
+    getInsertedLines:
+      (state) =>
+      (page: number | string): number[] =>
+        state.insertedLines[String(page)] ?? [],
+  },
+
+  actions: {
+    addPage(page: number, contents: ScriptLine[]): void {
+      this.tmpScript[String(page)] = structuredClone(contents);
+      if (!this.deletedLines[String(page)]) this.deletedLines[String(page)] = [];
+      if (!this.insertedLines[String(page)]) this.insertedLines[String(page)] = [];
+    },
+
+    removePage(page: number): void {
+      delete this.tmpScript[String(page)];
+      delete this.deletedLines[String(page)];
+      delete this.insertedLines[String(page)];
+    },
+
+    addBlankLine(page: number, line: ScriptLine): void {
+      const l = structuredClone(line);
+      l.page = page;
+      this.tmpScript[String(page)].push(l);
+    },
+
+    insertBlankLine(page: number, lineIndex: number, line: ScriptLine): void {
+      const pageStr = String(page);
+      if (this.deletedLines[pageStr]?.includes(lineIndex)) {
+        const l = structuredClone(line);
+        l.page = page;
+        l.id = this.tmpScript[pageStr][lineIndex].id;
+        this.tmpScript[pageStr].splice(lineIndex, 1, l);
+        this.deletedLines[pageStr].splice(this.deletedLines[pageStr].indexOf(lineIndex), 1);
+      } else {
+        const l = structuredClone(line);
+        l.page = page;
+        this.tmpScript[pageStr].splice(lineIndex, 0, l);
+        if (!this.insertedLines[pageStr]) this.insertedLines[pageStr] = [];
+        this.insertedLines[pageStr].push(lineIndex);
+      }
+    },
+
+    setLine(page: number, lineIndex: number, line: ScriptLine): void {
+      this.tmpScript[String(page)][lineIndex] = line;
+    },
+
+    deleteLine(page: number, lineIndex: number): void {
+      const pageStr = String(page);
+      if (this.tmpScript[pageStr][lineIndex].id !== null) {
+        if (!this.deletedLines[pageStr]) this.deletedLines[pageStr] = [];
+        this.deletedLines[pageStr].push(lineIndex);
+      } else {
+        this.tmpScript[pageStr].splice(lineIndex, 1);
+      }
+      if (this.insertedLines[pageStr]?.includes(lineIndex)) {
+        this.insertedLines[pageStr].splice(this.insertedLines[pageStr].indexOf(lineIndex), 1);
+      }
+    },
+
+    resetTracking(page: number): void {
+      this.deletedLines[String(page)] = [];
+      this.insertedLines[String(page)] = [];
+    },
+
+    emptyScript(): void {
+      this.tmpScript = {};
+      this.deletedLines = {};
+      this.insertedLines = {};
+    },
+
+    setCutMode(val: boolean): void {
+      this.cutMode = val;
+    },
+
+    setEditStatus(status: EditStatus): void {
+      this.editStatus = status;
+    },
+
+    async getScriptConfigStatus(): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/script/config'));
+      if (response.ok) {
+        const data = await response.json();
+        this.editStatus = {
+          canRequestEdit: data.can_request_edit,
+          currentEditor: data.current_editor,
+        };
+      } else {
+        log.error('Unable to get script config status');
+      }
+    },
+
+    async requestEditFailure(): Promise<void> {
+      toast.error('Unable to edit script');
+      await this.getScriptConfigStatus();
+      this.cutMode = false;
+    },
+  },
+});

--- a/client-v3/src/stores/show.ts
+++ b/client-v3/src/stores/show.ts
@@ -34,6 +34,7 @@ export const useShowStore = defineStore('show', {
     scriptModes: [] as ScriptMode[],
     sessionTags: [] as SessionTag[],
     scriptRevisions: [] as ScriptRevision[],
+    currentRevision: null as number | null,
     stageManagerMode: false,
   }),
 
@@ -722,9 +723,63 @@ export const useShowStore = defineStore('show', {
       if (response.ok) {
         const data = await response.json();
         this.scriptRevisions = data.revisions ?? [];
+        this.currentRevision = data.current_revision ?? null;
       } else {
         log.error('Unable to get script revisions');
       }
+    },
+
+    async addScriptRevision(payload: {
+      description: string;
+      parent_revision_id?: number | null;
+      set_as_current?: boolean | null;
+    }): Promise<void> {
+      const body: Record<string, unknown> = { description: payload.description };
+      if (payload.parent_revision_id != null) body.parent_revision_id = payload.parent_revision_id;
+      if (payload.set_as_current != null) body.set_as_current = payload.set_as_current;
+      const response = await fetch(makeURL('/api/v1/show/script/revisions'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (response.ok) {
+        await this.getScriptRevisions();
+        toast.success('Added new script revision!');
+      } else {
+        toast.error('Unable to add new script revision');
+      }
+    },
+
+    async deleteScriptRevision(revisionId: number): Promise<void> {
+      const params = new URLSearchParams({ rev_id: String(revisionId) });
+      const response = await fetch(`${makeURL('/api/v1/show/script/revisions')}?${params}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (response.ok) {
+        await this.getScriptRevisions();
+        toast.success('Deleted script revision!');
+      } else {
+        toast.error('Unable to delete script revision');
+      }
+    },
+
+    async loadScriptRevision(revisionId: number): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/script/revisions/current'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ new_rev_id: revisionId }),
+      });
+      if (response.ok) {
+        await this.getScriptRevisions();
+        toast.success('Loaded script revision!');
+      } else {
+        toast.error('Unable to load script revision');
+      }
+    },
+
+    async scriptRevisionChanged(): Promise<void> {
+      await this.getScriptRevisions();
     },
 
     clearCurrentShow(): void {
@@ -734,6 +789,7 @@ export const useShowStore = defineStore('show', {
       this.sceneList = [];
       this.sessionTags = [];
       this.scriptRevisions = [];
+      this.currentRevision = null;
     },
 
     // WS-triggered actions

--- a/client-v3/src/views/show/config/ConfigScript.vue
+++ b/client-v3/src/views/show/config/ConfigScript.vue
@@ -1,0 +1,17 @@
+<template>
+  <BContainer class="mx-0" fluid>
+    <BRow>
+      <BCol>
+        <BTabs content-class="mt-3">
+          <BTab title="Script" active><ScriptEditor /></BTab>
+          <BTab title="Stage Direction Styles"><StageDirectionStyles /></BTab>
+        </BTabs>
+      </BCol>
+    </BRow>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import ScriptEditor from '@/components/show/config/script/ScriptEditor.vue';
+import StageDirectionStyles from '@/components/show/config/script/StageDirectionStyles.vue';
+</script>

--- a/client-v3/src/views/show/config/ConfigScriptRevisions.vue
+++ b/client-v3/src/views/show/config/ConfigScriptRevisions.vue
@@ -1,0 +1,30 @@
+<template>
+  <BContainer class="mx-0" fluid>
+    <BRow v-if="!loading">
+      <BCol>
+        <BTabs content-class="mt-3">
+          <BTab title="Revisions" active><ScriptRevisions /></BTab>
+          <BTab title="Compiled Scripts"><CompiledScripts /></BTab>
+        </BTabs>
+      </BCol>
+    </BRow>
+    <BRow v-else>
+      <BCol class="text-center py-5"><BSpinner label="Loading..." /></BCol>
+    </BRow>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useShowStore } from '@/stores/show';
+import ScriptRevisions from '@/components/show/config/script/ScriptRevisions.vue';
+import CompiledScripts from '@/components/show/config/script/CompiledScripts.vue';
+
+const showStore = useShowStore();
+const loading = ref(true);
+
+onMounted(async () => {
+  await showStore.getScriptRevisions();
+  loading.value = false;
+});
+</script>


### PR DESCRIPTION
## Summary

- **Stores**: `script.ts` (pages, styles, compiled scripts, cuts), `scriptConfig.ts` (tmpScript working copy, edit lock, cut mode) with exported `computePageStatus`
- **Composables**: `useScriptNavigation` (headings/act-scene label logic), `useScriptDisplay` (stage direction styling)
- **Utilities**: `scriptUtils.ts` (`isWholeLineCut`), `mruSortUtils.ts` (MRU character sorting)
- **Revision management**: D3 revision graph with pan/zoom, `RevisionDetailModal`, `ScriptRevisions` (create/branch/load/delete), `CompiledScripts` (generate/delete)
- **Stage direction styles**: Full CRUD table + import from other shows
- **Script editor**: Non-collaborative editor with page navigation, edit lock (WS), line viewer/editor/parts, cut mode, bulk act/scene assignment, auto-save, save progress modal
- **Views**: `ConfigScript` (Script + Stage Direction Styles tabs), `ConfigScriptRevisions` (Revisions + Compiled Scripts tabs)
- **Router**: Both `show-config-script` routes now point to real views (replacing `PlaceholderView`)

## Test plan

- [ ] TypeScript: `npm run typecheck` — passes ✅
- [ ] Lint: `npm run ci-lint` — passes (0 errors, 0 warnings) ✅
- [ ] Tests: `npm run test:run` — 23/23 passing (including `scriptConfig.test.ts`) ✅
- [ ] Build: `npm run build` — succeeds ✅
- [ ] Browser `/ui-new/show-config/script-revisions`: revision table, graph (D3), new/branch/load/delete modals, compiled scripts generate/delete
- [ ] Browser `/ui-new/show-config/script`: page navigation, script line display, edit/stop/save flow, stage direction styles CRUD

🤖 Generated with [Claude Code](https://claude.com/claude-code)