### PR TITLE
Phase 12: Live Show View (Vue 3 migration)

### DIFF
--- a/client-v3/src/App.vue
+++ b/client-v3/src/App.vue
@@ -166,7 +166,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import type { BModal } from 'bootstrap-vue-next';
 import { useVuelidate } from '@vuelidate/core';
@@ -177,14 +177,17 @@ import { useConfirm } from '@/composables/useConfirm';
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue';
 import { useUserStore } from '@/stores/user';
 import { useSystemStore } from '@/stores/system';
+import { useShowStore } from '@/stores/show';
 import { useWebSocketStore } from '@/stores/websocket';
 import { useWebSocket } from '@/composables/useWebSocket';
 import { makeURL } from '@/js/utils';
 import { isElectron } from '@/js/platform';
 
 const route = useRoute();
+const router = useRouter();
 const userStore = useUserStore();
 const systemStore = useSystemStore();
+const showStore = useShowStore();
 const wsStore = useWebSocketStore();
 
 const { websocketHealthy } = storeToRefs(wsStore);
@@ -203,8 +206,7 @@ const changingPage = ref(false);
 const serverConnectionName = ref('Server');
 const goToPageModal = ref<InstanceType<typeof BModal>>();
 
-// Show session — populated in Phase 6 via show store; null until then
-const currentShowSession = computed(() => null);
+const currentShowSession = computed(() => showStore.currentSession);
 
 // Jump-to-page form
 const pageInputState = ref({ pageNo: 1 });
@@ -255,6 +257,12 @@ async function awaitWSConnect(): Promise<void> {
     if (userStore.authToken) {
       await userStore.getCurrentUser();
       await Promise.all([userStore.getCurrentRbac(), userStore.getUserSettings()]);
+    }
+    if (systemStore.currentShow != null) {
+      await showStore.getShowSessionData();
+      if (showStore.currentSession != null && route.path !== '/live') {
+        await router.push('/live');
+      }
     }
     loaded.value = true;
   } else {

--- a/client-v3/src/App.vue
+++ b/client-v3/src/App.vue
@@ -260,8 +260,8 @@ async function awaitWSConnect(): Promise<void> {
     }
     if (systemStore.currentShow != null) {
       await showStore.getShowSessionData();
-      if (showStore.currentSession != null && route.path !== '/live') {
-        await router.push('/live');
+      if (showStore.currentSession != null && router.currentRoute.value.path !== '/ui-new/live') {
+        await router.push('/ui-new/live');
       }
     }
     loaded.value = true;

--- a/client-v3/src/App.vue
+++ b/client-v3/src/App.vue
@@ -140,6 +140,11 @@
             <b>To get started, please create an admin user!</b>
           </BCol>
         </BRow>
+        <BRow class="mt-3">
+          <BCol>
+            <CreateUser :is-first-admin="true" />
+          </BCol>
+        </BRow>
       </BContainer>
     </template>
     <RouterView v-else />
@@ -186,6 +191,7 @@ import log from 'loglevel';
 import { toast } from '@/js/toast';
 import { useConfirm } from '@/composables/useConfirm';
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue';
+import CreateUser from '@/components/user/CreateUser.vue';
 import { useUserStore } from '@/stores/user';
 import { useSystemStore } from '@/stores/system';
 import { useShowStore } from '@/stores/show';
@@ -265,6 +271,7 @@ async function awaitWSConnect(): Promise<void> {
       clearTimeout(loadTimer);
       loadTimer = null;
     }
+    await systemStore.getRbacRoles();
     if (userStore.authToken) {
       await userStore.getCurrentUser();
       await Promise.all([userStore.getCurrentRbac(), userStore.getUserSettings()]);

--- a/client-v3/src/App.vue
+++ b/client-v3/src/App.vue
@@ -63,6 +63,17 @@
               >
                 Jump To Page
               </BDropdownItem>
+              <BDropdownItemButton
+                :disabled="
+                  currentShowSession == null ||
+                  !websocketHealthy ||
+                  stoppingSession ||
+                  startingSession
+                "
+                @click.stop.prevent="showStore.stageManagerMode = !showStore.stageManagerMode"
+              >
+                {{ showStore.stageManagerMode ? 'Disable' : 'Enable' }} Stage Manager
+              </BDropdownItemButton>
             </BNavItemDropdown>
           </template>
           <BNavItem

--- a/client-v3/src/App.vue
+++ b/client-v3/src/App.vue
@@ -260,8 +260,8 @@ async function awaitWSConnect(): Promise<void> {
     }
     if (systemStore.currentShow != null) {
       await showStore.getShowSessionData();
-      if (showStore.currentSession != null && router.currentRoute.value.path !== '/ui-new/live') {
-        await router.push('/ui-new/live');
+      if (showStore.currentSession != null && router.currentRoute.value.path !== '/live') {
+        await router.push('/live');
       }
     }
     loaded.value = true;

--- a/client-v3/src/assets/styles/dark.scss
+++ b/client-v3/src/assets/styles/dark.scss
@@ -3,6 +3,10 @@
 // making every rem-based size ~6.7% larger and reducing visible content.
 $font-size-base: 0.9375rem;
 
+// Bootstrap 4 defaulted navbar horizontal padding to $spacer (1rem = 16px).
+// Bootstrap 5 changed this to null → 0px, making navbar content flush to edges.
+$navbar-padding-x: 1rem;
+
 @import '../../../node_modules/bootswatch/dist/darkly/variables';
 @import 'bootstrap/scss/bootstrap';
 @import '../../../node_modules/bootswatch/dist/darkly/bootswatch';
@@ -22,4 +26,11 @@ body {
 // BVN's BFormGroup renders .b-form-group; Bootstrap 5 dropped .form-group's built-in margin
 .b-form-group {
   margin-bottom: 1rem;
+}
+
+// V2 App.vue had `nav a { font-weight: bold }` making navbar brand and links bold.
+// Scoped to .navbar so tab nav-links are unaffected (BV2 tabs aren't inside <nav>).
+.navbar .navbar-brand,
+.navbar .nav-link {
+  font-weight: bold;
 }

--- a/client-v3/src/assets/styles/dark.scss
+++ b/client-v3/src/assets/styles/dark.scss
@@ -1,3 +1,8 @@
+// Match V2 Bootswatch darkly (Bootstrap 4) base font size of 15px.
+// Bootstrap 5 darkly drops this override and defaults to 1rem (16px),
+// making every rem-based size ~6.7% larger and reducing visible content.
+$font-size-base: 0.9375rem;
+
 @import '../../../node_modules/bootswatch/dist/darkly/variables';
 @import 'bootstrap/scss/bootstrap';
 @import '../../../node_modules/bootswatch/dist/darkly/bootswatch';

--- a/client-v3/src/assets/styles/dark.scss
+++ b/client-v3/src/assets/styles/dark.scss
@@ -7,6 +7,21 @@ $font-size-base: 0.9375rem;
 // Bootstrap 5 changed this to null → 0px, making navbar content flush to edges.
 $navbar-padding-x: 1rem;
 
+// Bootstrap 4 default border-radius was .25rem (4px); Bootstrap 5 raised it to .375rem (6px).
+$border-radius: 0.25rem;
+$border-radius-sm: 0.2rem;
+$border-radius-lg: 0.3rem;
+
+// Bootstrap 4 table cell padding was .75rem; Bootstrap 5 reduced it to .5rem.
+$table-cell-padding-y: 0.75rem;
+$table-cell-padding-x: 0.75rem;
+
+// Bootstrap 4 dropdown item horizontal padding was 1.5rem; Bootstrap 5 reduced it to 1rem.
+$dropdown-item-padding-x: 1.5rem;
+
+// Bootstrap 4 links had no underline by default; Bootstrap 5 Reboot adds underline.
+$link-decoration: none;
+
 @import '../../../node_modules/bootswatch/dist/darkly/variables';
 @import 'bootstrap/scss/bootstrap';
 @import '../../../node_modules/bootswatch/dist/darkly/bootswatch';
@@ -33,4 +48,16 @@ body {
 .navbar .navbar-brand,
 .navbar .nav-link {
   font-weight: bold;
+}
+
+// V2 dark.scss highlighted the active navbar route in the darkly primary (teal) colour.
+#nav-collapse a.router-link-active {
+  color: #00bc8c !important;
+}
+
+// Bootstrap 4 vertical pills were full-width block elements; Bootstrap 5 pills are inline.
+// Match V2's full-width centered tab pills in vertical layouts (e.g. User Settings).
+.nav-pills.flex-column .nav-link {
+  width: 100%;
+  text-align: center;
 }

--- a/client-v3/src/components/show/config/acts_and_scenes/ConfigActs.vue
+++ b/client-v3/src/components/show/config/acts_and_scenes/ConfigActs.vue
@@ -14,9 +14,30 @@
         </BButton>
       </template>
       <template #cell(interval_after)="data">
-        <BBadge :variant="data.item.interval_after ? 'success' : 'danger'">
-          {{ data.item.interval_after ? 'Yes' : 'No' }}
-        </BBadge>
+        <svg
+          v-if="data.item.interval_after"
+          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
+          height="1em"
+          fill="#06BC8C"
+          viewBox="0 0 16 16"
+        >
+          <path
+            d="M2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2zm10.03 4.97a.75.75 0 0 1 .011 1.05l-3.992 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.75.75 0 0 1 1.079-.022z"
+          />
+        </svg>
+        <svg
+          v-else
+          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
+          height="1em"
+          fill="#E74C3C"
+          viewBox="0 0 16 16"
+        >
+          <path
+            d="M2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2zm3.354 4.646L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 1 1 .708-.708z"
+          />
+        </svg>
       </template>
       <template #cell(next_act)="data">
         <span v-if="data.item.next_act">{{ showStore.actById(data.item.next_act)?.name }}</span>

--- a/client-v3/src/components/show/config/cues/CueEditor.vue
+++ b/client-v3/src/components/show/config/cues/CueEditor.vue
@@ -1,0 +1,194 @@
+<template>
+  <BContainer class="mx-0 px-0" fluid>
+    <BRow class="script-row mb-2">
+      <BCol cols="2">
+        <BButtonGroup>
+          <BButton variant="success" @click="goToPageModal?.show()">Go to Page</BButton>
+          <BButton variant="success" @click="jumpToCueModal?.show()">Go to Cue</BButton>
+        </BButtonGroup>
+      </BCol>
+      <BCol cols="2" style="text-align: right">
+        <BButton variant="success" :disabled="currentEditPage === 1" @click="decrPage">
+          Prev Page
+        </BButton>
+      </BCol>
+      <BCol cols="4" class="text-center">
+        <p class="mb-0">Current Page: {{ currentEditPage }}</p>
+      </BCol>
+      <BCol cols="2" style="text-align: left">
+        <BButton variant="success" :disabled="currentEditPage >= currentMaxPage" @click="incrPage">
+          Next Page
+        </BButton>
+      </BCol>
+      <BCol cols="2" />
+    </BRow>
+    <BRow class="script-row">
+      <BCol cols="3">Cues</BCol>
+      <BCol>Script</BCol>
+    </BRow>
+    <hr />
+    <BRow class="script-row">
+      <BCol cols="12">
+        <template
+          v-for="(line, index) in scriptStore.getScriptPage(currentEditPage)"
+          :key="`page_${currentEditPage}_line_${index}`"
+        >
+          <ScriptLineCueEditor
+            :line="line"
+            :line-index="index"
+            :previous-line="scriptStore.getScriptPage(currentEditPage)[index - 1] ?? null"
+            :acts="showStore.actList"
+            :scenes="showStore.sceneList"
+            :characters="showStore.characterList"
+            :character-groups="showStore.characterGroupList"
+            :cues="scriptStore.cuesForLine(line.id)"
+            :cue-types="showStore.cueTypes"
+            :cuts="scriptStore.cuts"
+          />
+        </template>
+      </BCol>
+    </BRow>
+
+    <BModal
+      ref="goToPageModal"
+      title="Go to Page"
+      size="sm"
+      :hide-header-close="changingPage"
+      :hide-footer="changingPage"
+      :no-close-on-backdrop="changingPage"
+      :no-close-on-esc="changingPage"
+      :ok-disabled="pageV$.pageInputFormState.$invalid"
+      @ok.prevent="goToPage"
+    >
+      <BForm @submit.stop.prevent="goToPage">
+        <BFormGroup label="Page" label-for="page-input" label-cols="auto">
+          <BFormInput
+            id="page-input"
+            v-model="v$.pageInputFormState.pageNo.$model"
+            name="page-input"
+            type="number"
+            :state="validatePageState('pageNo')"
+            aria-describedby="page-feedback"
+          />
+          <BFormInvalidFeedback id="page-feedback">
+            This is a required field, and must be greater than 0.
+          </BFormInvalidFeedback>
+        </BFormGroup>
+      </BForm>
+    </BModal>
+
+    <JumpToCueModal ref="jumpToCueModal" @navigate="handleJumpToCue" />
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, onBeforeMount } from 'vue';
+import { useVuelidate } from '@vuelidate/core';
+import { required, minValue } from '@vuelidate/validators';
+import type { BModal } from 'bootstrap-vue-next';
+import { notNull, notNullAndGreaterThanZero } from '@/js/customValidators';
+import { useScriptStore } from '@/stores/script';
+import { useShowStore } from '@/stores/show';
+import { useUserStore } from '@/stores/user';
+import ScriptLineCueEditor from '@/components/show/config/cues/ScriptLineCueEditor.vue';
+import JumpToCueModal from '@/components/show/config/cues/JumpToCueModal.vue';
+
+const scriptStore = useScriptStore();
+const showStore = useShowStore();
+const userStore = useUserStore();
+
+const currentEditPage = ref(1);
+const currentMaxPage = ref(1);
+const changingPage = ref(false);
+
+const goToPageModal = ref<InstanceType<typeof BModal> | null>(null);
+const jumpToCueModal = ref<InstanceType<typeof JumpToCueModal> | null>(null);
+
+const pageInputFormState = ref({ pageNo: 1 });
+
+const rules = {
+  pageInputFormState: {
+    pageNo: { required, notNull, notNullAndGreaterThanZero, minValue: minValue(1) },
+  },
+};
+const v$ = useVuelidate(rules, { pageInputFormState });
+// Alias for template ok-disabled binding
+const pageV$ = v$;
+
+watch(currentEditPage, (val) => {
+  localStorage.setItem('cueEditPage', String(val));
+});
+
+onBeforeMount(async () => {
+  await Promise.all([
+    userStore.getCurrentUser().then(() => {
+      if (userStore.currentUser != null) {
+        return Promise.all([
+          userStore.getStageDirectionStyleOverrides(),
+          userStore.getCueColourOverrides(),
+        ]);
+      }
+      return Promise.resolve();
+    }),
+    showStore.getActList(),
+    showStore.getSceneList(),
+    showStore.getCharacterList(),
+    showStore.getCharacterGroupList(),
+    showStore.getCueTypes(),
+    scriptStore.loadCues(),
+    scriptStore.getCuts(),
+    scriptStore.getStageDirectionStyles(),
+    scriptStore.getMaxPage().then(() => {
+      currentMaxPage.value = scriptStore.maxPage;
+    }),
+  ]);
+
+  const storedPage = localStorage.getItem('cueEditPage');
+  if (storedPage != null) {
+    currentEditPage.value = parseInt(storedPage, 10);
+  }
+  await goToPageInner(currentEditPage.value);
+});
+
+function validatePageState(name: 'pageNo'): boolean | null {
+  const field = v$.value.pageInputFormState[name];
+  return field.$dirty ? !field.$error : null;
+}
+
+async function goToPageInner(pageNo: number): Promise<void> {
+  if (pageNo > 1) {
+    await scriptStore.loadScriptPage(pageNo - 1);
+  }
+  await scriptStore.loadScriptPage(pageNo);
+  currentEditPage.value = pageNo;
+  await scriptStore.loadScriptPage(pageNo + 1);
+}
+
+async function goToPage(): Promise<void> {
+  const valid = await v$.value.$validate();
+  if (!valid) return;
+  changingPage.value = true;
+  await goToPageInner(pageInputFormState.value.pageNo);
+  changingPage.value = false;
+  goToPageModal.value?.hide();
+}
+
+async function decrPage(): Promise<void> {
+  if (currentEditPage.value > 1) {
+    const targetPage = currentEditPage.value - 1;
+    await scriptStore.loadScriptPage(targetPage);
+    currentEditPage.value--;
+    await scriptStore.loadScriptPage(currentEditPage.value - 1);
+  }
+}
+
+async function incrPage(): Promise<void> {
+  currentEditPage.value++;
+  await scriptStore.loadScriptPage(currentEditPage.value + 1);
+}
+
+async function handleJumpToCue(pageNumber: number): Promise<void> {
+  await goToPageInner(pageNumber);
+  jumpToCueModal.value?.hide();
+}
+</script>

--- a/client-v3/src/components/show/config/cues/JumpToCueModal.vue
+++ b/client-v3/src/components/show/config/cues/JumpToCueModal.vue
@@ -1,0 +1,204 @@
+<template>
+  <BModal
+    ref="modal"
+    title="Jump to Cue"
+    :hide-header-close="searching || showResults"
+    :no-close-on-backdrop="searching || showResults"
+    :no-close-on-esc="searching || showResults"
+    :ok-disabled="v$.cueSearchForm.$invalid"
+    :ok-title="showResults ? undefined : 'Search'"
+    :hide-footer="showResults"
+    @ok.prevent="performCueSearch"
+    @hidden="resetCueSearch"
+  >
+    <div v-if="searching" class="text-center">
+      <BSpinner variant="primary" />
+      <p class="mt-2">Searching for cue...</p>
+    </div>
+
+    <template v-else-if="showResults">
+      <template v-if="multipleMatches">
+        <p>Multiple matches found — select one:</p>
+        <BListGroup>
+          <BListGroupItem
+            v-for="match in cueSearchResults.exact_matches"
+            :key="match.cue.id"
+            button
+            @click="navigateToMatch(match)"
+          >
+            {{ match.cue_type.prefix }} {{ match.cue.ident }} — Page {{ match.location.page }}
+          </BListGroupItem>
+        </BListGroup>
+      </template>
+      <template v-else-if="showSuggestions">
+        <BAlert variant="warning" :model-value="true">
+          No exact match found. Did you mean one of these?
+        </BAlert>
+        <BListGroup>
+          <BListGroupItem
+            v-for="suggestion in cueSearchResults.suggestions"
+            :key="suggestion.cue.id"
+            button
+            @click="navigateToMatch(suggestion)"
+          >
+            {{ suggestion.cue_type.prefix }} {{ suggestion.cue.ident }} — Page
+            {{ suggestion.location.page }}
+            <BBadge variant="info" class="ms-2">
+              {{ Math.round(suggestion.similarity_score * 100) }}% match
+            </BBadge>
+          </BListGroupItem>
+        </BListGroup>
+      </template>
+      <BAlert v-else-if="noMatches" variant="danger" :model-value="true">
+        No cues found matching "{{ lastSearchIdent }}".
+      </BAlert>
+      <div class="mt-3 d-flex gap-2">
+        <BButton variant="secondary" @click="resetCueSearch">New Search</BButton>
+        <BButton variant="outline-secondary" @click="modal?.hide()">Cancel</BButton>
+      </div>
+    </template>
+
+    <template v-else>
+      <BForm @submit.stop.prevent="performCueSearch">
+        <BFormGroup label="Cue Type" label-for="jump-cue-type">
+          <BFormSelect
+            id="jump-cue-type"
+            v-model="v$.cueSearchForm.cueTypeId.$model"
+            :options="cueTypeOptions"
+            :state="fieldState('cueTypeId')"
+          />
+          <BFormInvalidFeedback>Please select a cue type.</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Identifier" label-for="jump-cue-ident">
+          <BFormInput
+            id="jump-cue-ident"
+            v-model="v$.cueSearchForm.identifier.$model"
+            placeholder="e.g., 1, 42, 1.5"
+            :state="fieldState('identifier')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+        </BFormGroup>
+        <BAlert v-if="generalError" variant="danger" :model-value="true">
+          {{ generalError }}
+        </BAlert>
+      </BForm>
+    </template>
+  </BModal>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { BModal } from 'bootstrap-vue-next';
+import { useVuelidate } from '@vuelidate/core';
+import { required } from '@vuelidate/validators';
+import { notNull } from '@/js/customValidators';
+import { toast } from '@/js/toast';
+import { useScriptStore } from '@/stores/script';
+import { useShowStore } from '@/stores/show';
+
+interface CueMatch {
+  cue: { id: number; ident: string; cue_type_id: number };
+  cue_type: { id: number; prefix: string; description: string | null };
+  location: { page: number };
+  similarity_score?: number;
+}
+
+interface SearchResult {
+  exact_matches: CueMatch[];
+  suggestions: CueMatch[];
+}
+
+const emit = defineEmits<{ navigate: [page: number] }>();
+
+const scriptStore = useScriptStore();
+const showStore = useShowStore();
+
+const modal = ref<InstanceType<typeof BModal> | null>(null);
+
+const cueSearchForm = ref({ cueTypeId: null as number | null, identifier: '' });
+const rules = {
+  cueSearchForm: {
+    cueTypeId: { required, notNull },
+    identifier: { required },
+  },
+};
+const v$ = useVuelidate(rules, { cueSearchForm });
+
+const cueSearchResults = ref<SearchResult | null>(null);
+const generalError = ref<string | null>(null);
+const searching = ref(false);
+const showResults = ref(false);
+const lastSearchIdent = ref('');
+
+const cueTypeOptions = computed(() => [
+  { value: null, text: 'Select a cue type...', disabled: true },
+  ...showStore.cueTypes.map((t) => ({
+    value: t.id,
+    text: `${t.prefix} - ${t.description ?? 'No description'}`,
+  })),
+]);
+
+const multipleMatches = computed(() => (cueSearchResults.value?.exact_matches.length ?? 0) > 1);
+const showSuggestions = computed(
+  () =>
+    (cueSearchResults.value?.exact_matches.length ?? 0) === 0 &&
+    (cueSearchResults.value?.suggestions.length ?? 0) > 0
+);
+const noMatches = computed(
+  () =>
+    (cueSearchResults.value?.exact_matches.length ?? 0) === 0 &&
+    (cueSearchResults.value?.suggestions.length ?? 0) === 0
+);
+
+function fieldState(field: 'cueTypeId' | 'identifier'): boolean | null {
+  const f = v$.value.cueSearchForm[field];
+  return f.$dirty ? !f.$error : null;
+}
+
+async function performCueSearch(): Promise<void> {
+  const valid = await v$.value.$validate();
+  if (!valid) return;
+  searching.value = true;
+  generalError.value = null;
+  lastSearchIdent.value = cueSearchForm.value.identifier;
+  try {
+    const result = (await scriptStore.searchCues({
+      identifier: cueSearchForm.value.identifier,
+      cueTypeId: cueSearchForm.value.cueTypeId!,
+    })) as unknown as SearchResult;
+    cueSearchResults.value = result;
+    if (result.exact_matches.length === 1) {
+      navigateToMatch(result.exact_matches[0]);
+      modal.value?.hide();
+    } else {
+      showResults.value = true;
+    }
+  } catch {
+    generalError.value = 'Search failed. Please try again.';
+  } finally {
+    searching.value = false;
+  }
+}
+
+function navigateToMatch(match: CueMatch): void {
+  emit('navigate', match.location.page);
+  toast.success(
+    `Jumped to ${match.cue_type.prefix} ${match.cue.ident} on page ${match.location.page}`
+  );
+}
+
+function resetCueSearch(): void {
+  cueSearchForm.value = { cueTypeId: null, identifier: '' };
+  cueSearchResults.value = null;
+  generalError.value = null;
+  searching.value = false;
+  showResults.value = false;
+  v$.value.$reset();
+}
+
+function show(): void {
+  modal.value?.show();
+}
+
+defineExpose({ show });
+</script>

--- a/client-v3/src/components/show/config/cues/ScriptLineCueEditor.vue
+++ b/client-v3/src/components/show/config/cues/ScriptLineCueEditor.vue
@@ -1,0 +1,488 @@
+<template>
+  <div ref="lineContainer" style="margin: 0; padding: 0 0 0.2rem">
+    <!-- Act/scene heading -->
+    <BContainer v-if="needsActSceneLabelValue" fluid class="mx-0" style="margin: 0; padding: 0">
+      <BRow>
+        <BCol cols="3" />
+        <BCol>
+          <h4>{{ actLabel }} - {{ sceneLabel }}</h4>
+        </BCol>
+      </BRow>
+    </BContainer>
+
+    <!-- Main line row -->
+    <BContainer fluid class="mx-0" style="margin: 0; padding: 0">
+      <BRow
+        :class="{
+          'stage-direction': line.line_type === LINE_TYPES.STAGE_DIRECTION,
+        }"
+      >
+        <!-- Cue column -->
+        <BCol cols="3" class="cue-column">
+          <template v-if="line.line_type !== LINE_TYPES.SPACING">
+            <BButtonGroup>
+              <BButton
+                v-for="cue in cues"
+                :key="cue.id"
+                class="cue-button"
+                :disabled="!systemStore.isCueEditor"
+                :style="{
+                  backgroundColor: cueBackgroundColour(cue),
+                  color: contrastColor(cueBackgroundColour(cue)),
+                }"
+                @click.stop="openEditForm(cue)"
+              >
+                {{ cueLabel(cue) }}
+              </BButton>
+            </BButtonGroup>
+            <BButton
+              v-if="systemStore.isCueEditor"
+              variant="success"
+              class="cue-button ms-1"
+              :disabled="isLineCut"
+              @click.stop="openNewForm"
+            >
+              +
+            </BButton>
+          </template>
+        </BCol>
+
+        <!-- Line content -->
+        <template v-if="line.line_type === LINE_TYPES.DIALOGUE">
+          <BCol>
+            <BRow v-if="needsHeadingsAnyValue">
+              <BCol
+                v-for="(part, index) in line.line_parts"
+                :key="`heading_${lineIndex}_part_${index}`"
+                :style="{ textAlign: textAlign }"
+              >
+                <b v-if="needsHeadingsValue[index]">
+                  <template v-if="part.character_id != null">
+                    {{ characters.find((c) => c.id === part.character_id)?.name }}
+                  </template>
+                  <template v-else>
+                    {{ characterGroups.find((g) => g.id === part.character_group_id)?.name }}
+                  </template>
+                </b>
+                <b v-else>&nbsp;</b>
+              </BCol>
+            </BRow>
+            <BRow>
+              <BCol
+                v-for="(part, index) in line.line_parts"
+                :key="`line_${lineIndex}_part_${index}`"
+                :style="{ textAlign: textAlign }"
+              >
+                <p class="viewable-line" :class="{ 'cut-line-part': cuts.includes(part.id) }">
+                  {{ part.line_text }}
+                </p>
+              </BCol>
+            </BRow>
+          </BCol>
+        </template>
+
+        <template v-else-if="line.line_type === LINE_TYPES.STAGE_DIRECTION">
+          <BCol :style="{ textAlign: textAlign }">
+            <i class="viewable-line" :style="sdStyling">
+              <template v-if="sdStyle?.text_format === 'upper'">
+                {{ line.line_parts[0]?.line_text?.toUpperCase() }}
+              </template>
+              <template v-else-if="sdStyle?.text_format === 'lower'">
+                {{ line.line_parts[0]?.line_text?.toLowerCase() }}
+              </template>
+              <template v-else>
+                {{ line.line_parts[0]?.line_text }}
+              </template>
+            </i>
+          </BCol>
+        </template>
+
+        <template v-else-if="line.line_type === LINE_TYPES.CUE_LINE">
+          <BCol>
+            <BAlert variant="secondary" :model-value="true" class="text-muted small mb-0">
+              Cue Line
+            </BAlert>
+          </BCol>
+        </template>
+
+        <template v-else-if="line.line_type === LINE_TYPES.SPACING">
+          <BCol>
+            <BAlert variant="secondary" :model-value="true" class="text-muted small mb-0">
+              Spacing Line
+            </BAlert>
+          </BCol>
+        </template>
+      </BRow>
+    </BContainer>
+
+    <!-- Add New Cue Modal -->
+    <BModal
+      ref="newCueModal"
+      title="Add New Cue"
+      :ok-disabled="v$.newFormState.$invalid || submittingNewCue"
+      @hidden="resetNewForm"
+      @ok="onSubmitNew"
+    >
+      <BForm @submit.stop.prevent="">
+        <BFormGroup label="Cue Type" label-for="new-cue-type">
+          <BFormSelect
+            id="new-cue-type"
+            v-model="v$.newFormState.cueType.$model"
+            :options="cueTypeOptions"
+            :state="newFieldState('cueType')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Identifier" label-for="new-cue-ident">
+          <BFormInput
+            id="new-cue-ident"
+            v-model="v$.newFormState.ident.$model"
+            :state="newFieldState('ident')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+          <BFormText v-if="isDuplicateNewCue" class="text-warning">
+            A cue with this identifier already exists for this cue type.
+          </BFormText>
+        </BFormGroup>
+        <!-- Line preview -->
+        <template
+          v-if="
+            line.line_type === LINE_TYPES.DIALOGUE || line.line_type === LINE_TYPES.STAGE_DIRECTION
+          "
+        >
+          <hr />
+          <template v-if="line.line_type === LINE_TYPES.DIALOGUE">
+            <p v-for="part in line.line_parts" :key="part.id" class="viewable-line">
+              {{ part.line_text }}
+            </p>
+          </template>
+          <i v-else class="viewable-line">{{ line.line_parts[0]?.line_text }}</i>
+        </template>
+      </BForm>
+    </BModal>
+
+    <!-- Edit Cue Modal -->
+    <BModal
+      ref="editCueModal"
+      title="Edit Cue"
+      :ok-disabled="v$.editFormState.$invalid || submittingEditCue"
+      @hidden="resetEditForm"
+      @ok="onSubmitEdit"
+    >
+      <template #footer>
+        <BButton
+          variant="secondary"
+          :disabled="submittingEditCue || deletingCue"
+          @click="editCueModal?.hide()"
+        >
+          Cancel
+        </BButton>
+        <BButton variant="danger" :disabled="submittingEditCue || deletingCue" @click="deleteCue">
+          Delete
+        </BButton>
+        <BButton
+          variant="primary"
+          :disabled="v$.editFormState.$invalid || submittingEditCue || deletingCue"
+          @click="onSubmitEdit"
+        >
+          Save
+        </BButton>
+      </template>
+      <BForm @submit.stop.prevent="">
+        <BFormGroup label="Cue Type" label-for="edit-cue-type">
+          <BFormSelect
+            id="edit-cue-type"
+            v-model="v$.editFormState.cueType.$model"
+            :options="cueTypeOptions"
+            :state="editFieldState('cueType')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Identifier" label-for="edit-cue-ident">
+          <BFormInput
+            id="edit-cue-ident"
+            v-model="v$.editFormState.ident.$model"
+            :state="editFieldState('ident')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+          <BFormText v-if="isDuplicateEditCue" class="text-warning">
+            A cue with this identifier already exists for this cue type.
+          </BFormText>
+        </BFormGroup>
+      </BForm>
+    </BModal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { BModal } from 'bootstrap-vue-next';
+import { useVuelidate } from '@vuelidate/core';
+import { required } from '@vuelidate/validators';
+import { useScriptDisplay } from '@/composables/useScriptDisplay';
+import { useCueDisplay } from '@/composables/useCueDisplay';
+import { useScriptNavigation } from '@/composables/useScriptNavigation';
+import { useScriptStore } from '@/stores/script';
+import { useShowStore } from '@/stores/show';
+import { useSystemStore } from '@/stores/system';
+import { useUserStore } from '@/stores/user';
+import { useConfirm } from '@/composables/useConfirm';
+import { isWholeLineCut } from '@/js/scriptUtils';
+import { LINE_TYPES } from '@/constants/lineTypes';
+import type { ScriptLine } from '@/types/api/script';
+import type { Cue, CueType } from '@/types/api/cues';
+import type { Act, Scene, Character, CharacterGroup } from '@/types/api/show';
+
+const props = defineProps<{
+  line: ScriptLine;
+  lineIndex: number;
+  previousLine: ScriptLine | null;
+  acts: Act[];
+  scenes: Scene[];
+  characters: Character[];
+  characterGroups: CharacterGroup[];
+  cues: Cue[];
+  cueTypes: CueType[];
+  cuts: (number | null)[];
+}>();
+
+const scriptStore = useScriptStore();
+const showStore = useShowStore();
+const systemStore = useSystemStore();
+const userStore = useUserStore();
+const { confirm } = useConfirm();
+
+const { getStageDirectionStyle, stageDirectionStyling, scriptTextAlign } = useScriptDisplay();
+const { cueLabel, cueBackgroundColour, contrastColor } = useCueDisplay();
+const { needsHeadings, needsActSceneLabel } = useScriptNavigation();
+
+// Modal refs
+const newCueModal = ref<InstanceType<typeof BModal> | null>(null);
+const editCueModal = ref<InstanceType<typeof BModal> | null>(null);
+const lineContainer = ref<HTMLElement | null>(null);
+
+// Form state
+const newFormState = ref({
+  cueType: null as number | null,
+  ident: null as string | null,
+  lineId: null as number | null,
+});
+const editFormState = ref({
+  cueId: null as number | null,
+  cueType: null as number | null,
+  ident: null as string | null,
+  lineId: null as number | null,
+});
+const submittingNewCue = ref(false);
+const submittingEditCue = ref(false);
+const deletingCue = ref(false);
+
+const newRules = {
+  newFormState: {
+    cueType: { required },
+    ident: { required },
+    lineId: { required },
+  },
+};
+const editRules = {
+  editFormState: {
+    cueId: { required },
+    cueType: { required },
+    ident: { required },
+    lineId: { required },
+  },
+};
+const v$ = useVuelidate({ ...newRules, ...editRules }, { newFormState, editFormState });
+
+// Computed display values
+const sdStyle = computed(() =>
+  getStageDirectionStyle(
+    props.line,
+    scriptStore.stageDirectionStyles,
+    userStore.stageDirectionStyleOverrides
+  )
+);
+const sdStyling = computed(() => stageDirectionStyling(sdStyle.value));
+const textAlign = computed(() =>
+  scriptTextAlign(userStore.userSettings as Record<string, unknown>)
+);
+
+const needsHeadingsValue = computed(() =>
+  needsHeadings(props.line, props.previousLine, props.cuts, scriptStore.getScriptPage)
+);
+const needsHeadingsAnyValue = computed(() => needsHeadingsValue.value.some(Boolean));
+
+const needsActSceneLabelValue = computed(() =>
+  needsActSceneLabel(props.line, props.previousLine, props.cuts, scriptStore.getScriptPage)
+);
+
+const actLabel = computed(() => props.acts.find((a) => a.id === props.line.act_id)?.name ?? null);
+const sceneLabel = computed(
+  () => props.scenes.find((s) => s.id === props.line.scene_id)?.name ?? null
+);
+
+const isLineCut = computed(() => isWholeLineCut(props.line, props.cuts));
+
+// RBAC-filtered cue type options: admins see all, others only see types they can write
+const cueTypeOptions = computed(() => {
+  const base = [{ value: null, text: 'N/A' }];
+  if (systemStore.isAdminUser) {
+    return [
+      ...base,
+      ...props.cueTypes.map((t) => ({
+        value: t.id,
+        text: `${t.prefix}: ${t.description ?? ''}`,
+      })),
+    ];
+  }
+  const writeMask = systemStore.rbacRoles.find((r) => r.key === 'WRITE')?.value ?? 0;
+  const writableIds = new Set(
+    (userStore.currentRbac?.cuetypes ?? []).filter((x) => (x[1] & writeMask) !== 0).map((x) => x[0])
+  );
+  return [
+    ...base,
+    ...props.cueTypes
+      .filter((t) => writableIds.has(t.id))
+      .map((t) => ({ value: t.id, text: `${t.prefix}: ${t.description ?? ''}` })),
+  ];
+});
+
+// Duplicate detection across all cues
+const flatCues = computed(() => Object.values(scriptStore.cues).flat());
+
+const isDuplicateNewCue = computed(
+  () =>
+    newFormState.value.cueType != null &&
+    newFormState.value.ident != null &&
+    flatCues.value.some(
+      (c) => c.cue_type_id === newFormState.value.cueType && c.ident === newFormState.value.ident
+    )
+);
+
+const isDuplicateEditCue = computed(
+  () =>
+    editFormState.value.cueType != null &&
+    editFormState.value.ident != null &&
+    flatCues.value.some(
+      (c) =>
+        c.cue_type_id === editFormState.value.cueType &&
+        c.ident === editFormState.value.ident &&
+        c.id !== editFormState.value.cueId
+    )
+);
+
+function newFieldState(field: 'cueType' | 'ident'): boolean | null {
+  const f = v$.value.newFormState[field];
+  return f.$dirty ? !f.$error : null;
+}
+
+function editFieldState(field: 'cueType' | 'ident'): boolean | null {
+  const f = v$.value.editFormState[field];
+  return f.$dirty ? !f.$error : null;
+}
+
+// New cue modal
+function openNewForm(): void {
+  newFormState.value = { cueType: null, ident: null, lineId: props.line.id ?? null };
+  v$.value.newFormState.$reset();
+  newCueModal.value?.show();
+}
+
+function resetNewForm(): void {
+  newFormState.value = { cueType: null, ident: null, lineId: null };
+  submittingNewCue.value = false;
+  v$.value.newFormState.$reset();
+}
+
+async function onSubmitNew(event: Event): Promise<void> {
+  v$.value.newFormState.$touch();
+  if (v$.value.newFormState.$invalid || submittingNewCue.value) {
+    (event as SubmitEvent).preventDefault?.();
+    return;
+  }
+  submittingNewCue.value = true;
+  await scriptStore.addNewCue({
+    cueType: newFormState.value.cueType!,
+    ident: newFormState.value.ident!,
+    lineId: newFormState.value.lineId!,
+  });
+  newCueModal.value?.hide();
+  resetNewForm();
+}
+
+// Edit cue modal
+function openEditForm(cue: Cue): void {
+  editFormState.value = {
+    cueId: cue.id ?? null,
+    cueType: cue.cue_type_id ?? null,
+    ident: cue.ident ?? null,
+    lineId: props.line.id ?? null,
+  };
+  v$.value.editFormState.$reset();
+  editCueModal.value?.show();
+}
+
+function resetEditForm(): void {
+  editFormState.value = { cueId: null, cueType: null, ident: null, lineId: null };
+  submittingEditCue.value = false;
+  deletingCue.value = false;
+  v$.value.editFormState.$reset();
+}
+
+async function onSubmitEdit(event?: Event): Promise<void> {
+  v$.value.editFormState.$touch();
+  if (v$.value.editFormState.$invalid || submittingEditCue.value) {
+    (event as SubmitEvent | undefined)?.preventDefault?.();
+    return;
+  }
+  submittingEditCue.value = true;
+  await scriptStore.editCue({
+    cueId: editFormState.value.cueId!,
+    cueType: editFormState.value.cueType!,
+    ident: editFormState.value.ident!,
+    lineId: editFormState.value.lineId!,
+  });
+  editCueModal.value?.hide();
+  resetEditForm();
+}
+
+async function deleteCue(): Promise<void> {
+  const confirmed = await confirm('Are you sure you want to delete this cue?', {
+    title: 'Delete Cue',
+    okVariant: 'danger',
+    okTitle: 'Delete',
+  });
+  if (!confirmed) return;
+  deletingCue.value = true;
+  await scriptStore.deleteCue({
+    cueId: editFormState.value.cueId!,
+    lineId: editFormState.value.lineId!,
+  });
+  editCueModal.value?.hide();
+  resetEditForm();
+}
+</script>
+
+<style scoped>
+.viewable-line {
+  margin: 0;
+}
+
+.cue-column {
+  border-right: 0.1rem solid #3498db;
+  text-align: right;
+}
+
+.cue-button {
+  padding: 0.2rem;
+}
+
+.stage-direction {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.cut-line-part {
+  text-decoration: line-through;
+}
+</style>

--- a/client-v3/src/components/show/config/cues/ScriptLineCueEditor.vue
+++ b/client-v3/src/components/show/config/cues/ScriptLineCueEditor.vue
@@ -34,16 +34,16 @@
               >
                 {{ cueLabel(cue) }}
               </BButton>
+              <BButton
+                v-if="systemStore.isCueEditor"
+                variant="success"
+                class="cue-button add-cue-button"
+                :disabled="isLineCut"
+                @click.stop="openNewForm"
+              >
+                +
+              </BButton>
             </BButtonGroup>
-            <BButton
-              v-if="systemStore.isCueEditor"
-              variant="success"
-              class="cue-button ms-1"
-              :disabled="isLineCut"
-              @click.stop="openNewForm"
-            >
-              +
-            </BButton>
           </template>
         </BCol>
 
@@ -469,12 +469,21 @@ async function deleteCue(): Promise<void> {
 }
 
 .cue-column {
-  border-right: 0.1rem solid #3498db;
   text-align: right;
 }
 
 .cue-button {
   padding: 0.2rem;
+}
+
+.add-cue-button {
+  width: 1.6rem;
+  height: 1.6rem;
+  padding: 0;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .stage-direction {

--- a/client-v3/src/components/show/config/cues/ScriptLineCueEditor.vue
+++ b/client-v3/src/components/show/config/cues/ScriptLineCueEditor.vue
@@ -36,12 +36,21 @@
               </BButton>
               <BButton
                 v-if="systemStore.isCueEditor"
-                variant="success"
-                class="cue-button add-cue-button"
+                class="cue-button"
                 :disabled="isLineCut"
                 @click.stop="openNewForm"
               >
-                +
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="1em"
+                  height="1em"
+                  fill="#198754"
+                  viewBox="0 0 16 16"
+                >
+                  <path
+                    d="M2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2zm6.5 4.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3a.5.5 0 0 1 1 0z"
+                  />
+                </svg>
               </BButton>
             </BButtonGroup>
           </template>
@@ -474,16 +483,6 @@ async function deleteCue(): Promise<void> {
 
 .cue-button {
   padding: 0.2rem;
-}
-
-.add-cue-button {
-  width: 1.6rem;
-  height: 1.6rem;
-  padding: 0;
-  line-height: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
 }
 
 .stage-direction {

--- a/client-v3/src/components/show/config/cues/ScriptLineCueEditor.vue
+++ b/client-v3/src/components/show/config/cues/ScriptLineCueEditor.vue
@@ -44,7 +44,7 @@
                   xmlns="http://www.w3.org/2000/svg"
                   width="1em"
                   height="1em"
-                  fill="#198754"
+                  fill="#06BC8C"
                   viewBox="0 0 16 16"
                 >
                   <path

--- a/client-v3/src/components/show/config/mics/MicList.vue
+++ b/client-v3/src/components/show/config/mics/MicList.vue
@@ -15,7 +15,7 @@
               variant="outline-success"
               @click="newModal?.show()"
             >
-              Add Microphone
+              New Microphone
             </BButton>
           </template>
           <template #cell(btn)="data">

--- a/client-v3/src/components/show/config/script/ScriptRevisions.vue
+++ b/client-v3/src/components/show/config/script/ScriptRevisions.vue
@@ -5,7 +5,32 @@
         <div class="d-flex justify-content-between align-items-center">
           <h6 class="mb-0">Revision Branch Graph</h6>
           <BButton size="sm" variant="secondary" @click="graphCollapsed = !graphCollapsed">
-            {{ graphCollapsed ? '▼' : '▲' }}
+            <svg
+              v-if="!graphCollapsed"
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              fill="currentColor"
+              viewBox="0 0 16 16"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M7.646 4.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1-.708.708L8 5.707l-5.646 5.647a.5.5 0 0 1-.708-.708l6-6z"
+              />
+            </svg>
+            <svg
+              v-else
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              fill="currentColor"
+              viewBox="0 0 16 16"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"
+              />
+            </svg>
           </BButton>
         </div>
       </template>
@@ -21,10 +46,20 @@
 
     <BTable :items="showStore.scriptRevisions" :fields="revisionColumns" show-empty>
       <template #cell(current)="data">
-        <span v-if="data.item.id === showStore.currentRevision" class="text-success">✓</span>
+        <svg
+          v-if="data.item.id === showStore.currentRevision"
+          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
+          height="1em"
+          fill="#06BC8C"
+          viewBox="0 0 16 16"
+        >
+          <path
+            d="M2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2zm10.03 4.97a.75.75 0 0 1 .011 1.05l-3.992 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425a.75.75 0 0 1 1.079-.022z"
+          />
+        </svg>
         <BButton
           v-else-if="systemStore.isScriptEditor"
-          size="sm"
           variant="warning"
           :disabled="
             !canChangeRevisions ||
@@ -49,8 +84,19 @@
       <template #cell(btn)="data">
         <BButtonGroup v-if="systemStore.isScriptEditor && data.item.revision !== 1">
           <BButton
+            variant="warning"
+            :disabled="
+              !canChangeRevisions ||
+              submittingLoadRevision ||
+              submittingNewRevision ||
+              deletingRevision
+            "
+            @click="handleModalCreateFrom(data.item)"
+          >
+            Edit
+          </BButton>
+          <BButton
             variant="danger"
-            size="sm"
             :disabled="
               !canChangeRevisions ||
               submittingLoadRevision ||

--- a/client-v3/src/components/show/config/sessions/SessionTagDropdown.vue
+++ b/client-v3/src/components/show/config/sessions/SessionTagDropdown.vue
@@ -1,7 +1,17 @@
 <template>
   <BDropdown variant="link" size="sm" no-caret toggle-class="p-0 ms-2 edit-tags-btn">
     <template #button-content>
-      <span>✏️</span>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="1em"
+        height="1em"
+        fill="currentColor"
+        viewBox="0 0 16 16"
+      >
+        <path
+          d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168l10-10zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207 11.207 2.5zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293l6.5-6.5zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z"
+        />
+      </svg>
     </template>
 
     <BDropdownForm class="tag-dropdown-form" @click.stop>

--- a/client-v3/src/components/show/config/stage/CrewList.vue
+++ b/client-v3/src/components/show/config/stage/CrewList.vue
@@ -15,7 +15,7 @@
               variant="outline-success"
               @click="newModal?.show()"
             >
-              Add Crew Member
+              New Crew Member
             </BButton>
           </template>
           <template #cell(btn)="data">

--- a/client-v3/src/components/show/live/ScriptLineViewer.vue
+++ b/client-v3/src/components/show/live/ScriptLineViewer.vue
@@ -142,6 +142,7 @@
               </BButton>
               <BButton
                 v-if="cueAddMode"
+                variant="success"
                 class="cue-button"
                 :disabled="isLineCut"
                 @click.stop="addNewCue"
@@ -167,6 +168,7 @@
               </BButton>
               <BButton
                 v-if="cueAddMode"
+                variant="success"
                 class="cue-button"
                 :disabled="isLineCut"
                 @click.stop="addNewCue"

--- a/client-v3/src/components/show/live/ScriptLineViewer.vue
+++ b/client-v3/src/components/show/live/ScriptLineViewer.vue
@@ -1,0 +1,467 @@
+<template>
+  <div
+    ref="lineContainer"
+    style="margin: 0; padding: 0"
+    :style="{ paddingTop: spacingBefore + 'rem', '--spacing-before': spacingBefore + 'rem' }"
+  >
+    <BContainer v-once fluid class="mx-0" style="margin: 0; padding: 0">
+      <BRow v-if="needsIntervalBanner" class="interval-header">
+        <template v-if="cuePositionRight">
+          <BCol cols="9" class="interval-banner">
+            <BAlert variant="warning" style="margin: 0">
+              <h3>{{ previousActLabel }} - Interval</h3>
+            </BAlert>
+          </BCol>
+          <BCol
+            cols="3"
+            :class="[
+              'cue-column-right',
+              'd-flex',
+              'align-items-center',
+              'justify-content-center',
+              { 'first-row': isFirstRowIntervalBanner },
+            ]"
+          >
+            <BButton v-if="isScriptLeader" variant="primary" @click.stop="startInterval">
+              Start Interval
+            </BButton>
+          </BCol>
+        </template>
+        <template v-else>
+          <BCol
+            cols="3"
+            :class="[
+              'cue-column',
+              'd-flex',
+              'align-items-center',
+              'justify-content-center',
+              { 'first-row': isFirstRowIntervalBanner },
+            ]"
+          >
+            <BButton v-if="isScriptLeader" variant="primary" @click.stop="startInterval">
+              Start Interval
+            </BButton>
+          </BCol>
+          <BCol cols="9" class="interval-banner">
+            <BAlert variant="warning" style="margin: 0">
+              <h3>{{ previousActLabel }} - Interval</h3>
+            </BAlert>
+          </BCol>
+        </template>
+      </BRow>
+      <BRow v-if="needsActSceneLabel" class="act-scene-header">
+        <template v-if="cuePositionRight">
+          <BCol cols="9">
+            <h4>{{ actLabel }} - {{ sceneLabel }}</h4>
+          </BCol>
+          <BCol cols="3" :class="['cue-column-right', { 'first-row': isFirstRowActScene }]" />
+        </template>
+        <template v-else>
+          <BCol cols="3" :class="['cue-column', { 'first-row': isFirstRowActScene }]" />
+          <BCol cols="9">
+            <h4>{{ actLabel }} - {{ sceneLabel }}</h4>
+          </BCol>
+        </template>
+      </BRow>
+      <BRow
+        :class="{
+          'stage-direction': line.line_type === LINE_TYPES.STAGE_DIRECTION,
+          'heading-padding': line.line_type === LINE_TYPES.DIALOGUE && needsHeadingsAll,
+        }"
+      >
+        <template v-if="cuePositionRight">
+          <template v-if="line.line_type === LINE_TYPES.DIALOGUE">
+            <BCol>
+              <BRow v-if="needsHeadingsAny">
+                <BCol
+                  v-for="(part, index) in line.line_parts"
+                  :key="`heading_${lineIndex}_part_${index}`"
+                  :style="headingStyle"
+                >
+                  <template v-if="needsHeadings[index]">
+                    <b>
+                      <template v-if="part.character_id != null">
+                        {{ characters.find((c) => c.id === part.character_id)?.name }}
+                      </template>
+                      <template v-else>
+                        {{ characterGroups.find((g) => g.id === part.character_group_id)?.name }}
+                      </template>
+                    </b>
+                  </template>
+                  <b v-else>&nbsp;</b>
+                </BCol>
+              </BRow>
+              <BRow>
+                <BCol
+                  v-for="(part, index) in line.line_parts"
+                  :key="`line_${lineIndex}_part_${index}`"
+                  :style="dialogueStyle"
+                >
+                  <p class="viewable-line" :class="{ 'cut-line-part': cuts.includes(part.id) }">
+                    {{ part.line_text }}
+                  </p>
+                </BCol>
+              </BRow>
+            </BCol>
+          </template>
+          <template v-else-if="line.line_type === LINE_TYPES.STAGE_DIRECTION">
+            <BCol :style="{ textAlign: scriptTextAlign }">
+              <BRow v-if="isTaggedStageDirection && needsHeadingsAny" style="margin-bottom: 1rem">
+                <BCol :style="headingStyle">
+                  <b>{{ taggedStageDirectionHeadingName }}</b>
+                </BCol>
+              </BRow>
+              <i class="viewable-line" :style="stageDirectionStylingObj">
+                <template v-if="stageDirectionStyle?.text_format === 'upper'">
+                  {{ line.line_parts[0]?.line_text?.toUpperCase() }}
+                </template>
+                <template v-else-if="stageDirectionStyle?.text_format === 'lower'">
+                  {{ line.line_parts[0]?.line_text?.toLowerCase() }}
+                </template>
+                <template v-else>
+                  {{ line.line_parts[0]?.line_text }}
+                </template>
+              </i>
+            </BCol>
+          </template>
+          <template v-else-if="line.line_type === LINE_TYPES.CUE_LINE">
+            <BCol :style="dialogueStyle" />
+          </template>
+          <BCol cols="3" :class="['cue-column-right', { 'first-row': isFirstRowContent }]">
+            <BButtonGroup>
+              <BButton
+                v-for="cue in cues"
+                :key="cue.id"
+                class="cue-button"
+                :style="{
+                  backgroundColor: cueBackgroundColour(cue),
+                  color: contrastColor({ bgColor: cueBackgroundColour(cue) }),
+                }"
+              >
+                {{ cueLabel(cue) }}
+              </BButton>
+              <BButton
+                v-if="cueAddMode"
+                class="cue-button"
+                :disabled="isLineCut"
+                @click.stop="addNewCue"
+              >
+                +
+              </BButton>
+            </BButtonGroup>
+          </BCol>
+        </template>
+        <template v-else>
+          <BCol cols="3" :class="['cue-column', { 'first-row': isFirstRowContent }]">
+            <BButtonGroup>
+              <BButton
+                v-for="cue in cues"
+                :key="cue.id"
+                class="cue-button"
+                :style="{
+                  backgroundColor: cueBackgroundColour(cue),
+                  color: contrastColor({ bgColor: cueBackgroundColour(cue) }),
+                }"
+              >
+                {{ cueLabel(cue) }}
+              </BButton>
+              <BButton
+                v-if="cueAddMode"
+                class="cue-button"
+                :disabled="isLineCut"
+                @click.stop="addNewCue"
+              >
+                +
+              </BButton>
+            </BButtonGroup>
+          </BCol>
+          <template v-if="line.line_type === LINE_TYPES.DIALOGUE">
+            <BCol>
+              <BRow v-if="needsHeadingsAny">
+                <BCol
+                  v-for="(part, index) in line.line_parts"
+                  :key="`heading_${lineIndex}_part_${index}`"
+                  :style="headingStyle"
+                >
+                  <template v-if="needsHeadings[index]">
+                    <b>
+                      <template v-if="part.character_id != null">
+                        {{ characters.find((c) => c.id === part.character_id)?.name }}
+                      </template>
+                      <template v-else>
+                        {{ characterGroups.find((g) => g.id === part.character_group_id)?.name }}
+                      </template>
+                    </b>
+                  </template>
+                  <b v-else>&nbsp;</b>
+                </BCol>
+              </BRow>
+              <BRow>
+                <BCol
+                  v-for="(part, index) in line.line_parts"
+                  :key="`line_${lineIndex}_part_${index}`"
+                  :style="dialogueStyle"
+                >
+                  <p class="viewable-line" :class="{ 'cut-line-part': cuts.includes(part.id) }">
+                    {{ part.line_text }}
+                  </p>
+                </BCol>
+              </BRow>
+            </BCol>
+          </template>
+          <template v-else-if="line.line_type === LINE_TYPES.STAGE_DIRECTION">
+            <BCol :style="{ textAlign: scriptTextAlign }">
+              <BRow v-if="isTaggedStageDirection && needsHeadingsAny" style="margin-bottom: 1rem">
+                <BCol :style="headingStyle">
+                  <b>{{ taggedStageDirectionHeadingName }}</b>
+                </BCol>
+              </BRow>
+              <i class="viewable-line" :style="stageDirectionStylingObj">
+                <template v-if="stageDirectionStyle?.text_format === 'upper'">
+                  {{ line.line_parts[0]?.line_text?.toUpperCase() }}
+                </template>
+                <template v-else-if="stageDirectionStyle?.text_format === 'lower'">
+                  {{ line.line_parts[0]?.line_text?.toLowerCase() }}
+                </template>
+                <template v-else>
+                  {{ line.line_parts[0]?.line_text }}
+                </template>
+              </i>
+            </BCol>
+          </template>
+          <template v-else-if="line.line_type === LINE_TYPES.CUE_LINE">
+            <BCol :style="dialogueStyle" />
+          </template>
+        </template>
+      </BRow>
+    </BContainer>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { useScriptNavigation } from '@/composables/useScriptNavigation';
+import { useScriptDisplay } from '@/composables/useScriptDisplay';
+import { useCueDisplay } from '@/composables/useCueDisplay';
+import { useUserStore } from '@/stores/user';
+import { useScriptStore } from '@/stores/script';
+import { isWholeLineCut } from '@/js/scriptUtils';
+import { LINE_TYPES } from '@/constants/lineTypes';
+import type { ScriptLine, ScriptCut, StageDirectionStyle } from '@/types/api/script';
+import type { Act, Scene, Character, CharacterGroup } from '@/types/api/show';
+import type { Cue, CueType } from '@/types/api/cues';
+
+const props = defineProps<{
+  line: ScriptLine;
+  lineIndex: number;
+  previousLine: ScriptLine | null;
+  previousLineIndex: number | null;
+  acts: Act[];
+  scenes: Scene[];
+  characters: Character[];
+  characterGroups: CharacterGroup[];
+  cueTypes: CueType[];
+  cues: Cue[];
+  cuts: ScriptCut[];
+  stageDirectionStyles: StageDirectionStyle[];
+  stageDirectionStyleOverrides: StageDirectionStyle[];
+  isScriptLeader: boolean;
+  cueAddMode: boolean;
+  spacingBefore?: number;
+}>();
+
+const emit = defineEmits<{
+  'last-line-change': [page: number, lineIndex: number];
+  'first-line-change': [page: number, lineIndex: number, previousLineRef: string | null];
+  'start-interval': [actId: number];
+  'add-cue': [lineId: number];
+}>();
+
+const userStore = useUserStore();
+const scriptStore = useScriptStore();
+const { needsHeadings: computeNeedsHeadings, needsActSceneLabel: computeNeedsActSceneLabel } =
+  useScriptNavigation();
+const {
+  getStageDirectionStyle,
+  stageDirectionStyling: computeStyling,
+  scriptTextAlign: computeTextAlign,
+} = useScriptDisplay();
+const { cueLabel, cueBackgroundColour, contrastColor } = useCueDisplay();
+
+const lineContainer = ref<HTMLElement | null>(null);
+let observer: MutationObserver | null = null;
+
+const cuePositionRight = computed(() => userStore.userSettings?.cue_position_right ?? true);
+
+const needsHeadings = computed(() =>
+  computeNeedsHeadings(props.line, props.previousLine, props.cuts, scriptStore.getScriptPage)
+);
+const needsHeadingsAny = computed(() => needsHeadings.value.some(Boolean));
+const needsHeadingsAll = computed(() => needsHeadings.value.every(Boolean));
+
+const needsActSceneLabel = computed(() =>
+  computeNeedsActSceneLabel(props.line, props.previousLine, props.cuts, scriptStore.getScriptPage)
+);
+
+const needsIntervalBanner = computed(() => {
+  let prev: ScriptLine | null = props.previousLine;
+  while (prev != null && isWholeLineCut(prev, props.cuts)) {
+    const prevPage = scriptStore.getScriptPage(prev.page ?? 0);
+    const idx = prevPage.indexOf(prev);
+    prev = idx > 0 ? prevPage[idx - 1] : null;
+  }
+  if (prev == null || prev.act_id === props.line.act_id) return false;
+  const prevAct = props.acts.find((a) => a.id === prev!.act_id);
+  return prevAct?.interval_after === true;
+});
+
+const previousActLabel = computed(
+  () => props.acts.find((a) => a.id === props.previousLine?.act_id)?.name ?? null
+);
+const actLabel = computed(() => props.acts.find((a) => a.id === props.line.act_id)?.name ?? null);
+const sceneLabel = computed(
+  () => props.scenes.find((s) => s.id === props.line.scene_id)?.name ?? null
+);
+
+const stageDirectionStyle = computed(() =>
+  getStageDirectionStyle(props.line, props.stageDirectionStyles, props.stageDirectionStyleOverrides)
+);
+const stageDirectionStylingObj = computed(() => computeStyling(stageDirectionStyle.value));
+
+const scriptTextAlign = computed(() => computeTextAlign(userStore.userSettings));
+const headingStyle = computed(() => ({ textAlign: scriptTextAlign.value }));
+const dialogueStyle = computed(() => ({ textAlign: scriptTextAlign.value }));
+
+const isTaggedStageDirection = computed(() => {
+  const part = props.line.line_parts?.[0];
+  return (
+    props.line.line_type === LINE_TYPES.STAGE_DIRECTION &&
+    (part?.character_id != null || part?.character_group_id != null)
+  );
+});
+const taggedStageDirectionHeadingName = computed(() => {
+  const part = props.line.line_parts?.[0];
+  if (!part) return '';
+  if (part.character_id != null) {
+    return props.characters.find((c) => c.id === part.character_id)?.name ?? '';
+  }
+  return props.characterGroups.find((g) => g.id === part.character_group_id)?.name ?? '';
+});
+
+const isLineCut = computed(() => isWholeLineCut(props.line, props.cuts));
+const isFirstRowIntervalBanner = computed(() => needsIntervalBanner.value);
+const isFirstRowActScene = computed(() => !needsIntervalBanner.value && needsActSceneLabel.value);
+const isFirstRowContent = computed(() => !needsIntervalBanner.value && !needsActSceneLabel.value);
+
+function addNewCue(): void {
+  emit('add-cue', props.line.id);
+}
+
+function startInterval(): void {
+  if (!props.previousLine) return;
+  const actId = props.acts.find((a) => a.id === props.previousLine!.act_id)?.id;
+  if (actId != null) emit('start-interval', actId);
+}
+
+function onClassChange(classAttrValue: string | null, oldClassAttrValue: string | null): void {
+  const classList = classAttrValue?.split(' ') ?? [];
+  const oldClassList = oldClassAttrValue?.split(' ') ?? [];
+  if (classList.includes('last-script-element') && !oldClassList.includes('last-script-element')) {
+    emit('last-line-change', props.line.page ?? 0, props.lineIndex);
+  }
+  if (
+    classList.includes('first-script-element') &&
+    !oldClassList.includes('first-script-element')
+  ) {
+    const prev = props.previousLine;
+    const prevRef = prev != null ? `page_${prev.page}_line_${props.previousLineIndex}` : null;
+    emit('first-line-change', props.line.page ?? 0, props.lineIndex, prevRef);
+  }
+}
+
+onMounted(() => {
+  if (lineContainer.value) {
+    observer = new MutationObserver((mutations) => {
+      for (const m of mutations) {
+        const newValue = (m.target as Element).getAttribute(m.attributeName!);
+        onClassChange(newValue, m.oldValue);
+      }
+    });
+    observer.observe(lineContainer.value, {
+      attributes: true,
+      attributeOldValue: true,
+      attributeFilter: ['class'],
+    });
+  }
+});
+
+onUnmounted(() => {
+  observer?.disconnect();
+});
+</script>
+
+<style scoped>
+.cue-column {
+  border-right: 0.1rem solid #3498db;
+  margin-top: -1rem;
+  margin-bottom: -1rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.cue-column.first-row {
+  margin-top: calc(-1rem - var(--spacing-before, 0rem));
+  padding-top: calc(1rem + var(--spacing-before, 0rem));
+}
+
+.cue-column-right {
+  border-left: 0.1rem solid #3498db;
+  margin-top: -1rem;
+  margin-bottom: -1rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.cue-column-right.first-row {
+  margin-top: calc(-1rem - var(--spacing-before, 0rem));
+  padding-top: calc(1rem + var(--spacing-before, 0rem));
+}
+
+.interval-banner {
+  margin-top: -1rem;
+  margin-bottom: -1rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.cue-button {
+  padding: 0.2rem;
+}
+
+.stage-direction {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.heading-padding {
+  margin-top: 0.5rem;
+}
+
+.cut-line-part {
+  text-decoration: line-through;
+}
+
+.current-line {
+  background: #3498db54;
+}
+
+.interval-header,
+.act-scene-header {
+  background: var(--bs-body-bg);
+}
+
+.interval-header {
+  margin-top: 1rem;
+  padding-bottom: 1rem;
+}
+</style>

--- a/client-v3/src/components/show/live/ScriptLineViewer.vue
+++ b/client-v3/src/components/show/live/ScriptLineViewer.vue
@@ -140,16 +140,16 @@
               >
                 {{ cueLabel(cue) }}
               </BButton>
-              <BButton
-                v-if="cueAddMode"
-                variant="success"
-                class="cue-button"
-                :disabled="isLineCut"
-                @click.stop="addNewCue"
-              >
-                +
-              </BButton>
             </BButtonGroup>
+            <BButton
+              v-if="cueAddMode"
+              variant="success"
+              class="cue-button ms-1"
+              :disabled="isLineCut"
+              @click.stop="addNewCue"
+            >
+              +
+            </BButton>
           </BCol>
         </template>
         <template v-else>
@@ -166,16 +166,16 @@
               >
                 {{ cueLabel(cue) }}
               </BButton>
-              <BButton
-                v-if="cueAddMode"
-                variant="success"
-                class="cue-button"
-                :disabled="isLineCut"
-                @click.stop="addNewCue"
-              >
-                +
-              </BButton>
             </BButtonGroup>
+            <BButton
+              v-if="cueAddMode"
+              variant="success"
+              class="cue-button ms-1"
+              :disabled="isLineCut"
+              @click.stop="addNewCue"
+            >
+              +
+            </BButton>
           </BCol>
           <template v-if="line.line_type === LINE_TYPES.DIALOGUE">
             <BCol>
@@ -293,7 +293,7 @@ const { cueLabel, cueBackgroundColour, contrastColor } = useCueDisplay();
 const lineContainer = ref<HTMLElement | null>(null);
 let observer: MutationObserver | null = null;
 
-const cuePositionRight = computed(() => userStore.userSettings?.cue_position_right ?? true);
+const cuePositionRight = computed(() => userStore.userSettings?.cue_position_right ?? false);
 
 const needsHeadings = computed(() =>
   computeNeedsHeadings(props.line, props.previousLine, props.cuts, scriptStore.getScriptPage)
@@ -312,9 +312,8 @@ const needsIntervalBanner = computed(() => {
     const idx = prevPage.indexOf(prev);
     prev = idx > 0 ? prevPage[idx - 1] : null;
   }
-  if (prev == null || prev.act_id === props.line.act_id) return false;
-  const prevAct = props.acts.find((a) => a.id === prev!.act_id);
-  return prevAct?.interval_after === true;
+  if (prev == null) return false;
+  return prev.act_id !== props.line.act_id;
 });
 
 const previousActLabel = computed(

--- a/client-v3/src/components/show/live/ScriptLineViewer.vue
+++ b/client-v3/src/components/show/live/ScriptLineViewer.vue
@@ -135,7 +135,7 @@
                 class="cue-button"
                 :style="{
                   backgroundColor: cueBackgroundColour(cue),
-                  color: contrastColor({ bgColor: cueBackgroundColour(cue) }),
+                  color: contrastColor(cueBackgroundColour(cue)),
                 }"
               >
                 {{ cueLabel(cue) }}
@@ -160,7 +160,7 @@
                 class="cue-button"
                 :style="{
                   backgroundColor: cueBackgroundColour(cue),
-                  color: contrastColor({ bgColor: cueBackgroundColour(cue) }),
+                  color: contrastColor(cueBackgroundColour(cue)),
                 }"
               >
                 {{ cueLabel(cue) }}

--- a/client-v3/src/components/show/live/ScriptLineViewerCompact.vue
+++ b/client-v3/src/components/show/live/ScriptLineViewerCompact.vue
@@ -1,0 +1,340 @@
+<template>
+  <div
+    ref="lineContainer"
+    style="margin: 0; padding: 0"
+    :style="{ paddingTop: spacingBefore + 'rem', '--spacing-before': spacingBefore + 'rem' }"
+  >
+    <BContainer v-once fluid class="mx-0" style="margin: 0; padding: 0">
+      <BRow v-if="needsIntervalBanner" class="interval-header">
+        <BCol cols="12" class="interval-banner">
+          <BAlert variant="warning" style="margin: 0">
+            <h3>{{ previousActLabel }} - Interval</h3>
+          </BAlert>
+        </BCol>
+        <BCol
+          v-if="isScriptLeader"
+          cols="12"
+          class="d-flex align-items-center justify-content-center"
+          style="padding-top: 0.5rem; padding-bottom: 0.5rem"
+        >
+          <BButton variant="primary" @click.stop="startInterval">Start Interval</BButton>
+        </BCol>
+      </BRow>
+      <BRow v-if="needsActSceneLabel" class="act-scene">
+        <BCol
+          cols="2"
+          :class="['cue-column', 'text-end', 'fw-bold', 'cue', { 'first-row': isFirstRowActScene }]"
+        >
+          <span>{{ actLabel }}</span>
+        </BCol>
+        <BCol :cols="cueAddMode ? 9 : 10" class="line-part text-start fw-bold cue">
+          <span>{{ sceneLabel }}</span>
+        </BCol>
+        <BCol v-if="cueAddMode" cols="1" class="cue-add-column" />
+      </BRow>
+      <BRow v-for="(cue, cueIndex) in cues" :key="`cue_${cue.id}`">
+        <BCol
+          cols="2"
+          :class="[
+            'cue-column',
+            'line-part',
+            'text-end',
+            'fw-bold',
+            'cue',
+            { 'first-row': isFirstRowCues && cueIndex === 0 },
+          ]"
+          :style="{ color: cueBackgroundColour(cue) }"
+        >
+          <span>{{ cuePrefix(cue) }}</span>
+        </BCol>
+        <BCol
+          :cols="cueAddMode ? 9 : 10"
+          class="line-part text-start fw-bold cue"
+          :style="{ color: cueBackgroundColour(cue) }"
+        >
+          <span>{{ cue.ident }}</span>
+        </BCol>
+        <BCol v-if="cueAddMode" cols="1" class="cue-add-column" />
+      </BRow>
+      <BRow>
+        <template v-if="line.line_type === LINE_TYPES.DIALOGUE">
+          <template v-for="(part, index) in line.line_parts" :key="`part_${lineIndex}_${index}`">
+            <BCol
+              cols="2"
+              class="cue-column line-part text-end"
+              :class="{
+                'cut-line-part': cuts.includes(part.id),
+                'line-part-a': lineIndex % 2 === 0,
+                'line-part-b': lineIndex % 2 === 1,
+                'first-row': isFirstRowContent && index === 0,
+              }"
+            >
+              <p v-if="needsHeadings[index]">{{ characterOrGroupName(part) }}</p>
+            </BCol>
+            <BCol
+              :cols="cueAddMode ? 9 : 10"
+              class="line-part text-start"
+              :class="{
+                'cut-line-part': cuts.includes(part.id),
+                'line-part-a': lineIndex % 2 === 0,
+                'line-part-b': lineIndex % 2 === 1,
+              }"
+            >
+              <p class="viewable-line">{{ part.line_text }}</p>
+            </BCol>
+          </template>
+          <BCol
+            v-if="cueAddMode && !isLineCut"
+            cols="1"
+            class="cue-add-column d-flex align-items-center justify-content-center"
+          >
+            <BButton variant="success" size="sm" @click.stop="addNewCue">+</BButton>
+          </BCol>
+        </template>
+        <template v-else-if="line.line_type === LINE_TYPES.STAGE_DIRECTION">
+          <BCol cols="2" class="cue-column line-part text-end">
+            <p v-if="isTaggedStageDirection">{{ characterOrGroupName(line.line_parts[0]) }}</p>
+          </BCol>
+          <BCol :cols="cueAddMode ? 9 : 10" class="line-part text-start">
+            <i class="viewable-line" :style="stageDirectionStylingObj">
+              <template v-if="stageDirectionStyle?.text_format === 'upper'">
+                {{ line.line_parts[0]?.line_text?.toUpperCase() }}
+              </template>
+              <template v-else-if="stageDirectionStyle?.text_format === 'lower'">
+                {{ line.line_parts[0]?.line_text?.toLowerCase() }}
+              </template>
+              <template v-else>
+                {{ line.line_parts[0]?.line_text }}
+              </template>
+            </i>
+          </BCol>
+          <BCol
+            v-if="cueAddMode"
+            cols="1"
+            class="cue-add-column d-flex align-items-center justify-content-center"
+          >
+            <BButton variant="success" size="sm" @click.stop="addNewCue">+</BButton>
+          </BCol>
+        </template>
+        <template v-else-if="line.line_type === LINE_TYPES.CUE_LINE">
+          <BCol cols="2" class="cue-column" />
+          <BCol :cols="cueAddMode ? 9 : 10" class="line-part text-start" />
+          <BCol
+            v-if="cueAddMode"
+            cols="1"
+            class="cue-add-column d-flex align-items-center justify-content-center"
+          >
+            <BButton variant="success" size="sm" @click.stop="addNewCue">+</BButton>
+          </BCol>
+        </template>
+      </BRow>
+    </BContainer>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { useScriptNavigation } from '@/composables/useScriptNavigation';
+import { useScriptDisplay } from '@/composables/useScriptDisplay';
+import { useCueDisplay } from '@/composables/useCueDisplay';
+import { useScriptStore } from '@/stores/script';
+import { isWholeLineCut } from '@/js/scriptUtils';
+import { LINE_TYPES } from '@/constants/lineTypes';
+import type { ScriptLine, ScriptCut, StageDirectionStyle } from '@/types/api/script';
+import type { Act, Scene, Character, CharacterGroup } from '@/types/api/show';
+import type { Cue, CueType } from '@/types/api/cues';
+
+const props = defineProps<{
+  line: ScriptLine;
+  lineIndex: number;
+  previousLine: ScriptLine | null;
+  previousLineIndex: number | null;
+  acts: Act[];
+  scenes: Scene[];
+  characters: Character[];
+  characterGroups: CharacterGroup[];
+  cueTypes: CueType[];
+  cues: Cue[];
+  cuts: ScriptCut[];
+  stageDirectionStyles: StageDirectionStyle[];
+  stageDirectionStyleOverrides: StageDirectionStyle[];
+  isScriptLeader: boolean;
+  cueAddMode: boolean;
+  spacingBefore?: number;
+}>();
+
+const emit = defineEmits<{
+  'last-line-change': [page: number, lineIndex: number];
+  'first-line-change': [page: number, lineIndex: number, previousLineRef: string | null];
+  'start-interval': [actId: number];
+  'add-cue': [lineId: number];
+}>();
+
+const scriptStore = useScriptStore();
+const { needsHeadings: computeNeedsHeadings, needsActSceneLabel: computeNeedsActSceneLabel } =
+  useScriptNavigation();
+const { getStageDirectionStyle, stageDirectionStyling: computeStyling } = useScriptDisplay();
+const { cuePrefix, cueBackgroundColour } = useCueDisplay();
+
+const lineContainer = ref<HTMLElement | null>(null);
+let observer: MutationObserver | null = null;
+
+const needsHeadings = computed(() =>
+  computeNeedsHeadings(props.line, props.previousLine, props.cuts, scriptStore.getScriptPage)
+);
+
+const needsActSceneLabel = computed(() =>
+  computeNeedsActSceneLabel(props.line, props.previousLine, props.cuts, scriptStore.getScriptPage)
+);
+
+const needsIntervalBanner = computed(() => {
+  let prev: ScriptLine | null = props.previousLine;
+  while (prev != null && isWholeLineCut(prev, props.cuts)) {
+    const prevPage = scriptStore.getScriptPage(prev.page ?? 0);
+    const idx = prevPage.indexOf(prev);
+    prev = idx > 0 ? prevPage[idx - 1] : null;
+  }
+  if (prev == null || prev.act_id === props.line.act_id) return false;
+  const prevAct = props.acts.find((a) => a.id === prev!.act_id);
+  return prevAct?.interval_after === true;
+});
+
+const previousActLabel = computed(
+  () => props.acts.find((a) => a.id === props.previousLine?.act_id)?.name ?? null
+);
+const actLabel = computed(() => props.acts.find((a) => a.id === props.line.act_id)?.name ?? null);
+const sceneLabel = computed(
+  () => props.scenes.find((s) => s.id === props.line.scene_id)?.name ?? null
+);
+
+const stageDirectionStyle = computed(() =>
+  getStageDirectionStyle(props.line, props.stageDirectionStyles, props.stageDirectionStyleOverrides)
+);
+const stageDirectionStylingObj = computed(() => computeStyling(stageDirectionStyle.value));
+
+const isTaggedStageDirection = computed(() => {
+  const part = props.line.line_parts?.[0];
+  return (
+    props.line.line_type === LINE_TYPES.STAGE_DIRECTION &&
+    (part?.character_id != null || part?.character_group_id != null)
+  );
+});
+
+const isLineCut = computed(() => isWholeLineCut(props.line, props.cuts));
+const isFirstRowActScene = computed(() => needsActSceneLabel.value);
+const isFirstRowCues = computed(() => !needsActSceneLabel.value && props.cues.length > 0);
+const isFirstRowContent = computed(() => !needsActSceneLabel.value && props.cues.length === 0);
+
+function characterOrGroupName(part: ScriptLine['line_parts'][number]): string {
+  if (part.character_id != null) {
+    return props.characters.find((c) => c.id === part.character_id)?.name ?? '';
+  }
+  return props.characterGroups.find((g) => g.id === part.character_group_id)?.name ?? '';
+}
+
+function addNewCue(): void {
+  emit('add-cue', props.line.id);
+}
+
+function startInterval(): void {
+  if (!props.previousLine) return;
+  const actId = props.acts.find((a) => a.id === props.previousLine!.act_id)?.id;
+  if (actId != null) emit('start-interval', actId);
+}
+
+function onClassChange(classAttrValue: string | null, oldClassAttrValue: string | null): void {
+  const classList = classAttrValue?.split(' ') ?? [];
+  const oldClassList = oldClassAttrValue?.split(' ') ?? [];
+  if (classList.includes('last-script-element') && !oldClassList.includes('last-script-element')) {
+    emit('last-line-change', props.line.page ?? 0, props.lineIndex);
+  }
+  if (
+    classList.includes('first-script-element') &&
+    !oldClassList.includes('first-script-element')
+  ) {
+    const prev = props.previousLine;
+    const prevRef = prev != null ? `page_${prev.page}_line_${props.previousLineIndex}` : null;
+    emit('first-line-change', props.line.page ?? 0, props.lineIndex, prevRef);
+  }
+}
+
+onMounted(() => {
+  if (lineContainer.value) {
+    observer = new MutationObserver((mutations) => {
+      for (const m of mutations) {
+        const newValue = (m.target as Element).getAttribute(m.attributeName!);
+        onClassChange(newValue, m.oldValue);
+      }
+    });
+    observer.observe(lineContainer.value, {
+      attributes: true,
+      attributeOldValue: true,
+      attributeFilter: ['class'],
+    });
+  }
+});
+
+onUnmounted(() => {
+  observer?.disconnect();
+});
+</script>
+
+<style scoped>
+.cue-column {
+  border-right: 0.1rem solid #3498db;
+  margin-top: -1rem;
+  margin-bottom: -1rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.cue-column.first-row {
+  margin-top: calc(-1rem - var(--spacing-before, 0rem));
+  padding-top: calc(1rem + var(--spacing-before, 0rem));
+}
+
+.cut-line-part {
+  text-decoration: line-through;
+}
+
+.line-part {
+  font-size: 1.5rem;
+}
+
+.cue {
+  font-size: 2rem;
+}
+
+.line-part-a {
+  color: white;
+}
+
+.line-part-b {
+  color: gray;
+}
+
+.act-scene {
+  color: #f401fe;
+}
+
+.current-line {
+  background: #3498db54;
+}
+
+.interval-header {
+  background: var(--bs-body-bg);
+  margin-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.interval-banner {
+  margin-top: -1rem;
+  margin-bottom: -1rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.cue-add-column {
+  border-left: 0.1rem solid #3498db;
+}
+</style>

--- a/client-v3/src/components/show/live/ScriptViewPane.vue
+++ b/client-v3/src/components/show/live/ScriptViewPane.vue
@@ -101,8 +101,14 @@
       :ok-disabled="intervalTimerLength === 0"
       ok-only
       ok-variant="success"
-      @show="resetIntervalState"
-      @hidden="resetIntervalState"
+      @show="
+        intervalModalOpen = true;
+        resetIntervalState();
+      "
+      @hidden="
+        intervalModalOpen = false;
+        resetIntervalState();
+      "
       @ok="startInterval"
     >
       <BContainer fluid class="mx-0">
@@ -160,7 +166,11 @@
       title="Add New Cue"
       size="md"
       :ok-disabled="v$.newCueFormState.$invalid || submittingNewCue"
-      @hidden="resetNewCueForm"
+      @show="newCueModalOpen = true"
+      @hidden="
+        newCueModalOpen = false;
+        resetNewCueForm();
+      "
       @ok="onSubmitNewCue"
     >
       <BForm @submit.stop.prevent="onSubmitNewCue">
@@ -258,6 +268,8 @@ const isScrollingProgrammatically = ref(false);
 
 // UI state
 const cueAddMode = ref(false);
+const intervalModalOpen = ref(false);
+const newCueModalOpen = ref(false);
 
 // Cue modal state
 const newCueFormState = ref({
@@ -521,7 +533,9 @@ function handleKeyNavigation(event: KeyboardEvent): void {
     !props.isScriptLeader ||
     !initialLoad.value ||
     isScrollingProgrammatically.value ||
-    props.intervalActive
+    props.intervalActive ||
+    intervalModalOpen.value ||
+    newCueModalOpen.value
   )
     return;
   event.preventDefault();
@@ -533,7 +547,9 @@ function handlePageNavigation(event: KeyboardEvent): void {
     !props.isScriptLeader ||
     !initialLoad.value ||
     isScrollingProgrammatically.value ||
-    props.intervalActive
+    props.intervalActive ||
+    intervalModalOpen.value ||
+    newCueModalOpen.value
   )
     return;
   event.preventDefault();
@@ -549,7 +565,9 @@ function handleWheelNavigation(event: WheelEvent): void {
     !props.isScriptLeader ||
     !initialLoad.value ||
     isScrollingProgrammatically.value ||
-    props.intervalActive
+    props.intervalActive ||
+    intervalModalOpen.value ||
+    newCueModalOpen.value
   )
     return;
   const scriptContainer = document.getElementById('script-container');

--- a/client-v3/src/components/show/live/ScriptViewPane.vue
+++ b/client-v3/src/components/show/live/ScriptViewPane.vue
@@ -21,7 +21,6 @@
               v-show="
                 !isWholeLineCut(line, scriptStore.cuts) && line.line_type !== LINE_TYPES.SPACING
               "
-              v-once
               :id="`page_${page}_line_${index}`"
               :key="`page_${page}_line_${index}_ADDMODE:${cueAddMode}_CUES:${scriptStore.cuesForLine(line.id).length}`"
               class="script-item"
@@ -55,7 +54,6 @@
               v-show="
                 !isWholeLineCut(line, scriptStore.cuts) && line.line_type !== LINE_TYPES.SPACING
               "
-              v-once
               :id="`page_${page}_line_${index}`"
               :key="`page_${page}_line_${index}_ADDMODE:${cueAddMode}_CUES:${scriptStore.cuesForLine(line.id).length}`"
               class="script-item"

--- a/client-v3/src/components/show/live/ScriptViewPane.vue
+++ b/client-v3/src/components/show/live/ScriptViewPane.vue
@@ -1,0 +1,891 @@
+<template>
+  <BRow
+    ref="scriptContainerRow"
+    :aria-hidden="intervalActive ? 'true' : null"
+    :style="{ 'margin-right': stageManagerMode ? '0px' : '-15px' }"
+  >
+    <BCol
+      id="script-container"
+      cols="12"
+      class="script-container"
+      :data-following="isScriptFollowing"
+    >
+      <div v-if="!initialLoad" class="text-center center-spinner">
+        <BSpinner style="width: 10rem; height: 10rem" variant="info" />
+      </div>
+      <template v-else>
+        <template v-if="scriptMode === 2">
+          <template v-for="page in pageIter" :key="`page_${page}`">
+            <ScriptLineViewerCompact
+              v-for="(line, index) in scriptStore.getScriptPage(page)"
+              v-show="
+                !isWholeLineCut(line, scriptStore.cuts) && line.line_type !== LINE_TYPES.SPACING
+              "
+              v-once
+              :id="`page_${page}_line_${index}`"
+              :key="`page_${page}_line_${index}_ADDMODE:${cueAddMode}_CUES:${scriptStore.cuesForLine(line.id).length}`"
+              class="script-item"
+              :line-index="index"
+              :line="line"
+              :acts="showStore.actList"
+              :scenes="showStore.sceneList"
+              :characters="showStore.characterList"
+              :character-groups="showStore.characterGroupList"
+              :previous-line="getPreviousLineForIndex(page, index)"
+              :previous-line-index="getPreviousLineIndex(page, index)"
+              :cue-types="showStore.cueTypes"
+              :cues="scriptStore.cuesForLine(line.id)"
+              :cuts="scriptStore.cuts"
+              :stage-direction-styles="scriptStore.stageDirectionStyles"
+              :stage-direction-style-overrides="userStore.stageDirectionStyleOverrides"
+              :is-script-leader="isScriptLeader"
+              :cue-add-mode="cueAddMode"
+              :spacing-before="getSpacingBefore(page, index)"
+              @last-line-change="handleLastLineChange"
+              @first-line-change="handleFirstLineChange"
+              @start-interval="configureInterval"
+              @add-cue="openNewCueModal"
+            />
+          </template>
+        </template>
+        <template v-else>
+          <template v-for="page in pageIter" :key="`page_${page}`">
+            <ScriptLineViewer
+              v-for="(line, index) in scriptStore.getScriptPage(page)"
+              v-show="
+                !isWholeLineCut(line, scriptStore.cuts) && line.line_type !== LINE_TYPES.SPACING
+              "
+              v-once
+              :id="`page_${page}_line_${index}`"
+              :key="`page_${page}_line_${index}_ADDMODE:${cueAddMode}_CUES:${scriptStore.cuesForLine(line.id).length}`"
+              class="script-item"
+              :line-index="index"
+              :line="line"
+              :acts="showStore.actList"
+              :scenes="showStore.sceneList"
+              :characters="showStore.characterList"
+              :character-groups="showStore.characterGroupList"
+              :previous-line="getPreviousLineForIndex(page, index)"
+              :previous-line-index="getPreviousLineIndex(page, index)"
+              :cue-types="showStore.cueTypes"
+              :cues="scriptStore.cuesForLine(line.id)"
+              :cuts="scriptStore.cuts"
+              :stage-direction-styles="scriptStore.stageDirectionStyles"
+              :stage-direction-style-overrides="userStore.stageDirectionStyleOverrides"
+              :is-script-leader="isScriptLeader"
+              :cue-add-mode="cueAddMode"
+              :spacing-before="getSpacingBefore(page, index)"
+              @last-line-change="handleLastLineChange"
+              @first-line-change="handleFirstLineChange"
+              @start-interval="configureInterval"
+              @add-cue="openNewCueModal"
+            />
+          </template>
+        </template>
+        <BRow class="script-footer">
+          <BCol>
+            <BButtonGroup>
+              <BButton variant="danger" :disabled="stoppingSession" @click.stop="stopShow">
+                End Show
+              </BButton>
+            </BButtonGroup>
+          </BCol>
+        </BRow>
+      </template>
+    </BCol>
+
+    <!-- Start Interval Modal -->
+    <BModal
+      ref="intervalModal"
+      title="Start Interval"
+      size="md"
+      ok-title="Start"
+      :ok-disabled="intervalTimerLength === 0"
+      ok-only
+      ok-variant="success"
+      @show="resetIntervalState"
+      @hidden="resetIntervalState"
+      @ok="startInterval"
+    >
+      <BContainer fluid class="mx-0">
+        <BRow class="justify-content-center mb-3">
+          <BCol md="auto">
+            <div class="d-flex align-items-center gap-2">
+              <div class="text-center">
+                <label class="form-label">Hours</label>
+                <BFormInput
+                  v-model.number="intervalHours"
+                  type="number"
+                  min="0"
+                  max="23"
+                  style="width: 5rem; text-align: center"
+                />
+              </div>
+              <span class="fs-4 pt-3">:</span>
+              <div class="text-center">
+                <label class="form-label">Minutes</label>
+                <BFormInput
+                  v-model.number="intervalMinutes"
+                  type="number"
+                  min="0"
+                  max="59"
+                  style="width: 5rem; text-align: center"
+                />
+              </div>
+              <span class="fs-4 pt-3">:</span>
+              <div class="text-center">
+                <label class="form-label">Seconds</label>
+                <BFormInput
+                  v-model.number="intervalSeconds"
+                  type="number"
+                  min="0"
+                  max="59"
+                  style="width: 5rem; text-align: center"
+                />
+              </div>
+            </div>
+          </BCol>
+        </BRow>
+        <BRow class="justify-content-center">
+          <BCol md="auto">
+            <BAlert variant="info" :model-value="true">
+              Select the length of the interval (HH:MM:SS)
+            </BAlert>
+          </BCol>
+        </BRow>
+      </BContainer>
+    </BModal>
+
+    <!-- Add Cue Modal -->
+    <BModal
+      ref="newCueModal"
+      title="Add New Cue"
+      size="md"
+      :ok-disabled="v$.newCueFormState.$invalid || submittingNewCue"
+      @hidden="resetNewCueForm"
+      @ok="onSubmitNewCue"
+    >
+      <BForm @submit.stop.prevent="onSubmitNewCue">
+        <BFormGroup label="Cue Type" label-for="cue-type-input">
+          <BFormSelect
+            id="cue-type-input"
+            v-model="v$.newCueFormState.cueType.$model"
+            :options="cueTypeOptions"
+            :state="validateFieldState('cueType')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+        </BFormGroup>
+        <BFormGroup label="Identifier" label-for="ident-input">
+          <BFormInput
+            id="ident-input"
+            v-model="v$.newCueFormState.ident.$model"
+            :state="validateFieldState('ident')"
+          />
+          <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
+          <BFormText v-if="isDuplicateCue" class="text-warning">
+            A cue with this identifier already exists for this cue type
+          </BFormText>
+        </BFormGroup>
+      </BForm>
+    </BModal>
+  </BRow>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue';
+import { useVuelidate } from '@vuelidate/core';
+import { required } from '@vuelidate/validators';
+import { debounce } from 'lodash';
+import log from 'loglevel';
+
+import { makeURL } from '@/js/utils';
+import { isWholeLineCut } from '@/js/scriptUtils';
+import { LINE_TYPES } from '@/constants/lineTypes';
+import { useShowStore } from '@/stores/show';
+import { useScriptStore } from '@/stores/script';
+import { useUserStore } from '@/stores/user';
+import { useSystemStore } from '@/stores/system';
+import { useWebSocket } from '@/composables/useWebSocket';
+import { toast } from '@/js/toast';
+import ScriptLineViewer from './ScriptLineViewer.vue';
+import ScriptLineViewerCompact from './ScriptLineViewerCompact.vue';
+import type { ScriptLine } from '@/types/api/script';
+
+const props = defineProps<{
+  isScriptFollowing: boolean;
+  isScriptLeader: boolean;
+  sessionFollowData: Record<string, unknown>;
+  initialLineRef: string | null;
+  intervalActive: boolean;
+  scriptMode: number;
+  stageManagerMode: boolean;
+}>();
+
+const emit = defineEmits<{
+  'page-change': [page: number];
+  'script-loaded': [];
+}>();
+
+const showStore = useShowStore();
+const scriptStore = useScriptStore();
+const userStore = useUserStore();
+const systemStore = useSystemStore();
+const { sendObj } = useWebSocket();
+
+// Template refs
+const intervalModal = ref<InstanceType<(typeof import('bootstrap-vue-next'))['BModal']> | null>(
+  null
+);
+const newCueModal = ref<InstanceType<(typeof import('bootstrap-vue-next'))['BModal']> | null>(null);
+
+// Page loading state
+const currentLoadedPage = ref(0);
+const currentMaxPage = ref(0);
+const currentFirstPage = ref(1);
+const currentLastPage = ref(1);
+const currentMinLoadedPage = ref<number | null>(null);
+const pageBatchSize = 3;
+const assignedLastLine = ref(false);
+
+// Script load state
+const initialLoad = ref(false);
+const fullLoad = ref(false);
+
+// Navigation state
+const currentPage = ref(1);
+const currentLineOnPage = ref(0);
+const currentLine = ref<string | null>(null);
+const previousLine = ref<string | null>(null);
+const isScrollingProgrammatically = ref(false);
+
+// UI state
+const cueAddMode = ref(false);
+
+// Cue modal state
+const newCueFormState = ref({
+  cueType: null as number | null,
+  ident: null as string | null,
+  lineId: null as number | null,
+});
+const submittingNewCue = ref(false);
+
+// Interval modal state
+const intervalActId = ref<number | null>(null);
+const intervalHours = ref(0);
+const intervalMinutes = ref(0);
+const intervalSeconds = ref(0);
+
+// Session control
+const stoppingSession = ref(false);
+
+// Vuelidate
+const rules = {
+  newCueFormState: {
+    cueType: { required },
+    ident: { required },
+    lineId: { required },
+  },
+};
+const v$ = useVuelidate(rules, { newCueFormState });
+
+// Computed
+const pageIter = computed(() => [...Array(currentMaxPage.value).keys()].map((i) => i + 1));
+
+const intervalTimerLength = computed(
+  () => intervalHours.value * 3600 + intervalMinutes.value * 60 + intervalSeconds.value
+);
+
+const cueTypeOptions = computed(() => [
+  { value: null, text: 'N/A' },
+  ...showStore.cueTypes.map((ct) => ({ value: ct.id, text: `${ct.prefix}: ${ct.description}` })),
+]);
+
+const isDuplicateCue = computed(() => {
+  if (!newCueFormState.value.ident || !newCueFormState.value.cueType) return false;
+  const allCues = Object.values(scriptStore.cues).flat();
+  return allCues.some(
+    (cue) =>
+      cue.cue_type_id === newCueFormState.value.cueType && cue.ident === newCueFormState.value.ident
+  );
+});
+
+// Debounced resize handler
+const debounceContentSize = debounce(computeContentSize, 100);
+
+// --- Navigation ---
+
+function getPreviousLineForIndex(pageIndex: number, lineIndex: number): ScriptLine | null {
+  if (lineIndex > 0) {
+    return scriptStore.getScriptPage(pageIndex)[lineIndex - 1] ?? null;
+  }
+  let loopPageNo = pageIndex - 1;
+  while (loopPageNo >= 1) {
+    const loopPage = scriptStore.getScriptPage(loopPageNo);
+    if (loopPage.length > 0) return loopPage[loopPage.length - 1];
+    loopPageNo--;
+  }
+  return null;
+}
+
+function getPreviousLineIndex(pageIndex: number, lineIndex: number): number | null {
+  if (lineIndex > 0) return lineIndex - 1;
+  let loopPageNo = pageIndex - 1;
+  while (loopPageNo >= 1) {
+    const loopPage = scriptStore.getScriptPage(loopPageNo);
+    if (loopPage.length > 0) return loopPage.length - 1;
+    loopPageNo--;
+  }
+  return null;
+}
+
+function getSpacingBefore(page: number, index: number): number {
+  let spacingCount = 0;
+  let currentPageIdx = page;
+  let currentIndex = index - 1;
+
+  while (currentPageIdx >= 1) {
+    if (currentIndex < 0) {
+      currentPageIdx--;
+      if (currentPageIdx < 1) break;
+      const prevPageLines = scriptStore.getScriptPage(currentPageIdx);
+      if (!prevPageLines || prevPageLines.length === 0) break;
+      currentIndex = prevPageLines.length - 1;
+      continue;
+    }
+    const pageLines = scriptStore.getScriptPage(currentPageIdx);
+    if (!pageLines || currentIndex >= pageLines.length) break;
+    const line = pageLines[currentIndex];
+    if (line.line_type === LINE_TYPES.SPACING) {
+      spacingCount++;
+      currentIndex--;
+    } else {
+      break;
+    }
+  }
+  return spacingCount;
+}
+
+function scrollToElement(element: Element | null): void {
+  const container = document.getElementById('script-container');
+  if (!container || !element) return;
+  const elementRect = element.getBoundingClientRect();
+  const containerRect = container.getBoundingClientRect();
+  container.scrollTop = elementRect.top - containerRect.top + container.scrollTop;
+}
+
+function findContextElement(
+  targetPage: number,
+  targetLineOnPage: number,
+  contextLines: number
+): Element | null {
+  let curPage = targetPage;
+  let curLine = targetLineOnPage;
+  let visibleLinesFound = 0;
+
+  while (visibleLinesFound < contextLines && curPage >= 1) {
+    curLine--;
+    if (curLine < 0) {
+      curPage--;
+      if (curPage < 1) return document.getElementById('page_1_line_0');
+      const prevPageLines = scriptStore.getScriptPage(curPage);
+      if (!prevPageLines || prevPageLines.length === 0) continue;
+      curLine = prevPageLines.length - 1;
+    }
+    const pageLines = scriptStore.getScriptPage(curPage);
+    if (pageLines && curLine < pageLines.length) {
+      const line = pageLines[curLine];
+      if (!isWholeLineCut(line, scriptStore.cuts)) {
+        visibleLinesFound++;
+        if (visibleLinesFound >= contextLines) {
+          return document.getElementById(`page_${curPage}_line_${curLine}`);
+        }
+      }
+    }
+  }
+  if (visibleLinesFound > 0) {
+    return document.getElementById(`page_${curPage}_line_${curLine}`);
+  }
+  return null;
+}
+
+function navigateTo(targetPage: number, targetLineOnPage: number, preventScroll = false): boolean {
+  if (targetPage > currentLoadedPage.value) return false;
+  const pageLines = scriptStore.getScriptPage(targetPage);
+  if (!pageLines || targetLineOnPage >= pageLines.length) return false;
+
+  currentPage.value = targetPage;
+  currentLineOnPage.value = targetLineOnPage;
+  emit('page-change', targetPage);
+
+  const targetElementId = `page_${targetPage}_line_${targetLineOnPage}`;
+  const targetElement = document.getElementById(targetElementId);
+  if (!targetElement) {
+    log.error(`Could not find element for line: ${targetElementId}`);
+    return false;
+  }
+
+  document.querySelectorAll('.script-item').forEach((el) => el.classList.remove('current-line'));
+  targetElement.classList.add('current-line');
+
+  previousLine.value = currentLine.value;
+  currentLine.value = targetElementId;
+
+  if (!preventScroll) {
+    isScrollingProgrammatically.value = true;
+    const contextElement = findContextElement(targetPage, targetLineOnPage, 3);
+    scrollToElement(contextElement ?? targetElement);
+
+    if (fullLoad.value) {
+      sendObj({
+        OP: 'SCRIPT_SCROLL',
+        DATA: { previous_line: previousLine.value, current_line: currentLine.value },
+      });
+    }
+
+    setTimeout(() => {
+      isScrollingProgrammatically.value = false;
+      computeScriptBoundaries();
+    }, 50);
+  }
+
+  return true;
+}
+
+function navigateRelative(deltaLine: number): boolean {
+  if (deltaLine === 0) return true;
+  const direction = deltaLine > 0 ? 1 : -1;
+  let newPage = currentPage.value;
+  let newLineOnPage = currentLineOnPage.value;
+  let visibleLinesMoved = 0;
+
+  while (visibleLinesMoved < Math.abs(deltaLine)) {
+    newLineOnPage += direction;
+    if (newLineOnPage < 0) {
+      newPage--;
+      if (newPage < 1) {
+        newPage = 1;
+        newLineOnPage = 0;
+        break;
+      }
+      const prevPageLines = scriptStore.getScriptPage(newPage);
+      if (!prevPageLines) break;
+      newLineOnPage = prevPageLines.length - 1;
+      if (newLineOnPage < 0) newLineOnPage = 0;
+    } else {
+      const currentPageLines = scriptStore.getScriptPage(newPage);
+      if (!currentPageLines) break;
+      if (newLineOnPage >= currentPageLines.length) {
+        newPage++;
+        if (newPage > currentLoadedPage.value) {
+          newPage = currentLoadedPage.value;
+          newLineOnPage = currentPageLines.length - 1;
+          break;
+        }
+        newLineOnPage = 0;
+      }
+    }
+    const pageLines = scriptStore.getScriptPage(newPage);
+    if (pageLines && newLineOnPage < pageLines.length) {
+      if (!isWholeLineCut(pageLines[newLineOnPage], scriptStore.cuts)) {
+        visibleLinesMoved++;
+      }
+      if (visibleLinesMoved >= Math.abs(deltaLine)) break;
+    } else {
+      break;
+    }
+  }
+  return navigateTo(newPage, newLineOnPage);
+}
+
+// --- Keyboard/wheel handlers ---
+
+function handleKeyPress(event: KeyboardEvent): void {
+  if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+    handleKeyNavigation(event);
+  } else if (event.key === 'PageUp' || event.key === 'PageDown') {
+    handlePageNavigation(event);
+  } else if (event.key === 'C') {
+    handleCueEditToggle(event);
+  }
+}
+
+function handleCueEditToggle(event: KeyboardEvent): void {
+  event.preventDefault();
+  if (systemStore.isShowEditor) {
+    cueAddMode.value = !cueAddMode.value;
+  } else {
+    cueAddMode.value = false;
+  }
+}
+
+function handleKeyNavigation(event: KeyboardEvent): void {
+  if (
+    !props.isScriptLeader ||
+    !initialLoad.value ||
+    isScrollingProgrammatically.value ||
+    props.intervalActive
+  )
+    return;
+  event.preventDefault();
+  navigateRelative(event.key === 'ArrowDown' ? 1 : -1);
+}
+
+function handlePageNavigation(event: KeyboardEvent): void {
+  if (
+    !props.isScriptLeader ||
+    !initialLoad.value ||
+    isScrollingProgrammatically.value ||
+    props.intervalActive
+  )
+    return;
+  event.preventDefault();
+  const isPageDown = event.key === 'PageDown';
+  let targetPage = currentPage.value + (isPageDown ? 1 : -1);
+  if (targetPage < 1) targetPage = 1;
+  else if (targetPage > currentLoadedPage.value) return;
+  navigateTo(targetPage, 0);
+}
+
+function handleWheelNavigation(event: WheelEvent): void {
+  if (
+    !props.isScriptLeader ||
+    !initialLoad.value ||
+    isScrollingProgrammatically.value ||
+    props.intervalActive
+  )
+    return;
+  const scriptContainer = document.getElementById('script-container');
+  if (!scriptContainer) return;
+  const isAtTop = scriptContainer.scrollTop === 0;
+  const isAtBottom =
+    scriptContainer.scrollHeight - scriptContainer.scrollTop === scriptContainer.clientHeight;
+  if ((event.deltaY > 0 && !isAtBottom) || (event.deltaY < 0 && !isAtTop)) {
+    event.preventDefault();
+    navigateRelative(event.deltaY > 0 ? 1 : -1);
+  }
+}
+
+// --- Follow watcher ---
+
+function handleFollowDataChange(): void {
+  const followData = props.sessionFollowData;
+  if (props.isScriptFollowing && followData.current_line) {
+    const lineRef = followData.current_line as string;
+    const currentLineElement = document.getElementById(lineRef);
+    if (currentLineElement != null) {
+      const idParts = lineRef.split('_');
+      const page = parseInt(idParts[1], 10);
+      const line = parseInt(idParts[3], 10);
+
+      document
+        .querySelectorAll('.script-item')
+        .forEach((el) => el.classList.remove('current-line'));
+      currentLineElement.classList.add('current-line');
+
+      const contextElement = findContextElement(page, line, 3);
+      scrollToElement(contextElement ?? currentLineElement);
+
+      currentPage.value = page;
+      emit('page-change', page);
+      computeScriptBoundaries();
+    }
+  }
+}
+
+// --- Script boundaries ---
+
+function computeScriptBoundaries(): void {
+  if (isScrollingProgrammatically.value) return;
+  const scriptContainer = document.getElementById('script-container');
+  if (!scriptContainer) return;
+
+  const containerRect = scriptContainer.getBoundingClientRect();
+  const cutoffTop = containerRect.top;
+  const cutoffBottom = containerRect.top + scriptContainer.clientHeight;
+  const scriptItems = scriptContainer.querySelectorAll<HTMLElement>('.script-item');
+
+  let firstAssigned = false;
+  scriptItems.forEach((el) => el.classList.remove('first-script-element'));
+  for (const el of Array.from(scriptItems)) {
+    const rect = el.getBoundingClientRect();
+    if (rect.top >= cutoffTop) {
+      el.classList.add('first-script-element');
+      firstAssigned = true;
+      break;
+    }
+  }
+  if (!firstAssigned && scriptItems.length > 0) {
+    scriptItems[0].classList.add('first-script-element');
+  }
+
+  let lastObject: HTMLElement | null = null;
+  let assignedLast = false;
+  scriptItems.forEach((el) => el.classList.remove('last-script-element'));
+  for (const el of Array.from(scriptItems)) {
+    const rect = el.getBoundingClientRect();
+    if (rect.top >= cutoffBottom) {
+      el.classList.add('last-script-element');
+      assignedLast = true;
+      break;
+    }
+    if (rect.top < cutoffBottom) lastObject = el;
+  }
+  assignedLastLine.value = assignedLast;
+  if (!assignedLast && lastObject) {
+    lastObject.classList.add('last-script-element');
+  }
+}
+
+function computeContentSize(): void {
+  const scriptContainer = document.getElementById('script-container');
+  if (!scriptContainer) return;
+  const startPos = scriptContainer.getBoundingClientRect().top;
+  const boxHeight = document.documentElement.clientHeight - startPos;
+  scriptContainer.style.height = `${boxHeight - 10}px`;
+  computeScriptBoundaries();
+}
+
+// --- Script loading ---
+
+async function loadCompiledScript(): Promise<boolean> {
+  const response = await fetch(makeURL('/api/v1/show/script/compiled'));
+  if (!response.ok) return false;
+  const respJson = await response.json();
+  let maxLoadedPage = 1;
+  let minLoadedPage = Number.POSITIVE_INFINITY;
+  Object.entries(respJson).forEach(([pageStr, pageContents]) => {
+    const pageNumber = parseInt(pageStr, 10);
+    if (pageNumber > maxLoadedPage) maxLoadedPage = pageNumber;
+    if (pageNumber < minLoadedPage) minLoadedPage = pageNumber;
+    scriptStore.script[String(pageNumber)] = pageContents as ScriptLine[];
+  });
+  currentLoadedPage.value = maxLoadedPage;
+  currentMinLoadedPage.value = minLoadedPage;
+  return true;
+}
+
+async function loadNextPage(): Promise<void> {
+  if (currentLoadedPage.value < currentMaxPage.value) {
+    currentLoadedPage.value++;
+    await scriptStore.loadScriptPage(currentLoadedPage.value);
+  }
+}
+
+// --- Lazy-load handlers from line components ---
+
+async function handleLastLineChange(lastPage: number, _lineIndex: number): Promise<void> {
+  currentLastPage.value = lastPage;
+  const cutoffPage = currentLoadedPage.value - pageBatchSize;
+  if (lastPage >= cutoffPage && currentLoadedPage.value < currentMaxPage.value) {
+    for (let i = 0; i < pageBatchSize; i++) await loadNextPage();
+    computeScriptBoundaries();
+    while (!assignedLastLine.value && currentLoadedPage.value <= currentMaxPage.value) {
+      await loadNextPage();
+      computeScriptBoundaries();
+      await nextTick();
+    }
+  }
+  await nextTick();
+}
+
+async function handleFirstLineChange(
+  firstPage: number,
+  lineIndex: number,
+  prevLine: string | null
+): Promise<void> {
+  currentFirstPage.value = firstPage;
+  previousLine.value = prevLine;
+  currentLine.value = `page_${firstPage}_line_${lineIndex}`;
+
+  const cutoffPage = firstPage - pageBatchSize;
+  if ((currentMinLoadedPage.value ?? 0) > cutoffPage) {
+    for (let i = 0; i < pageBatchSize; i++) {
+      if ((currentMinLoadedPage.value ?? 0) > 1) {
+        currentMinLoadedPage.value = (currentMinLoadedPage.value ?? 1) - 1;
+        await scriptStore.loadScriptPage(currentMinLoadedPage.value);
+      }
+    }
+  }
+}
+
+// --- Interval modal ---
+
+function configureInterval(actId: number): void {
+  intervalActId.value = actId;
+  (intervalModal.value as any)?.show();
+}
+
+function resetIntervalState(): void {
+  intervalHours.value = 0;
+  intervalMinutes.value = 0;
+  intervalSeconds.value = 0;
+}
+
+function startInterval(): void {
+  sendObj({
+    OP: 'BEGIN_INTERVAL',
+    DATA: { actId: intervalActId.value, length: intervalTimerLength.value },
+  });
+  toast.success('Interval started!');
+}
+
+// --- Cue modal ---
+
+function openNewCueModal(lineId: number): void {
+  resetNewCueForm();
+  newCueFormState.value.lineId = lineId;
+  (newCueModal.value as any)?.show();
+}
+
+function resetNewCueForm(): void {
+  newCueFormState.value = { cueType: null, ident: null, lineId: null };
+  submittingNewCue.value = false;
+  nextTick(() => v$.value.$reset());
+}
+
+function validateFieldState(field: 'cueType' | 'ident'): boolean | null {
+  const f = v$.value.newCueFormState[field];
+  return f.$dirty ? !f.$error : null;
+}
+
+async function onSubmitNewCue(event: Event): Promise<void> {
+  v$.value.newCueFormState.$touch();
+  if (v$.value.newCueFormState.$invalid || submittingNewCue.value) {
+    event.preventDefault();
+    return;
+  }
+  submittingNewCue.value = true;
+  try {
+    await scriptStore.addNewCue({
+      cueType: newCueFormState.value.cueType!,
+      ident: newCueFormState.value.ident!,
+      lineId: newCueFormState.value.lineId!,
+    });
+    (newCueModal.value as any)?.hide();
+    resetNewCueForm();
+  } catch (error) {
+    log.error('Error submitting new cue:', error);
+    event.preventDefault();
+  } finally {
+    submittingNewCue.value = false;
+  }
+}
+
+// --- Stop show ---
+
+async function stopShow(): Promise<void> {
+  stoppingSession.value = true;
+  const response = await fetch(makeURL('/api/v1/show/sessions/stop'), { method: 'POST' });
+  if (response.ok) {
+    toast.success('Stopped show session');
+  } else {
+    log.error('Unable to stop show session');
+    toast.error('Unable to stop show session');
+  }
+  stoppingSession.value = false;
+}
+
+// --- Lifecycle ---
+
+onMounted(async () => {
+  await Promise.all([
+    userStore.getCurrentUser().then(() => {
+      if (userStore.currentUser != null) {
+        return Promise.all([
+          userStore.getStageDirectionStyleOverrides(),
+          userStore.getCueColourOverrides(),
+        ]);
+      }
+      return Promise.resolve();
+    }),
+    showStore.getSceneList(),
+    showStore.getCharacterList(),
+    showStore.getCharacterGroupList(),
+    showStore.getCueTypes(),
+    scriptStore.loadCues(),
+    scriptStore.getCuts(),
+    scriptStore.getStageDirectionStyles(),
+    scriptStore.getMaxPage().then(() => {
+      currentMaxPage.value = scriptStore.maxPage;
+    }),
+  ]);
+
+  computeContentSize();
+
+  const loadedCompiledScript = await loadCompiledScript();
+
+  if (!loadedCompiledScript) {
+    currentMinLoadedPage.value = 1;
+    for (let i = 0; i < currentMaxPage.value; i++) await loadNextPage();
+  }
+
+  initialLoad.value = true;
+  await nextTick();
+  computeScriptBoundaries();
+
+  if (props.initialLineRef) {
+    scrollToElement(document.getElementById(props.initialLineRef));
+    const parts = props.initialLineRef.split('_');
+    if (parts.length >= 4) {
+      navigateTo(parseInt(parts[1], 10), parseInt(parts[3], 10));
+    }
+    await nextTick();
+    computeScriptBoundaries();
+  } else {
+    navigateTo(1, 0);
+  }
+
+  fullLoad.value = true;
+
+  window.addEventListener('keydown', handleKeyPress);
+  const scriptContainer = document.getElementById('script-container');
+  if (scriptContainer) {
+    scriptContainer.addEventListener('wheel', handleWheelNavigation, { passive: false });
+  }
+  window.addEventListener('resize', debounceContentSize);
+
+  emit('script-loaded');
+});
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeyPress);
+  const scriptContainer = document.getElementById('script-container');
+  if (scriptContainer) {
+    scriptContainer.removeEventListener('wheel', handleWheelNavigation);
+  }
+  window.removeEventListener('resize', debounceContentSize);
+});
+
+// Watch follow data reactively
+import { watch } from 'vue';
+watch(() => props.sessionFollowData, handleFollowDataChange, { deep: true });
+</script>
+
+<style scoped>
+.script-container {
+  overflow: scroll;
+  overflow-x: auto;
+  width: 100vw;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.script-container::-webkit-scrollbar {
+  display: none;
+  width: 0 !important;
+}
+
+.script-container[data-following='true'] {
+  overflow: hidden !important;
+}
+
+.script-footer {
+  border-top: 0.1rem solid #3498db;
+  padding-top: 0.5rem;
+  padding-bottom: 0.1rem;
+}
+
+.center-spinner {
+  margin-top: 20vh;
+}
+</style>

--- a/client-v3/src/components/show/live/StageManagerPane.vue
+++ b/client-v3/src/components/show/live/StageManagerPane.vue
@@ -1,0 +1,548 @@
+<template>
+  <div ref="paneContainer" class="stage-manager-pane">
+    <div class="pane-header">
+      <h6 class="mb-0">Stage Manager</h6>
+    </div>
+    <div v-if="!loaded" class="loading-state">
+      <BSpinner small variant="light" />
+    </div>
+    <div v-else-if="showStore.orderedScenes.length === 0" class="empty-state">
+      <small class="text-muted">No scenes configured</small>
+    </div>
+    <div v-else ref="scrollContainer" class="scenes-container">
+      <BCard
+        v-for="scene in showStore.orderedScenes"
+        :ref="(el) => setSceneCardRef(el, scene.id)"
+        :key="scene.id"
+        no-body
+        class="scene-card mb-2"
+        :class="{
+          'current-scene': scene.id === currentSceneId,
+          'next-scene': scene.id === nextSceneId,
+        }"
+      >
+        <BCardHeader class="p-2 scene-header" role="button" @click="toggleScene(scene.id)">
+          <div class="d-flex justify-content-between align-items-center">
+            <span class="scene-title">
+              <span class="me-1">{{ expandedScenes[scene.id] ? '▼' : '▶' }}</span>
+              {{ getSceneDisplayName(scene) }}
+            </span>
+            <span class="scene-badges d-flex align-items-center gap-1">
+              <span v-if="pinnedScenes[scene.id]" title="Pinned">📌</span>
+              <BBadge v-if="scene.id === currentSceneId" variant="success" pill>Current</BBadge>
+              <BBadge v-else-if="scene.id === nextSceneId" variant="primary" pill>Next</BBadge>
+            </span>
+          </div>
+        </BCardHeader>
+        <BCollapse v-model="expandedScenes[scene.id]">
+          <BCardBody class="p-2 scene-body">
+            <div class="d-flex justify-content-end mb-2">
+              <BButton size="sm" variant="primary" @click.stop.prevent="showSMPlanModal(scene)">
+                Plan
+              </BButton>
+            </div>
+            <div
+              v-if="
+                getSceneryForScene(scene.id).length === 0 && getPropsForScene(scene.id).length === 0
+              "
+              class="empty-scene"
+            >
+              <small>No props or scenery</small>
+            </div>
+            <template v-else>
+              <div v-if="getSceneryForScene(scene.id).length > 0" class="mb-2">
+                <small class="section-label">Scenery</small>
+                <ul class="item-list mb-0">
+                  <li v-for="item in getSceneryForScene(scene.id)" :key="`scenery-${item.id}`">
+                    {{ getSceneryDisplayName(item) }}
+                  </li>
+                </ul>
+              </div>
+              <div v-if="getPropsForScene(scene.id).length > 0">
+                <small class="section-label">Props</small>
+                <ul class="item-list mb-0">
+                  <li v-for="item in getPropsForScene(scene.id)" :key="`prop-${item.id}`">
+                    {{ getPropDisplayName(item) }}
+                  </li>
+                </ul>
+              </div>
+            </template>
+          </BCardBody>
+        </BCollapse>
+      </BCard>
+    </div>
+
+    <BModal
+      ref="smPlanModal"
+      :title="smPlanScene ? `${getSceneDisplayName(smPlanScene)} - Plan` : ''"
+      size="lg"
+      ok-only
+      @hidden="smPlanScene = null"
+    >
+      <div v-if="smPlanScene">
+        <BCard no-body class="mb-2">
+          <BCardHeader class="p-2" role="button" @click="smPlanSet = !smPlanSet">
+            <span>{{ smPlanSet ? '▼' : '▶' }} Setting</span>
+          </BCardHeader>
+          <BCollapse v-model="smPlanSet">
+            <BCardBody class="p-2">
+              <BContainer fluid class="mx-0 px-0">
+                <BRow class="plan-header-row">
+                  <BCol cols="6" class="plan-header-col border-end"><b>Scenery</b></BCol>
+                  <BCol cols="6" class="plan-header-col"><b>Props</b></BCol>
+                </BRow>
+                <BRow class="plan-content-row">
+                  <BCol cols="6" class="plan-content-col border-end">
+                    <ul v-if="getSettingScenery(smPlanScene).length > 0" class="item-list mb-0">
+                      <li
+                        v-for="item in getSettingScenery(smPlanScene)"
+                        :key="`set-scenery-${item.id}`"
+                      >
+                        {{ getSceneryDisplayName(item) }}
+                        <div
+                          v-if="getCrewNamesForSettingItem(item, 'scenery', smPlanScene).length > 0"
+                          class="crew-names"
+                        >
+                          {{ getCrewNamesForSettingItem(item, 'scenery', smPlanScene).join(', ') }}
+                        </div>
+                      </li>
+                    </ul>
+                    <p v-else class="text-muted mb-0">None</p>
+                  </BCol>
+                  <BCol cols="6" class="plan-content-col">
+                    <ul v-if="getSettingProps(smPlanScene).length > 0" class="item-list mb-0">
+                      <li v-for="item in getSettingProps(smPlanScene)" :key="`set-prop-${item.id}`">
+                        {{ getPropDisplayName(item) }}
+                        <div
+                          v-if="getCrewNamesForSettingItem(item, 'prop', smPlanScene).length > 0"
+                          class="crew-names"
+                        >
+                          {{ getCrewNamesForSettingItem(item, 'prop', smPlanScene).join(', ') }}
+                        </div>
+                      </li>
+                    </ul>
+                    <p v-else class="text-muted mb-0">None</p>
+                  </BCol>
+                </BRow>
+              </BContainer>
+            </BCardBody>
+          </BCollapse>
+        </BCard>
+        <BCard no-body class="mb-2">
+          <BCardHeader class="p-2" role="button" @click="smPlanStrike = !smPlanStrike">
+            <span>{{ smPlanStrike ? '▼' : '▶' }} Striking</span>
+          </BCardHeader>
+          <BCollapse v-model="smPlanStrike">
+            <BCardBody class="p-2">
+              <BContainer fluid class="mx-0 px-0">
+                <BRow class="plan-header-row">
+                  <BCol cols="6" class="plan-header-col border-end"><b>Scenery</b></BCol>
+                  <BCol cols="6" class="plan-header-col"><b>Props</b></BCol>
+                </BRow>
+                <BRow class="plan-content-row">
+                  <BCol cols="6" class="plan-content-col border-end">
+                    <ul v-if="getStrikingScenery(smPlanScene).length > 0" class="item-list mb-0">
+                      <li
+                        v-for="item in getStrikingScenery(smPlanScene)"
+                        :key="`strike-scenery-${item.id}`"
+                      >
+                        {{ getSceneryDisplayName(item) }}
+                        <div
+                          v-if="
+                            getCrewNamesForStrikingItem(item, 'scenery', smPlanScene).length > 0
+                          "
+                          class="crew-names"
+                        >
+                          {{ getCrewNamesForStrikingItem(item, 'scenery', smPlanScene).join(', ') }}
+                        </div>
+                      </li>
+                    </ul>
+                    <p v-else class="text-muted mb-0">None</p>
+                  </BCol>
+                  <BCol cols="6" class="plan-content-col">
+                    <ul v-if="getStrikingProps(smPlanScene).length > 0" class="item-list mb-0">
+                      <li
+                        v-for="item in getStrikingProps(smPlanScene)"
+                        :key="`strike-prop-${item.id}`"
+                      >
+                        {{ getPropDisplayName(item) }}
+                        <div
+                          v-if="getCrewNamesForStrikingItem(item, 'prop', smPlanScene).length > 0"
+                          class="crew-names"
+                        >
+                          {{ getCrewNamesForStrikingItem(item, 'prop', smPlanScene).join(', ') }}
+                        </div>
+                      </li>
+                    </ul>
+                    <p v-else class="text-muted mb-0">None</p>
+                  </BCol>
+                </BRow>
+              </BContainer>
+            </BCardBody>
+          </BCollapse>
+        </BCard>
+      </div>
+      <div v-else><p>No scene selected.</p></div>
+    </BModal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue';
+import { debounce } from 'lodash';
+import { useShowStore } from '@/stores/show';
+import { useStageStore } from '@/stores/stage';
+import { useScriptStore } from '@/stores/script';
+import type { Scene } from '@/types/api/show';
+import type { Props, Scenery } from '@/types/api/stage';
+
+const props = defineProps<{
+  sessionFollowData: Record<string, unknown>;
+}>();
+
+const showStore = useShowStore();
+const stageStore = useStageStore();
+const scriptStore = useScriptStore();
+
+const loaded = ref(false);
+const expandedScenes = ref<Record<number, boolean>>({});
+const pinnedScenes = ref<Record<number, boolean>>({});
+const smPlanScene = ref<Scene | null>(null);
+const smPlanSet = ref(true);
+const smPlanStrike = ref(true);
+const paneContainer = ref<HTMLElement | null>(null);
+const scrollContainer = ref<HTMLElement | null>(null);
+const smPlanModal = ref<InstanceType<typeof import('bootstrap-vue-next').BModal> | null>(null);
+const sceneCardRefs = ref<Record<number, Element>>({});
+
+function setSceneCardRef(el: unknown, sceneId: number): void {
+  if (el && (el as Element).tagName) sceneCardRefs.value[sceneId] = el as Element;
+}
+
+const currentSceneId = computed((): number | null => {
+  const lineRef = props.sessionFollowData?.current_line as string | undefined;
+  if (!lineRef) return null;
+  const parts = lineRef.split('_');
+  if (parts.length < 4) return null;
+  const page = parseInt(parts[1], 10);
+  const lineIdx = parseInt(parts[3], 10);
+  return scriptStore.getScriptPage(page)[lineIdx]?.scene_id ?? null;
+});
+
+const nextSceneId = computed((): number | null => {
+  if (currentSceneId.value === null) return null;
+  const idx = showStore.orderedScenes.findIndex((s) => s.id === currentSceneId.value);
+  if (idx === -1 || idx >= showStore.orderedScenes.length - 1) return null;
+  return showStore.orderedScenes[idx + 1].id;
+});
+
+watch(currentSceneId, (newId, oldId) => {
+  if (newId !== null && newId !== oldId) {
+    const idx = showStore.orderedScenes.findIndex((s) => s.id === newId);
+    const autoExpand = new Set([newId]);
+    if (idx !== -1 && idx < showStore.orderedScenes.length - 1) {
+      autoExpand.add(showStore.orderedScenes[idx + 1].id);
+    }
+    showStore.orderedScenes.forEach((s) => {
+      if (!autoExpand.has(s.id) && !pinnedScenes.value[s.id]) {
+        expandedScenes.value[s.id] = false;
+      }
+    });
+    autoExpand.forEach((id) => {
+      expandedScenes.value[id] = true;
+    });
+    nextTick(() => autoScrollToCurrentScene(newId));
+  }
+});
+
+watch(
+  () => showStore.orderedScenes,
+  (scenes) => {
+    scenes.forEach((scene, index) => {
+      if (expandedScenes.value[scene.id] === undefined) {
+        expandedScenes.value[scene.id] = index === 0;
+      }
+    });
+  },
+  { immediate: true }
+);
+
+const debounceComputeContentSize = debounce(computeContentSize, 100);
+
+onMounted(async () => {
+  await Promise.all([
+    showStore.getActList(),
+    showStore.getSceneList(),
+    stageStore.getPropsList(),
+    stageStore.getSceneryList(),
+    stageStore.getPropsAllocations(),
+    stageStore.getSceneryAllocations(),
+    stageStore.getPropTypes(),
+    stageStore.getSceneryTypes(),
+    stageStore.getCrewList(),
+    stageStore.getCrewAssignments(),
+  ]);
+  loaded.value = true;
+  await nextTick();
+  computeContentSize();
+  window.addEventListener('resize', debounceComputeContentSize);
+});
+
+onUnmounted(() => window.removeEventListener('resize', debounceComputeContentSize));
+
+function computeContentSize(): void {
+  if (!paneContainer.value) return;
+  const top = paneContainer.value.getBoundingClientRect().top;
+  paneContainer.value.style.height = `${document.documentElement.clientHeight - top}px`;
+}
+
+function toggleScene(sceneId: number): void {
+  const isExpanded = expandedScenes.value[sceneId];
+  expandedScenes.value[sceneId] = !isExpanded;
+  pinnedScenes.value[sceneId] = !isExpanded;
+}
+
+function getSceneDisplayName(scene: Scene): string {
+  const act = showStore.actById(scene.act);
+  return `${act?.name ?? 'Unknown Act'}: ${scene.name}`;
+}
+
+function getPropsForScene(sceneId: number): Props[] {
+  return stageStore.propsAllocations
+    .filter((a) => a.scene_id === sceneId)
+    .map((a) => stageStore.propById(a.props_id)!)
+    .filter(Boolean);
+}
+
+function getSceneryForScene(sceneId: number): Scenery[] {
+  return stageStore.sceneryAllocations
+    .filter((a) => a.scene_id === sceneId)
+    .map((a) => stageStore.sceneryById(a.scenery_id)!)
+    .filter(Boolean);
+}
+
+function getPreviousScene(scene: Scene): Scene | null {
+  const idx = showStore.orderedScenes.findIndex((s) => s.id === scene.id);
+  return idx > 0 ? showStore.orderedScenes[idx - 1] : null;
+}
+
+function getSettingProps(scene: Scene): Props[] {
+  const current = getPropsForScene(scene.id);
+  const prev = getPreviousScene(scene);
+  if (!prev) return current;
+  const prevIds = new Set(getPropsForScene(prev.id).map((p) => p.id));
+  return current.filter((p) => !prevIds.has(p.id));
+}
+
+function getStrikingProps(scene: Scene): Props[] {
+  const prev = getPreviousScene(scene);
+  if (!prev) return [];
+  const currentIds = new Set(getPropsForScene(scene.id).map((p) => p.id));
+  return getPropsForScene(prev.id).filter((p) => !currentIds.has(p.id));
+}
+
+function getSettingScenery(scene: Scene): Scenery[] {
+  const current = getSceneryForScene(scene.id);
+  const prev = getPreviousScene(scene);
+  if (!prev) return current;
+  const prevIds = new Set(getSceneryForScene(prev.id).map((s) => s.id));
+  return current.filter((s) => !prevIds.has(s.id));
+}
+
+function getStrikingScenery(scene: Scene): Scenery[] {
+  const prev = getPreviousScene(scene);
+  if (!prev) return [];
+  const currentIds = new Set(getSceneryForScene(scene.id).map((s) => s.id));
+  return getSceneryForScene(prev.id).filter((s) => !currentIds.has(s.id));
+}
+
+function getPropDisplayName(prop: Props): string {
+  const type = stageStore.propTypeById(prop.prop_type_id);
+  return type ? `${type.name}: ${prop.name}` : (prop.name ?? '');
+}
+
+function getSceneryDisplayName(scenery: Scenery): string {
+  const type = stageStore.sceneryTypeById(scenery.scenery_type_id);
+  return type ? `${type.name}: ${scenery.name}` : (scenery.name ?? '');
+}
+
+function formatCrewName(crewId: number | null): string {
+  const c = stageStore.crewById(crewId);
+  if (!c) return 'Unknown';
+  return c.last_name ? `${c.first_name} ${c.last_name}` : (c.first_name ?? '');
+}
+
+function getCrewNamesForSettingItem(
+  item: Props | Scenery,
+  itemType: 'prop' | 'scenery',
+  scene: Scene
+): string[] {
+  const assignments =
+    itemType === 'prop'
+      ? (stageStore.crewAssignmentsByProp[item.id] ?? [])
+      : (stageStore.crewAssignmentsByScenery[item.id] ?? []);
+  return assignments
+    .filter((a) => a.assignment_type === 'set' && a.scene_id === scene.id)
+    .map((a) => formatCrewName(a.crew_id));
+}
+
+function getCrewNamesForStrikingItem(
+  item: Props | Scenery,
+  itemType: 'prop' | 'scenery',
+  scene: Scene
+): string[] {
+  const prev = getPreviousScene(scene);
+  if (!prev) return [];
+  const assignments =
+    itemType === 'prop'
+      ? (stageStore.crewAssignmentsByProp[item.id] ?? [])
+      : (stageStore.crewAssignmentsByScenery[item.id] ?? []);
+  return assignments
+    .filter((a) => a.assignment_type === 'strike' && a.scene_id === prev.id)
+    .map((a) => formatCrewName(a.crew_id));
+}
+
+function autoScrollToCurrentScene(currentId: number): void {
+  if (!scrollContainer.value) return;
+  const idx = showStore.orderedScenes.findIndex((s) => s.id === currentId);
+  const targetId = idx > 0 ? showStore.orderedScenes[idx - 1].id : currentId;
+  const el = sceneCardRefs.value[targetId];
+  if (!el) return;
+  const containerTop = scrollContainer.value.getBoundingClientRect().top;
+  const elTop = el.getBoundingClientRect().top;
+  scrollContainer.value.scrollTo({
+    top: elTop - containerTop + scrollContainer.value.scrollTop,
+    behavior: 'smooth',
+  });
+}
+
+function showSMPlanModal(scene: Scene): void {
+  smPlanScene.value = scene;
+  smPlanSet.value = true;
+  smPlanStrike.value = true;
+  smPlanModal.value?.show();
+}
+</script>
+
+<style scoped>
+.stage-manager-pane {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+  background-color: var(--body-background, #222);
+}
+.pane-header {
+  flex-shrink: 0;
+  padding: 0.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  background-color: rgba(0, 0, 0, 0.2);
+}
+.scenes-container {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0.5rem;
+  min-height: 0;
+}
+.loading-state,
+.empty-state {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 1;
+  padding: 1rem;
+}
+.scene-card {
+  background-color: #303030;
+  border: 1px solid #444;
+  border-radius: 0.25rem;
+}
+.scene-card.current-scene {
+  border-color: #28a745;
+  border-width: 2px;
+}
+.scene-card.next-scene {
+  border-color: #2863a7;
+  border-width: 2px;
+}
+.scene-header {
+  cursor: pointer;
+  background-color: #3a3a3a;
+  border-bottom: 1px solid #444;
+  transition: background-color 0.15s ease-in-out;
+}
+.scene-header:hover {
+  background-color: #454545;
+}
+.current-scene .scene-header {
+  background-color: #1a472a;
+}
+.next-scene .scene-header {
+  background-color: #1a3147;
+}
+.current-scene .scene-header:hover {
+  background-color: #215d35;
+}
+.next-scene .scene-header:hover {
+  background-color: #28476b;
+}
+.scene-title {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: #dee2e6;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.scene-badges {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+.scene-body {
+  background-color: #303030;
+}
+.section-label {
+  display: block;
+  color: #6c757d;
+  font-weight: 600;
+  text-transform: uppercase;
+  margin-bottom: 0.25rem;
+}
+.item-list {
+  list-style: none;
+  padding-left: 0.5rem;
+  margin: 0;
+}
+.item-list li {
+  color: #adb5bd;
+  padding: 0.1rem 0;
+}
+.empty-scene {
+  color: #6c757d;
+  font-style: italic;
+}
+.plan-header-row {
+  margin: 0;
+  padding: 0;
+  border-bottom: 1px solid #dee2e6;
+}
+.plan-header-col {
+  padding: 0.5rem 0.75rem;
+}
+.plan-content-row {
+  margin: 0;
+  padding: 0;
+}
+.plan-content-col {
+  padding: 0.5rem 0.75rem;
+}
+.crew-names {
+  color: #6c757d;
+  font-size: 0.8rem;
+  padding-left: 0.5rem;
+  font-style: italic;
+}
+</style>

--- a/client-v3/src/components/user/settings/AboutUser.vue
+++ b/client-v3/src/components/user/settings/AboutUser.vue
@@ -1,8 +1,8 @@
 <template>
-  <BTableSimple class="w-100">
+  <BTableSimple class="w-100 text-center">
     <BTbody>
       <BTr v-for="key in orderedKeys" :key="key">
-        <BTh>{{ key }}</BTh>
+        <BTh scope="row">{{ key }}</BTh>
         <BTd>{{ tableData[key] != null ? tableData[key] : 'N/A' }}</BTd>
       </BTr>
     </BTbody>

--- a/client-v3/src/composables/useWebSocket.ts
+++ b/client-v3/src/composables/useWebSocket.ts
@@ -167,14 +167,22 @@ function connect(): void {
   log.debug('Connecting to WebSocket:', wsURL);
   ws = new WebSocket(wsURL);
 
-  ws.onopen = () => {
+  ws.onopen = async () => {
+    const wasErrored = errorCount > 0;
     wsStore.$patch({ isConnected: true });
-    if (errorCount > 0) {
+    if (wasErrored) {
       toast.success(
         `WebSocket reconnected after ${errorCount} attempt${errorCount > 1 ? 's' : ''}`
       );
     }
     log.info('WebSocket connected');
+    if (wasErrored) {
+      const { useShowStore } = await import('@/stores/show');
+      const showStore = useShowStore();
+      if (showStore.currentSession != null) {
+        await showStore.getShowSessionData();
+      }
+    }
   };
 
   ws.onmessage = (event: MessageEvent) => {

--- a/client-v3/src/composables/useWebSocket.ts
+++ b/client-v3/src/composables/useWebSocket.ts
@@ -77,13 +77,13 @@ async function handleMessage(msg: WsMessage): Promise<void> {
       settingsChangedToast();
       break;
     case 'START_SHOW':
-      if (router.currentRoute.value.path !== '/ui-new/live') {
-        router.push('/ui-new/live');
+      if (router.currentRoute.value.path !== '/live') {
+        router.push('/live');
       }
       break;
     case 'STOP_SHOW':
-      if (router.currentRoute.value.path !== '/ui-new/') {
-        router.push('/ui-new/');
+      if (router.currentRoute.value.path !== '/') {
+        router.push('/');
       }
       break;
     case 'RELOAD_CLIENT':

--- a/client-v3/src/router/index.ts
+++ b/client-v3/src/router/index.ts
@@ -2,7 +2,6 @@ import { createRouter, createWebHistory } from 'vue-router';
 import { isElectron } from '@/js/platform';
 import HomeView from '@/views/HomeView.vue';
 import NotFoundView from '@/views/NotFoundView.vue';
-import PlaceholderView from '@/views/PlaceholderView.vue';
 
 const router = createRouter({
   history: createWebHistory('/ui-new/'),
@@ -108,7 +107,7 @@ const router = createRouter({
       path: '/live',
       name: 'live',
       component: () => import('@/views/show/ShowLiveView.vue'),
-      meta: { requiresAuth: true },
+      meta: { requiresAuth: false },
     },
     {
       path: '/me',
@@ -120,7 +119,7 @@ const router = createRouter({
       path: '/force-password-change',
       name: 'force-password-change',
       component: () => import('@/views/user/ForcePasswordChangeView.vue'),
-      meta: { requiresAuth: true },
+      meta: { requiresAuth: true, requiresPasswordChange: true },
     },
     {
       path: '/help',
@@ -149,7 +148,7 @@ const router = createRouter({
   ],
 });
 
-router.beforeEach(async (to) => {
+router.beforeEach(async (to, from) => {
   const { useSystemStore } = await import('@/stores/system');
   const { useUserStore } = await import('@/stores/user');
   const { toast } = await import('@/js/toast');
@@ -210,7 +209,7 @@ router.beforeEach(async (to) => {
   // Already logged in — don't show login page
   if (to.path === '/login' && isAuthenticated) {
     toast.info('You are already logged in');
-    return '/';
+    return from.fullPath === '/login' ? '/' : from.fullPath;
   }
 
   // Require auth

--- a/client-v3/src/router/index.ts
+++ b/client-v3/src/router/index.ts
@@ -107,8 +107,8 @@ const router = createRouter({
     {
       path: '/live',
       name: 'live',
-      component: PlaceholderView,
-      meta: { requiresAuth: false },
+      component: () => import('@/views/show/ShowLiveView.vue'),
+      meta: { requiresAuth: true },
     },
     {
       path: '/me',

--- a/client-v3/src/router/index.ts
+++ b/client-v3/src/router/index.ts
@@ -250,10 +250,17 @@ router.beforeEach(async (to) => {
     }
   }
 
-  // Live page requires an active show session
+  // Live page requires an active show session and a healthy WebSocket
   if (to.path === '/live') {
-    // Show session check added in Phase 6 when show store is available
-    // For now, allow navigation (the live page itself will handle the guard)
+    const { useShowStore } = await import('@/stores/show');
+    const { useWebSocketStore } = await import('@/stores/websocket');
+    const showStore = useShowStore();
+    const wsStore = useWebSocketStore();
+    await showStore.getShowSessionData();
+    if (!showStore.currentSession || !wsStore.websocketHealthy) {
+      toast.error('No active show session or connection issue');
+      return '/';
+    }
   }
 
   return undefined;

--- a/client-v3/src/stores/script.ts
+++ b/client-v3/src/stores/script.ts
@@ -224,5 +224,57 @@ export const useScriptStore = defineStore('script', {
         toast.error('Unable to add new cue');
       }
     },
+
+    async editCue(cue: {
+      cueId: number;
+      cueType: number;
+      ident: string;
+      lineId: number;
+    }): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/cues'), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(cue),
+      });
+      if (response.ok) {
+        await this.loadCues();
+        toast.success('Edited cue!');
+      } else {
+        toast.error('Unable to edit cue');
+      }
+    },
+
+    async deleteCue(cue: { cueId: number; lineId: number }): Promise<void> {
+      const params = new URLSearchParams({
+        cueId: String(cue.cueId),
+        lineId: String(cue.lineId),
+      });
+      const response = await fetch(`${makeURL('/api/v1/show/cues')}?${params}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (response.ok) {
+        await this.loadCues();
+        toast.success('Deleted cue!');
+      } else {
+        toast.error('Unable to delete cue');
+      }
+    },
+
+    async searchCues(payload: {
+      identifier: string;
+      cueTypeId: number;
+    }): Promise<Record<string, unknown>> {
+      const params = new URLSearchParams({
+        identifier: payload.identifier,
+        cue_type_id: String(payload.cueTypeId),
+      });
+      const response = await fetch(`${makeURL('/api/v1/show/cues/search')}?${params}`);
+      if (response.ok) {
+        return response.json() as Promise<Record<string, unknown>>;
+      }
+      log.error('Unable to search for cue');
+      throw new Error('Cue search failed');
+    },
   },
 });

--- a/client-v3/src/stores/script.ts
+++ b/client-v3/src/stores/script.ts
@@ -8,6 +8,7 @@ import type {
   CompiledScript,
   ScriptCut,
 } from '@/types/api/script';
+import type { Cue } from '@/types/api/cues';
 
 export const useScriptStore = defineStore('script', {
   state: () => ({
@@ -16,6 +17,7 @@ export const useScriptStore = defineStore('script', {
     compiledScripts: [] as CompiledScript[],
     cuts: [] as ScriptCut[],
     maxPage: 1,
+    cues: {} as Record<string, Cue[]>,
   }),
 
   getters: {
@@ -27,6 +29,10 @@ export const useScriptStore = defineStore('script', {
       (state) =>
       (id: number | null): StageDirectionStyle | null =>
         id != null ? (state.stageDirectionStyles.find((s) => s.id === id) ?? null) : null,
+    cuesForLine:
+      (state) =>
+      (lineId: number | null): Cue[] =>
+        lineId != null ? (state.cues[String(lineId)] ?? []) : [],
   },
 
   actions: {
@@ -193,6 +199,30 @@ export const useScriptStore = defineStore('script', {
 
     clearScript(): void {
       this.script = {};
+    },
+
+    async loadCues(): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/cues'));
+      if (response.ok) {
+        const data = await response.json();
+        this.cues = data.cues as Record<string, Cue[]>;
+      } else {
+        log.error('Unable to load cues');
+      }
+    },
+
+    async addNewCue(cue: { cueType: number; ident: string; lineId: number }): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/cues'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(cue),
+      });
+      if (response.ok) {
+        await this.loadCues();
+        toast.success('Added new cue!');
+      } else {
+        toast.error('Unable to add new cue');
+      }
     },
   },
 });

--- a/client-v3/src/stores/show.ts
+++ b/client-v3/src/stores/show.ts
@@ -2,6 +2,9 @@ import { defineStore } from 'pinia';
 import log from 'loglevel';
 import { makeURL } from '@/js/utils';
 import { toast } from '@/js/toast';
+import type { ActiveToast } from 'vue-toast-notification';
+
+let noLeaderToast: ActiveToast | null = null;
 import { detectMicConflicts } from '@/js/micConflictUtils';
 import type { MicConflict, MicConflictResult } from '@/js/micConflictUtils';
 import type { Cast, Character, CharacterGroup, Act, Scene } from '@/types/api/show';
@@ -544,6 +547,10 @@ export const useShowStore = defineStore('show', {
         this.sessions = data.sessions;
         this.currentSession = data.current_session;
         this.currentInterval = data.current_interval;
+        if (this.currentSession?.client_internal_id != null) {
+          noLeaderToast?.dismiss();
+          noLeaderToast = null;
+        }
       } else {
         log.error('Unable to get show sessions');
       }
@@ -794,11 +801,17 @@ export const useShowStore = defineStore('show', {
 
     // WS-triggered actions
     async electedLeader(): Promise<void> {
+      noLeaderToast?.dismiss();
+      noLeaderToast = null;
       toast.info('You are now leader of the script - other clients will follow your view');
     },
     async noLeader(): Promise<void> {
       await this.getShowSessionData();
-      toast.warning('There is no script leader. Please scroll your own script!');
+      noLeaderToast?.dismiss();
+      noLeaderToast = toast.warning('There is no script leader. Please scroll your own script!', {
+        duration: 0,
+        dismissible: true,
+      });
     },
     scriptScroll(data: Record<string, unknown>): void {
       this.sessionFollowData = data;

--- a/client-v3/src/stores/system.ts
+++ b/client-v3/src/stores/system.ts
@@ -5,6 +5,7 @@ import { toast } from '@/js/toast';
 import type { Show } from '@/types/api/show';
 import type { SystemSettings } from '@/types/api/settings';
 import { useUserStore } from '@/stores/user';
+import router from '@/router';
 
 interface ConnectedSession {
   internal_id: string;
@@ -172,14 +173,21 @@ export const useSystemStore = defineStore('system', {
       await this.getRawSettings();
 
       if (this.settings.current_show) {
-        const response = await fetch(makeURL('/api/v1/show'));
-        if (response.ok) {
-          this.currentShow = await response.json();
-        } else {
-          log.error('Unable to fetch current show');
+        const currShowId = this.settings.current_show;
+        if (!this.currentShow || this.currentShow.id !== currShowId) {
+          const response = await fetch(makeURL('/api/v1/show'));
+          if (response.ok) {
+            this.currentShow = await response.json();
+          } else {
+            log.error('Unable to fetch current show');
+          }
         }
       } else {
         this.currentShow = null;
+        const currentPath = router.currentRoute.value.path;
+        if (currentPath.startsWith('/show-config') || currentPath.startsWith('/live')) {
+          router.push('/');
+        }
       }
     },
     async getShowDetails(): Promise<void> {

--- a/client-v3/src/views/HomeView.vue
+++ b/client-v3/src/views/HomeView.vue
@@ -24,14 +24,15 @@ import { computed } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useSystemStore } from '@/stores/system';
 import { useUserStore } from '@/stores/user';
+import { useShowStore } from '@/stores/show';
 
 const systemStore = useSystemStore();
 const userStore = useUserStore();
+const showStore = useShowStore();
 
 const { currentShow, settings } = storeToRefs(systemStore);
 
-// Stub until Phase 6 wires in the show store
-const currentShowSession = computed(() => null);
+const currentShowSession = computed(() => showStore.currentSession);
 
 const isAdminUser = computed(() => userStore.currentUser?.is_admin ?? false);
 </script>

--- a/client-v3/src/views/show/ShowLiveView.vue
+++ b/client-v3/src/views/show/ShowLiveView.vue
@@ -225,4 +225,8 @@ onUnmounted(() => {
 .interval-overlay {
   padding: 2rem;
 }
+
+:deep(.default-theme.splitpanes .splitpanes__pane) {
+  background-color: var(--bs-body-bg);
+}
 </style>

--- a/client-v3/src/views/show/ShowLiveView.vue
+++ b/client-v3/src/views/show/ShowLiveView.vue
@@ -1,0 +1,228 @@
+<template>
+  <BContainer
+    fluid
+    class="mx-0"
+    :style="{ 'padding-right': showStore.stageManagerMode ? '0px' : '15px' }"
+  >
+    <BRow
+      class="session-header"
+      style="padding-top: 0.1rem; padding-bottom: 0.1rem"
+      :style="{ 'padding-right': showStore.stageManagerMode ? '15px' : '0px' }"
+    >
+      <BCol cols="4" style="text-align: left">
+        <b v-if="isScriptFollowing">{{ systemStore.currentShow?.name }} - Following</b>
+        <b v-else-if="isScriptLeader">{{ systemStore.currentShow?.name }} - Leading</b>
+        <b v-else>{{ systemStore.currentShow?.name }} - Manual</b>
+      </BCol>
+      <BCol cols="4" style="text-align: center">
+        <b>Page {{ currentPage }}</b>
+      </BCol>
+      <BCol cols="4" style="text-align: right">
+        <b>Elapsed Time: {{ msToTimerString(elapsedTime) }}</b>
+      </BCol>
+    </BRow>
+    <BOverlay :show="showStore.currentInterval != null" rounded="sm" variant="secondary">
+      <template #overlay>
+        <div class="text-center interval-overlay">
+          <BContainer fluid class="mx-0">
+            <BRow>
+              <BCol class="d-flex align-items-center justify-content-center">
+                <h3>{{ intervalOverlayHeading }} - Interval in Progress ⏱</h3>
+              </BCol>
+            </BRow>
+            <BRow v-if="intervalTimerActive">
+              <BCol class="d-flex align-items-center justify-content-center">
+                <h1 style="margin-top: 0.5rem">
+                  <span :style="intervalTimerStyle">{{ intervalTimerValues[0] }}</span
+                  >:<span :style="intervalTimerStyle">{{ intervalTimerValues[1] }}</span
+                  >:<span :style="intervalTimerStyle">{{ intervalTimerValues[2] }}</span>
+                </h1>
+              </BCol>
+            </BRow>
+            <BRow style="margin-top: 0.5rem">
+              <BCol class="d-flex align-items-center justify-content-center">
+                <BButton v-if="isScriptLeader" variant="primary" @click.stop="stopInterval">
+                  Stop Interval
+                </BButton>
+              </BCol>
+            </BRow>
+          </BContainer>
+        </div>
+      </template>
+      <Splitpanes class="default-theme">
+        <Pane>
+          <ScriptViewPane
+            :is-script-following="isScriptFollowing"
+            :is-script-leader="isScriptLeader"
+            :session-follow-data="showStore.sessionFollowData"
+            :initial-line-ref="showStore.currentSession?.latest_line_ref ?? null"
+            :interval-active="showStore.currentInterval != null"
+            :script-mode="systemStore.currentShow?.script_mode ?? 1"
+            :stage-manager-mode="showStore.stageManagerMode"
+            @page-change="currentPage = $event"
+          />
+        </Pane>
+        <Pane v-if="showStore.stageManagerMode" :size="20">
+          <StageManagerPane :session-follow-data="showStore.sessionFollowData" />
+        </Pane>
+      </Splitpanes>
+    </BOverlay>
+  </BContainer>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
+import { Splitpanes, Pane } from 'splitpanes';
+import 'splitpanes/dist/splitpanes.css';
+
+import { formatTimerParts, msToTimerParts, msToTimerString } from '@/js/utils';
+import { useShowStore } from '@/stores/show';
+import { useSystemStore } from '@/stores/system';
+import { useWebSocketStore } from '@/stores/websocket';
+import { useWebSocket } from '@/composables/useWebSocket';
+import { toast } from '@/js/toast';
+import ScriptViewPane from '@/components/show/live/ScriptViewPane.vue';
+import StageManagerPane from '@/components/show/live/StageManagerPane.vue';
+
+const showStore = useShowStore();
+const systemStore = useSystemStore();
+const wsStore = useWebSocketStore();
+const { sendObj } = useWebSocket();
+
+// Session header state
+const loadedSessionData = ref(false);
+const currentPage = ref(1);
+
+// Elapsed time
+const elapsedTime = ref(0);
+let elapsedTimer: ReturnType<typeof setInterval> | null = null;
+let startTime: Date | null = null;
+
+// Interval timer
+let intervalTimerHandle: ReturnType<typeof setInterval> | null = null;
+let intervalStartDate: Date | null = null;
+const isIntervalLong = ref(false);
+const intervalTimerValues = ref<(string | number)[]>([0, 0, 0]);
+const intervalRemainingTime = ref(0);
+const intervalTimerActive = ref(false);
+
+// Computed
+
+const isScriptLeader = computed(
+  () =>
+    loadedSessionData.value && showStore.currentSession?.client_internal_id === wsStore.internalUUID
+);
+
+const isScriptFollowing = computed(
+  () =>
+    loadedSessionData.value &&
+    showStore.currentSession?.client_internal_id != null &&
+    !isScriptLeader.value
+);
+
+const intervalOverlayHeading = computed(() => {
+  if (!showStore.currentInterval || showStore.actList.length === 0) return '';
+  return showStore.actList.find((a) => a.id === showStore.currentInterval!.act_id)?.name ?? '';
+});
+
+const intervalTimerColour = computed(() => {
+  if (isIntervalLong.value) return '#cc0000';
+  const initialLength = (showStore.currentInterval?.initial_length ?? 1) * 1000;
+  const progress = Math.abs(intervalRemainingTime.value) / initialLength;
+  return progress > 0.25 ? '#00cc00' : '#d76113';
+});
+
+const intervalTimerStyle = computed(() => ({
+  margin: '.5rem',
+  'border-radius': '3px',
+  color: '#ffffff',
+  'background-color': intervalTimerColour.value,
+  padding: '.25rem',
+}));
+
+// Methods
+
+function createDateAsUTC(date: Date): Date {
+  return new Date(
+    Date.UTC(
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate(),
+      date.getHours(),
+      date.getMinutes(),
+      date.getSeconds()
+    )
+  );
+}
+
+function updateElapsedTime(): void {
+  if (startTime != null) elapsedTime.value = Date.now() - startTime.getTime();
+}
+
+function stopInterval(): void {
+  sendObj({ OP: 'END_INTERVAL', DATA: {} });
+  toast.success('Interval stopped!');
+}
+
+function updateIntervalTimer(): void {
+  if (!intervalStartDate || !showStore.currentInterval) return;
+  const elapsed = Date.now() - intervalStartDate.getTime();
+  intervalRemainingTime.value = showStore.currentInterval.initial_length! * 1000 - elapsed;
+  isIntervalLong.value = intervalRemainingTime.value < 0;
+  intervalTimerValues.value = formatTimerParts(
+    ...msToTimerParts(Math.abs(intervalRemainingTime.value))
+  );
+}
+
+function setupIntervalTimer(): void {
+  if (intervalTimerHandle !== null) {
+    clearInterval(intervalTimerHandle);
+    intervalTimerHandle = null;
+  }
+  intervalTimerValues.value = [0, 0, 0];
+  isIntervalLong.value = false;
+  intervalRemainingTime.value = 0;
+  intervalTimerActive.value = false;
+
+  if (showStore.currentInterval) {
+    intervalStartDate = createDateAsUTC(
+      new Date(showStore.currentInterval.start_datetime!.replace(' ', 'T'))
+    );
+    updateIntervalTimer();
+    intervalTimerActive.value = true;
+    intervalTimerHandle = setInterval(updateIntervalTimer, 500);
+  }
+}
+
+watch(() => showStore.currentInterval, setupIntervalTimer);
+
+onMounted(async () => {
+  await Promise.all([showStore.getShowSessionData(), showStore.getActList()]);
+  loadedSessionData.value = true;
+
+  if (showStore.currentInterval != null) setupIntervalTimer();
+
+  if (showStore.currentSession?.start_date_time) {
+    startTime = createDateAsUTC(
+      new Date(showStore.currentSession.start_date_time.replace(' ', 'T'))
+    );
+  }
+  updateElapsedTime();
+  elapsedTimer = setInterval(updateElapsedTime, 1000);
+});
+
+onUnmounted(() => {
+  if (elapsedTimer !== null) clearInterval(elapsedTimer);
+  if (intervalTimerHandle !== null) clearInterval(intervalTimerHandle);
+});
+</script>
+
+<style scoped>
+.session-header {
+  border-bottom: 0.1rem solid #3498db;
+}
+
+.interval-overlay {
+  padding: 2rem;
+}
+</style>

--- a/client-v3/src/views/show/config/ConfigCast.vue
+++ b/client-v3/src/views/show/config/ConfigCast.vue
@@ -142,7 +142,11 @@ const deletingCast = ref(false);
 const newCastModal = ref<InstanceType<typeof BModal>>();
 const editCastModal = ref<InstanceType<typeof BModal>>();
 
-const castFields = ['first_name', 'last_name', { key: 'btn', label: '' }];
+const castFields = [
+  { key: 'first_name', label: 'First Name' },
+  { key: 'last_name', label: 'Last Name' },
+  { key: 'btn', label: '' },
+];
 
 interface NewCastForm {
   firstName: string;

--- a/client-v3/src/views/show/config/ConfigCues.vue
+++ b/client-v3/src/views/show/config/ConfigCues.vue
@@ -60,7 +60,7 @@
             />
           </BTab>
           <BTab title="Cue Configuration">
-            <PlaceholderView />
+            <CueEditor />
           </BTab>
           <BTab title="Cue Counts">
             <CueCountStats />
@@ -222,7 +222,7 @@ import { useSystemStore } from '@/stores/system';
 import { useShowStore } from '@/stores/show';
 import { useConfirm } from '@/composables/useConfirm';
 import CueCountStats from '@/components/show/config/cues/CueCountStats.vue';
-import PlaceholderView from '@/views/PlaceholderView.vue';
+import CueEditor from '@/components/show/config/cues/CueEditor.vue';
 import type { CueType } from '@/types/api/cues';
 
 const systemStore = useSystemStore();


### PR DESCRIPTION
## Summary

- Ports the real-time live show execution view to Vue 3 + Pinia (5 new components)
- Ports the cue assignment editor to Vue 3 (3 new components, completing the Cue Configuration tab)
- Fixes all V2 parity gaps identified during pre-release audit
- **Full visual parity pass**: page-by-page Playwright comparison identified and resolved 15+ Bootstrap 4→5 visual differences

### Live Show View

- `ShowLiveView.vue`: session header bar, elapsed time counter, interval overlay with colour-coded countdown, Splitpanes layout with optional stage manager pane
- `ScriptViewPane.vue`: compiled-script-first loading with page-by-page fallback, keyboard/wheel navigation (leader only), lazy page loading via MutationObserver, add-cue and start-interval modals (Vuelidate v2), WebSocket `SCRIPT_SCROLL` dispatch
- `ScriptLineViewer.vue`: normal mode rendering — cue buttons with colour overrides, act/scene labels, interval banners at all act boundaries, stage direction styling, cue column left/right preference
- `ScriptLineViewerCompact.vue`: compact 2-column mode with cues as prefix/ident rows above content
- `StageManagerPane.vue`: ordered scene list with setting/striking props/scenery/crew per scene, auto-expands current + next scene tracking session follow data

### Cue Assignment Editor (Cue Configuration tab)

- `ScriptLineCueEditor.vue`: per-line cue display with add/edit/delete modals, RBAC-filtered cue type options (write-permission mask per type), and duplicate-ident validation
- `JumpToCueModal.vue`: fuzzy cue search with exact/suggestion/no-match states and similarity % badge; auto-navigates on single exact match
- `CueEditor.vue`: page navigator with `localStorage('cueEditPage')` persistence, Go To Page modal, and adjacent-page pre-fetching; replaces `PlaceholderView` in Cue Configuration tab

### Store changes

- `stores/script.ts`: adds `cues` state, `cuesForLine` getter, `loadCues()`, `addNewCue()`, `editCue()`, `deleteCue()`, and `searchCues()` actions
- `router/index.ts`: replaces `PlaceholderView` for `/live` with `ShowLiveView`

## Visual parity fixes (Bootstrap 4 → 5)

Global CSS (`dark.scss` SCSS variable overrides):
- Border-radius: `.375rem` → `.25rem` (BS4 default)
- Table cell padding: `.5rem` → `.75rem` (BS4 default)
- Dropdown item padding: `1rem` → `1.5rem` (BS4 default)
- Link decoration: none (BS5 Reboot adds underline)
- Active navbar route: teal `#00bc8c` highlight (V2 `dark.scss` rule)
- Vertical nav-pills: full-width + centered (BS4 block behaviour)

Per-component fixes:
- `ConfigActs`: Interval After badge → check-square/x-square SVG icons (match V2)
- `ScriptRevisions`: checkmark span → check-square SVG; add Edit button; remove `size="sm"`; chevron SVG collapse toggle
- `CrewList`: "Add Crew Member" → "New Crew Member"
- `MicList`: "Add Microphone" → "New Microphone"
- `SessionTagDropdown`: ✏️ emoji → inline pencil-fill Bootstrap icon SVG
- `ConfigCast`: explicit `'First Name'`/`'Last Name'` labels (BVN auto-label only capitalises first word)
- `AboutUser`: `text-center` + `scope="row"` to match V2's centred table

## Bug fixes (V2 parity)

- **Session wiring**: `currentShowSession` in `HomeView.vue` was hardcoded `null` — now wired to `showStore.currentSession`
- **Router push path**: `START_SHOW`/`STOP_SHOW` WS handlers corrected for Vue Router 4 base handling
- **No-leader toast**: persistent toast stored as handle; dismissed by `electedLeader()` and `getShowSessionData()`
- **v-once cache collision**: Removed `v-once` from double-nested `v-for`
- **Cue rendering**: Fixed `contrastColor()` call signature
- **Splitpanes background**: Added `:deep` CSS override for dark-mode pane background
- **Stage Manager toggle**: Added to Live Config navbar dropdown
- **Interval banner**: Changed to show at all act boundaries (V2 behaviour)
- **`cue_position_right` default**: Changed to `false` to match backend column default
- **Modal keyboard blocking**: Arrow/Page/wheel navigation blocked when modals open
- **Reconnect refresh**: `ws.onopen` re-fetches session data after reconnect

## Test plan

- [x] `npm run build` — no errors
- [x] `npm run typecheck` — passes
- [x] `npm run ci-lint` — passes
- [x] `npm run test:run` — 23/23 pass
- [x] Page-by-page visual comparison (14 pages) — all major differences resolved
- [x] Browser at `/ui-new/live` — script loads, session header renders, cues display
- [x] Cue Configuration tab: navigation, modals, add/edit/delete all functional
- [x] No JavaScript console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)