### PR TITLE
Fix CodeQL alert 1154 and add client-v3 to CI tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,15 @@ updates:
     versioning-strategy: increase
     target-branch: dev
   - package-ecosystem: "npm"
+    directory: "/client-v3"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    versioning-strategy: increase
+    target-branch: dev
+  - package-ecosystem: "npm"
     directory: "/electron"
     schedule:
       interval: "daily"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -33,6 +33,9 @@ labels:
 - label: "client"
   files:
     - "electron/.*"
+- label: "client-v3"
+  files:
+    - "client-v3/.*"
 - label: "server"
   files:
     - "server/.*"

--- a/client-v3/src/composables/useWebSocket.ts
+++ b/client-v3/src/composables/useWebSocket.ts
@@ -139,7 +139,7 @@ async function dispatchAction(action: string, data: Record<string, unknown>): Pr
   if (pinia) {
     const storeMap = (pinia as unknown as { _s: Map<string, Record<string, unknown>> })._s;
     for (const store of storeMap.values()) {
-      if (typeof store[camelAction] === 'function') {
+      if (Object.hasOwn(store, camelAction) && typeof store[camelAction] === 'function') {
         await (store[camelAction] as (d: Record<string, unknown>) => Promise<void>)(data);
         return;
       }


### PR DESCRIPTION
## Summary

- **CodeQL #1154**: Adds `Object.hasOwn(store, camelAction)` guard before the dynamic Pinia dispatch in `client-v3/src/composables/useWebSocket.ts`. Without this, prototype-inherited names (`valueOf`, `hasOwnProperty`, etc.) could theoretically match the action name lookup — CodeQL flags this as `js/unvalidated-dynamic-method-call`. The fix ensures only own-property store actions are dispatched.
- **dependabot**: Adds an `npm` entry for `/client-v3` so Dependabot opens automated PRs against `dev` once this branch lands there.
- **labeler**: Adds a `client-v3` label rule covering `client-v3/.*` files so PRs get labelled correctly.

## Test plan

- [ ] `cd client-v3 && npm run typecheck` — passes
- [ ] `cd client-v3 && npm run ci-lint` — passes
- [ ] WS action dispatch works end-to-end (own-property store actions are unaffected by the guard)
- [ ] CodeQL alert 1154 resolves after this merges into `feature/vue3-migration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)