### PR TITLE
Fix SonarCloud reliability issues (PR #1036)

### DIFF
--- a/client-v3/src/components/show/config/cues/CueEditor.vue
+++ b/client-v3/src/components/show/config/cues/CueEditor.vue
@@ -145,7 +145,7 @@ onBeforeMount(async () => {
 
   const storedPage = localStorage.getItem('cueEditPage');
   if (storedPage != null) {
-    currentEditPage.value = parseInt(storedPage, 10);
+    currentEditPage.value = Number.parseInt(storedPage, 10);
   }
   await goToPageInner(currentEditPage.value);
 });

--- a/client-v3/src/components/show/config/mics/MicAllocations.vue
+++ b/client-v3/src/components/show/config/mics/MicAllocations.vue
@@ -220,7 +220,7 @@ const allocationByCharacter = computed((): Record<number, Record<number, string 
   });
 
   Object.keys(showStore.micAllocations).forEach((micId) => {
-    const mic = showStore.microphoneById(parseInt(micId, 10));
+    const mic = showStore.microphoneById(Number.parseInt(micId, 10));
     if (!mic) return;
     sortedScenes.value.forEach((scene) => {
       const charId = allAllocations.value[micId]?.[scene.id];
@@ -232,10 +232,10 @@ const allocationByCharacter = computed((): Record<number, Record<number, string 
 
   const result: Record<number, Record<number, string | null>> = {};
   Object.keys(temp).forEach((charId) => {
-    const charIdNum = parseInt(charId, 10);
+    const charIdNum = Number.parseInt(charId, 10);
     result[charIdNum] = {};
     Object.keys(temp[charIdNum]).forEach((sceneId) => {
-      const sceneIdNum = parseInt(sceneId, 10);
+      const sceneIdNum = Number.parseInt(sceneId, 10);
       const mics = temp[charIdNum][sceneIdNum];
       result[charIdNum][sceneIdNum] = mics.length > 0 ? mics.join(', ') : null;
     });
@@ -353,7 +353,7 @@ function getTooltipText(characterId: number, sceneId: number): string {
   const micNames: string[] = [];
   Object.keys(showStore.micAllocations).forEach((micId) => {
     if (allAllocations.value[micId]?.[sceneId] === characterId) {
-      const name = showStore.microphoneById(parseInt(micId, 10))?.name;
+      const name = showStore.microphoneById(Number.parseInt(micId, 10))?.name;
       if (name) micNames.push(name);
     }
   });

--- a/client-v3/src/components/show/config/mics/MicTimeline.vue
+++ b/client-v3/src/components/show/config/mics/MicTimeline.vue
@@ -277,7 +277,7 @@ function generateBarsForCharacter(
   Object.keys(allocations.value).forEach((micId) => {
     const micAllocs = allocations.value[micId];
     if (!Array.isArray(micAllocs)) return;
-    const micIdNum = parseInt(micId, 10);
+    const micIdNum = Number.parseInt(micId, 10);
     const segments: Seg[] = [];
     let current: Seg | null = null;
 
@@ -329,7 +329,7 @@ function generateBarsForCast(castId: number, rowIndex: number, bars: AllocationB
   Object.keys(allocations.value).forEach((micId) => {
     const micAllocs = allocations.value[micId];
     if (!Array.isArray(micAllocs)) return;
-    const micIdNum = parseInt(micId, 10);
+    const micIdNum = Number.parseInt(micId, 10);
     const segments: Seg[] = [];
     let current: Seg | null = null;
 

--- a/client-v3/src/components/show/config/mics/ResourceAvailability.vue
+++ b/client-v3/src/components/show/config/mics/ResourceAvailability.vue
@@ -122,7 +122,7 @@ const peakUsage = computed(() => {
     Object.keys(allocations.value).forEach((micId) => {
       const micAllocs = allocations.value[micId];
       if (Array.isArray(micAllocs) && micAllocs.some((a) => a.scene_id === scene.id)) {
-        micsInScene.add(parseInt(micId, 10));
+        micsInScene.add(Number.parseInt(micId, 10));
       }
     });
     max = Math.max(max, micsInScene.size);

--- a/client-v3/src/components/show/config/mics/SceneDensityHeatmap.vue
+++ b/client-v3/src/components/show/config/mics/SceneDensityHeatmap.vue
@@ -122,7 +122,7 @@ const sceneDensityData = computed((): SceneDensityEntry[] =>
     Object.keys(allocations.value).forEach((micId) => {
       const micAllocs = allocations.value[micId];
       if (Array.isArray(micAllocs) && micAllocs.some((a) => a.scene_id === scene.id)) {
-        micsInScene.add(parseInt(micId, 10));
+        micsInScene.add(Number.parseInt(micId, 10));
       }
     });
     return { scene, micCount: micsInScene.size };
@@ -169,7 +169,7 @@ const uniqueMicsUsed = computed(() => {
   Object.keys(allocations.value).forEach((micId) => {
     const micAllocs = allocations.value[micId];
     if (Array.isArray(micAllocs) && micAllocs.length > 0) {
-      allMics.add(parseInt(micId, 10));
+      allMics.add(Number.parseInt(micId, 10));
     }
   });
   return allMics.size;

--- a/client-v3/src/components/show/config/script/ScriptEditor.vue
+++ b/client-v3/src/components/show/config/script/ScriptEditor.vue
@@ -271,7 +271,7 @@ const saveProgressVariant = computed(() => {
 });
 
 const pagesWithOpenEdits = computed(() =>
-  [...editingLines.value].map((x) => parseInt(x.split('_')[1], 10))
+  [...editingLines.value].map((x) => Number.parseInt(x.split('_')[1], 10))
 );
 
 const scriptChanges = computed<boolean>(() => {
@@ -404,8 +404,7 @@ function blankLine(lineType: number): ScriptLine {
     scene_id: null,
     page: currentPage.value,
     line_type: lineType,
-    line_parts:
-      lineType === LINE_TYPES.DIALOGUE || lineType === LINE_TYPES.STAGE_DIRECTION ? [] : [],
+    line_parts: [],
     stage_direction_style_id: null,
   };
 }
@@ -442,8 +441,8 @@ async function insertLineAt(pageIndex: number, lineIndex: number, lineType: numb
   const shifted = new Set<string>();
   editingLines.value.forEach((ident) => {
     const parts = ident.split('_');
-    const ep = parseInt(parts[1], 10);
-    const ei = parseInt(parts[3], 10);
+    const ep = Number.parseInt(parts[1], 10);
+    const ei = Number.parseInt(parts[3], 10);
     if (ep === pageIndex && ei >= newLineIndex) {
       shifted.add(`page_${ep}_line_${ei + 1}`);
     } else {
@@ -491,8 +490,8 @@ function deleteLine(pageIndex: number, lineIndex: number): void {
   const shifted = new Set<string>();
   editingLines.value.forEach((ident) => {
     const parts = ident.split('_');
-    const ep = parseInt(parts[1], 10);
-    const ei = parseInt(parts[3], 10);
+    const ep = Number.parseInt(parts[1], 10);
+    const ei = Number.parseInt(parts[3], 10);
     if (ep === pageIndex && ei >= lineIndex) {
       shifted.add(`page_${ep}_line_${ei - 1}`);
     } else {
@@ -503,8 +502,8 @@ function deleteLine(pageIndex: number, lineIndex: number): void {
 
   if (latestAddedLine.value) {
     const parts = latestAddedLine.value.split('_');
-    const ep = parseInt(parts[1], 10);
-    const ei = parseInt(parts[3], 10);
+    const ep = Number.parseInt(parts[1], 10);
+    const ei = Number.parseInt(parts[3], 10);
     if (ep === pageIndex && ei >= lineIndex) {
       latestAddedLine.value = `page_${pageIndex}_line_${ei - 1}`;
     }
@@ -535,7 +534,7 @@ async function saveScript(): Promise<void> {
   savingInProgress.value = true;
   saveError.value = false;
   await scriptStore.getMaxPage();
-  const tmpPageKeys = Object.keys(scriptConfigStore.tmpScript).map((x) => parseInt(x, 10));
+  const tmpPageKeys = Object.keys(scriptConfigStore.tmpScript).map((x) => Number.parseInt(x, 10));
   const maxPage = Math.max(scriptStore.maxPage, ...tmpPageKeys, 0);
   totalSavePages.value = maxPage;
   curSavePage.value = 0;
@@ -761,7 +760,7 @@ onMounted(async () => {
   linePartCuts.value = [...scriptStore.cuts];
 
   const storedPage = localStorage.getItem('scriptEditPage');
-  const startPage = storedPage != null ? parseInt(storedPage, 10) : 1;
+  const startPage = storedPage != null ? Number.parseInt(storedPage, 10) : 1;
   await goToPageInner(startPage);
 
   loaded.value = true;

--- a/client-v3/src/components/show/config/script/ScriptEditor.vue
+++ b/client-v3/src/components/show/config/script/ScriptEditor.vue
@@ -760,7 +760,7 @@ onMounted(async () => {
   linePartCuts.value = [...scriptStore.cuts];
 
   const storedPage = localStorage.getItem('scriptEditPage');
-  const startPage = storedPage != null ? Number.parseInt(storedPage, 10) : 1;
+  const startPage = storedPage == null ? 1 : Number.parseInt(storedPage, 10);
   await goToPageInner(startPage);
 
   loaded.value = true;

--- a/client-v3/src/components/show/config/script/ScriptLinePart.vue
+++ b/client-v3/src/components/show/config/script/ScriptLinePart.vue
@@ -174,11 +174,11 @@ const combinedValue = computed<string | null>({
       state.value.character_id = null;
       state.value.character_group_id = null;
     } else if (val.startsWith('c:')) {
-      state.value.character_id = parseInt(val.slice(2), 10);
+      state.value.character_id = Number.parseInt(val.slice(2), 10);
       state.value.character_group_id = null;
     } else if (val.startsWith('g:')) {
       state.value.character_id = null;
-      state.value.character_group_id = parseInt(val.slice(2), 10);
+      state.value.character_group_id = Number.parseInt(val.slice(2), 10);
     }
     v$.value.$touch();
   },

--- a/client-v3/src/components/show/live/ScriptViewPane.vue
+++ b/client-v3/src/components/show/live/ScriptViewPane.vue
@@ -116,8 +116,9 @@
           <BCol md="auto">
             <div class="d-flex align-items-center gap-2">
               <div class="text-center">
-                <label class="form-label">Hours</label>
+                <label class="form-label" for="interval-hours">Hours</label>
                 <BFormInput
+                  id="interval-hours"
                   v-model.number="intervalHours"
                   type="number"
                   min="0"
@@ -127,8 +128,9 @@
               </div>
               <span class="fs-4 pt-3">:</span>
               <div class="text-center">
-                <label class="form-label">Minutes</label>
+                <label class="form-label" for="interval-minutes">Minutes</label>
                 <BFormInput
+                  id="interval-minutes"
                   v-model.number="intervalMinutes"
                   type="number"
                   min="0"
@@ -138,8 +140,9 @@
               </div>
               <span class="fs-4 pt-3">:</span>
               <div class="text-center">
-                <label class="form-label">Seconds</label>
+                <label class="form-label" for="interval-seconds">Seconds</label>
                 <BFormInput
+                  id="interval-seconds"
                   v-model.number="intervalSeconds"
                   type="number"
                   min="0"
@@ -590,8 +593,8 @@ function handleFollowDataChange(): void {
     const currentLineElement = document.getElementById(lineRef);
     if (currentLineElement != null) {
       const idParts = lineRef.split('_');
-      const page = parseInt(idParts[1], 10);
-      const line = parseInt(idParts[3], 10);
+      const page = Number.parseInt(idParts[1], 10);
+      const line = Number.parseInt(idParts[3], 10);
 
       document
         .querySelectorAll('.script-item')
@@ -670,7 +673,7 @@ async function loadCompiledScript(): Promise<boolean> {
   let maxLoadedPage = 1;
   let minLoadedPage = Number.POSITIVE_INFINITY;
   Object.entries(respJson).forEach(([pageStr, pageContents]) => {
-    const pageNumber = parseInt(pageStr, 10);
+    const pageNumber = Number.parseInt(pageStr, 10);
     if (pageNumber > maxLoadedPage) maxLoadedPage = pageNumber;
     if (pageNumber < minLoadedPage) minLoadedPage = pageNumber;
     scriptStore.script[String(pageNumber)] = pageContents as ScriptLine[];
@@ -843,7 +846,7 @@ onMounted(async () => {
     scrollToElement(document.getElementById(props.initialLineRef));
     const parts = props.initialLineRef.split('_');
     if (parts.length >= 4) {
-      navigateTo(parseInt(parts[1], 10), parseInt(parts[3], 10));
+      navigateTo(Number.parseInt(parts[1], 10), Number.parseInt(parts[3], 10));
     }
     await nextTick();
     computeScriptBoundaries();

--- a/client-v3/src/components/show/live/StageManagerPane.vue
+++ b/client-v3/src/components/show/live/StageManagerPane.vue
@@ -225,8 +225,8 @@ const currentSceneId = computed((): number | null => {
   if (!lineRef) return null;
   const parts = lineRef.split('_');
   if (parts.length < 4) return null;
-  const page = parseInt(parts[1], 10);
-  const lineIdx = parseInt(parts[3], 10);
+  const page = Number.parseInt(parts[1], 10);
+  const lineIdx = Number.parseInt(parts[3], 10);
   return scriptStore.getScriptPage(page)[lineIdx]?.scene_id ?? null;
 });
 

--- a/client-v3/src/js/micConflictUtils.ts
+++ b/client-v3/src/js/micConflictUtils.ts
@@ -212,7 +212,7 @@ export function detectMicConflicts(
       const characterId = micAllocations[sceneId];
       if (characterId == null) return;
 
-      const sceneIdNum = parseInt(sceneId, 10);
+      const sceneIdNum = Number.parseInt(sceneId, 10);
       const adjacentScenes = getAdjacentScenes(sceneIdNum, sceneGraph);
 
       const adjacentSceneIds = [
@@ -243,14 +243,14 @@ export function detectMicConflicts(
 
         const isDuplicate = conflicts.some(
           (c) =>
-            c.micId === parseInt(micId, 10) &&
+            c.micId === Number.parseInt(micId, 10) &&
             c.sceneId === adjacentSceneId &&
             c.adjacentSceneId === sceneIdNum
         );
 
         if (!isDuplicate) {
           conflicts.push({
-            micId: parseInt(micId, 10),
+            micId: Number.parseInt(micId, 10),
             sceneId: sceneIdNum,
             sceneName: currentSceneNode?.sceneName || 'Unknown',
             actName: currentSceneNode?.actName || 'Unknown',

--- a/client-v3/src/js/utils.ts
+++ b/client-v3/src/js/utils.ts
@@ -4,9 +4,9 @@ import { baseURL as platformBaseURL, makeURL as platformMakeURL } from '@/js/pla
 // in strict ESM. Inline the standard YIQ formula that the library implements.
 export function contrastColor(bgColor: string): string {
   const hex = (bgColor ?? '#ffffff').replace('#', '');
-  const r = parseInt(hex.substring(0, 2), 16) || 0;
-  const g = parseInt(hex.substring(2, 4), 16) || 0;
-  const b = parseInt(hex.substring(4, 6), 16) || 0;
+  const r = Number.parseInt(hex.substring(0, 2), 16) || 0;
+  const g = Number.parseInt(hex.substring(2, 4), 16) || 0;
+  const b = Number.parseInt(hex.substring(4, 6), 16) || 0;
   return (r * 299 + g * 587 + b * 114) / 1000 >= 128 ? '#000000' : '#ffffff';
 }
 

--- a/client-v3/src/stores/scriptConfig.ts
+++ b/client-v3/src/stores/scriptConfig.ts
@@ -26,11 +26,11 @@ export function computePageStatus(
     });
 
   const deepDiff = detailedDiff(augmented, tmpScriptPage);
-  const addedIndices = Object.keys(deepDiff.added).map((x) => parseInt(x, 10));
+  const addedIndices = Object.keys(deepDiff.added).map((x) => Number.parseInt(x, 10));
   return {
     added: addedIndices.filter((idx) => tmpScriptPage[idx]?.id == null),
     updated: [
-      ...Object.keys(deepDiff.updated).map((x) => parseInt(x, 10)),
+      ...Object.keys(deepDiff.updated).map((x) => Number.parseInt(x, 10)),
       ...addedIndices.filter((idx) => tmpScriptPage[idx]?.id != null),
     ],
     deleted: [...deletedLines],

--- a/server/controllers/controllers.py
+++ b/server/controllers/controllers.py
@@ -1,6 +1,7 @@
 import os
 
 from tornado.escape import url_unescape
+from tornado.ioloop import IOLoop
 from tornado.web import HTTPError
 from tornado_prometheus import MetricsHandler
 
@@ -44,8 +45,10 @@ class RootController(BaseController):
             raise HTTPError(404)
 
         try:
-            with open(full_path, "r", encoding="utf-8") as file:
-                self.write(file.read())
+            content = await IOLoop.current().run_in_executor(
+                None, lambda: open(full_path, "r", encoding="utf-8").read()
+            )
+            self.write(content)
         except Exception as e:
             get_logger().error(f"Error serving index.html: {str(e)}")
             raise HTTPError(500) from e


### PR DESCRIPTION
## Summary

Fixes the SonarCloud reliability issues blocking PR #1036 from passing the quality gate (C reliability rating on new code, required ≥ A).

**HIGH — `python:S7493`** (1 issue)
- `server/controllers/controllers.py`: `RootController.get()` is async but used a blocking `open()` call. Replaced with `await IOLoop.current().run_in_executor(None, ...)` to keep the Tornado event loop non-blocking, consistent with the rest of the codebase.

**MEDIUM — `typescript:S3923`** (1 issue)
- `ScriptEditor.vue`: `blankLine()` had a ternary where both branches returned `[]`. Collapsed to `line_parts: []`.

**MEDIUM — `Web:S6853`** (3 issues)
- `ScriptViewPane.vue`: Three `<label>` elements (Hours/Minutes/Seconds) had no `for` attribute. Added `for`/`id` pairs so screen readers can associate labels with their controls.

**LOW/quality-gate — `typescript:S7773`** (36 issues, 12 files)
- Mechanical replacement of `parseInt(` → `Number.parseInt(` across `client-v3/src`. No functional change — `Number.parseInt === parseInt` in ES2015+. Required to bring the reliability rating up to A.

## Test plan

- [ ] `cd client-v3 && npm run typecheck` — clean
- [ ] `cd client-v3 && npm run ci-lint` — clean
- [ ] `cd server && ruff check controllers/controllers.py` — clean
- [ ] SonarCloud re-analysis shows HIGH and MEDIUM reliability issues resolved
- [ ] `RootController` serves `index.html` without blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)