### PR TITLE
fix: address critical error handling issues from PR #1036 review

### DIFF
--- a/client-v3/src/App.vue
+++ b/client-v3/src/App.vue
@@ -127,7 +127,11 @@
     </BNavbar>
 
     <template v-if="!loaded">
-      <div class="text-center center-spinner">
+      <div v-if="startupError" class="text-center center-spinner">
+        <p class="text-danger">Failed to connect to the server. Please check your connection.</p>
+        <BButton variant="primary" @click="retryStartup">Retry</BButton>
+      </div>
+      <div v-else class="text-center center-spinner">
         <BSpinner style="width: 10rem; height: 10rem" variant="info" />
       </div>
     </template>
@@ -219,6 +223,7 @@ const isElectronEnv = ref(false);
 
 // Local state
 const loaded = ref(false);
+const startupError = ref(false);
 const stoppingSession = ref(false);
 const startingSession = ref(false);
 const changingPage = ref(false);
@@ -253,14 +258,19 @@ onMounted(async () => {
     }
   }
 
-  if (userStore.authToken) {
-    await userStore.refreshToken();
-    await userStore.setupTokenRefresh();
-  }
+  try {
+    if (userStore.authToken) {
+      await userStore.refreshToken();
+      await userStore.setupTokenRefresh();
+    }
 
-  await systemStore.getSettings();
-  connect();
-  await awaitWSConnect();
+    await systemStore.getSettings();
+    connect();
+    await awaitWSConnect();
+  } catch (e) {
+    log.error('Startup error:', e);
+    startupError.value = true;
+  }
 });
 
 onBeforeUnmount(() => {
@@ -304,6 +314,22 @@ async function awaitWSConnect(): Promise<void> {
   if (shouldContinue) {
     await loadShowDataAndNavigate();
     loaded.value = true;
+  }
+}
+
+async function retryStartup(): Promise<void> {
+  startupError.value = false;
+  try {
+    if (userStore.authToken) {
+      await userStore.refreshToken();
+      await userStore.setupTokenRefresh();
+    }
+    await systemStore.getSettings();
+    connect();
+    await awaitWSConnect();
+  } catch (e) {
+    log.error('Retry startup error:', e);
+    startupError.value = true;
   }
 }
 

--- a/client-v3/src/components/show/config/script/ScriptEditor.vue
+++ b/client-v3/src/components/show/config/script/ScriptEditor.vue
@@ -533,7 +533,12 @@ async function saveScript(): Promise<void> {
 
   savingInProgress.value = true;
   saveError.value = false;
-  await scriptStore.getMaxPage();
+  const maxPageOk = await scriptStore.getMaxPage();
+  if (!maxPageOk) {
+    toast.error('Unable to save script — could not determine page count. Please try again.');
+    savingInProgress.value = false;
+    return;
+  }
   const tmpPageKeys = Object.keys(scriptConfigStore.tmpScript).map((x) => Number.parseInt(x, 10));
   const maxPage = Math.max(scriptStore.maxPage, ...tmpPageKeys, 0);
   totalSavePages.value = maxPage;

--- a/client-v3/src/composables/useWebSocket.ts
+++ b/client-v3/src/composables/useWebSocket.ts
@@ -66,6 +66,8 @@ async function handleMessage(msg: WsMessage): Promise<void> {
     case 'WS_AUTH_ERROR':
       wsStore.$patch({ authenticated: false, pendingAuthentication: false });
       log.error('WebSocket authentication error:', msg.DATA);
+      toast.error('WebSocket authentication failed. Please log in again.');
+      await userStore.logout();
       break;
     case 'WS_TOKEN_REFRESH_SUCCESS':
       log.info('WebSocket token refreshed successfully');
@@ -108,8 +110,7 @@ function screamingToCamel(s: string): string {
 async function dispatchAction(action: string, data: Record<string, unknown>): Promise<void> {
   // Actions that can't be auto-routed by naming convention
   if (action === 'TOKEN_REFRESH') {
-    const payload = data as { DATA: { access_token: string } };
-    await useUserStore().tokenRefreshFromServer(payload.DATA.access_token);
+    await useUserStore().tokenRefreshFromServer((data as { access_token: string }).access_token);
     return;
   }
   if (action === 'SHOW_CHANGED') {

--- a/client-v3/src/stores/script.ts
+++ b/client-v3/src/stores/script.ts
@@ -70,12 +70,15 @@ export const useScriptStore = defineStore('script', {
       return response.ok;
     },
 
-    async getMaxPage(): Promise<void> {
+    async getMaxPage(): Promise<boolean> {
       const response = await fetch(makeURL('/api/v1/show/script/max_page'));
       if (response.ok) {
         const data = await response.json();
         this.maxPage = data.max_page;
+        return true;
       }
+      log.error('Unable to fetch max page');
+      return false;
     },
 
     async getStageDirectionStyles(): Promise<void> {

--- a/client-v3/src/stores/user.ts
+++ b/client-v3/src/stores/user.ts
@@ -53,12 +53,19 @@ export const useUserStore = defineStore('user', {
         const data = await response.json();
         if (data.access_token) this._setToken(data.access_token);
 
-        const { useSystemStore } = await import('@/stores/system');
-        await useSystemStore().getRbacRoles();
-        await this.getCurrentUser();
-        await this.getCurrentRbac();
-        await this.getUserSettings();
-        await this.setupTokenRefresh();
+        try {
+          const { useSystemStore } = await import('@/stores/system');
+          await useSystemStore().getRbacRoles();
+          await this.getCurrentUser();
+          await this.getCurrentRbac();
+          await this.getUserSettings();
+          await this.setupTokenRefresh();
+        } catch (e) {
+          log.error('Error loading user data after login:', e);
+          this._clearToken();
+          toast.error('Login failed — unable to load user data. Please try again.');
+          return false;
+        }
 
         // Trigger WS authentication if the connection is waiting
         wsStore.triggerAuthentication();
@@ -119,21 +126,26 @@ export const useUserStore = defineStore('user', {
 
     async refreshToken(): Promise<boolean> {
       if (!this.authToken) return false;
-      const response = await fetch(makeURL('/api/v1/auth/refresh-token'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
-      });
-      if (response.ok) {
-        const data = await response.json();
-        this._setToken(data.access_token);
-        const { useWebSocketStore } = await import('@/stores/websocket');
-        useWebSocketStore().refreshWsToken();
-        log.debug('Token refreshed successfully');
-        return true;
+      try {
+        const response = await fetch(makeURL('/api/v1/auth/refresh-token'), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        });
+        if (response.ok) {
+          const data = await response.json();
+          this._setToken(data.access_token);
+          const { useWebSocketStore } = await import('@/stores/websocket');
+          useWebSocketStore().refreshWsToken();
+          log.debug('Token refreshed successfully');
+          return true;
+        }
+        log.error('Failed to refresh token');
+        return false;
+      } catch (e) {
+        log.error('Network error during token refresh:', e);
+        return false;
       }
-      log.error('Failed to refresh token');
-      return false;
     },
 
     async tokenRefreshFromServer(newToken: string): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes 6 critical issues identified in the PR #1036 (Vue 3 migration) code review. All issues were verified against the actual source code before fixing.

- **`TOKEN_REFRESH` WS handler data shape bug** (`useWebSocket.ts`): `dispatchAction` passes `msg.DATA` to handlers, but the handler was reading `payload.DATA.access_token` (i.e. `msg.DATA.DATA`), which is always `undefined`. Every server-initiated token refresh was silently failing.
- **`WS_AUTH_ERROR` no user feedback** (`useWebSocket.ts`): Added toast notification and `logout()` call so the user is informed and redirected rather than left in a silently broken authenticated-but-unauthenticated state.
- **`refreshToken()` no try/catch** (`user.ts`): Network errors were propagating as unhandled rejections, causing a permanent loading spinner on startup. Now returns `false` on network failure.
- **`login()` ghost state** (`user.ts`): The five post-login data fetches (`getRbacRoles`, `getCurrentUser`, `getCurrentRbac`, `getUserSettings`, `setupTokenRefresh`) had no error handling. A mid-sequence failure left `authToken` set but `currentUser = null`. Now wrapped in try/catch with `_clearToken()` rollback.
- **`App.vue` startup no error boundary**: The startup chain had no try/catch. Any thrown error left `loaded = false` permanently with only a spinner. Now shows a user-visible error message with a Retry button.
- **`getMaxPage()` silent failure** (`script.ts` + `ScriptEditor.vue`): `getMaxPage()` now returns a `boolean` success flag. `saveScript()` aborts with a toast if the page count fetch fails rather than proceeding with a potentially stale value.

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run ci-lint` passes
- [ ] `npm run test:run` passes (23 tests)
- [ ] Manual: simulate network failure at startup → error message + Retry button appears
- [ ] Manual: log in and verify successful login still works end-to-end
- [ ] Manual: save script changes and verify save completes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)