### PR TITLE
Post-merge review fixes: 401 queuing, revision toasts, ws.onopen, logout await, dropdown fix

### DIFF
--- a/client-v3/src/App.vue
+++ b/client-v3/src/App.vue
@@ -111,9 +111,7 @@
               <em>{{ userStore.currentUser.username }}</em>
             </template>
             <BDropdownItem to="/me"> Settings </BDropdownItem>
-            <BDropdownItemButton @click.stop.prevent="userStore.logout()">
-              Sign Out
-            </BDropdownItemButton>
+            <BDropdownItemButton @click.stop.prevent="handleLogout"> Sign Out </BDropdownItemButton>
           </BNavItemDropdown>
           <BNavText id="connection-status" :class="{ healthy: websocketHealthy }">
             <template v-if="websocketHealthy"> Connected </template>
@@ -399,6 +397,10 @@ async function switchServer(): Promise<void> {
   await api?.clearActiveConnection?.();
   await router.push('/electron/server-selector');
   window.location.reload();
+}
+
+async function handleLogout(): Promise<void> {
+  await userStore.logout();
 }
 
 async function goToLivePage(): Promise<void> {

--- a/client-v3/src/components/show/config/script/ScriptEditor.vue
+++ b/client-v3/src/components/show/config/script/ScriptEditor.vue
@@ -121,14 +121,8 @@
     <BRow class="script-row pt-1">
       <BCol cols="10" class="ms-auto">
         <BButtonGroup v-show="canEdit && !scriptConfigStore.cutMode" style="float: right">
-          <BDropdown
-            split
-            text="Add Dialogue"
-            variant="primary"
-            end
-            boundary="window"
-            @click="addNewLine(LINE_TYPES.DIALOGUE)"
-          >
+          <BButton variant="primary" @click="addNewLine(LINE_TYPES.DIALOGUE)">Add Dialogue</BButton>
+          <BDropdown variant="primary" end toggle-class="dropdown-toggle-split">
             <BDropdownItem @click="addNewLine(LINE_TYPES.STAGE_DIRECTION)"
               >Add Stage Direction</BDropdownItem
             >

--- a/client-v3/src/components/show/config/script/ScriptLineViewer.vue
+++ b/client-v3/src/components/show/config/script/ScriptLineViewer.vue
@@ -121,26 +121,26 @@
           End
         </BButton>
       </BButtonGroup>
-      <BDropdown
-        v-else-if="canEdit && !isCutMode"
-        split
-        text="Edit"
-        end
-        boundary="window"
-        style="padding: 0"
-        variant="link"
-        @click.prevent.stop="$emit('editLine')"
-      >
-        <BDropdownItem @click.prevent.stop="$emit('insertDialogue')">Insert Dialogue</BDropdownItem>
-        <BDropdownItem @click.prevent.stop="$emit('insertStageDirection')"
-          >Insert Stage Direction</BDropdownItem
+      <BButtonGroup v-else-if="canEdit && !isCutMode">
+        <BButton variant="link" style="padding: 0" @click.prevent.stop="$emit('editLine')"
+          >Edit</BButton
         >
-        <BDropdownItem @click.prevent.stop="$emit('insertCueLine')">Insert Cue Line</BDropdownItem>
-        <BDropdownItem @click.prevent.stop="$emit('insertSpacing')">Insert Spacing</BDropdownItem>
-        <BDropdownItem variant="danger" @click.prevent.stop="$emit('deleteLine')"
-          >Delete</BDropdownItem
-        >
-      </BDropdown>
+        <BDropdown end toggle-class="dropdown-toggle-split" variant="link" style="padding: 0">
+          <BDropdownItem @click.prevent.stop="$emit('insertDialogue')"
+            >Insert Dialogue</BDropdownItem
+          >
+          <BDropdownItem @click.prevent.stop="$emit('insertStageDirection')"
+            >Insert Stage Direction</BDropdownItem
+          >
+          <BDropdownItem @click.prevent.stop="$emit('insertCueLine')"
+            >Insert Cue Line</BDropdownItem
+          >
+          <BDropdownItem @click.prevent.stop="$emit('insertSpacing')">Insert Spacing</BDropdownItem>
+          <BDropdownItem variant="danger" @click.prevent.stop="$emit('deleteLine')"
+            >Delete</BDropdownItem
+          >
+        </BDropdown>
+      </BButtonGroup>
     </BCol>
   </BRow>
 </template>

--- a/client-v3/src/composables/useWebSocket.ts
+++ b/client-v3/src/composables/useWebSocket.ts
@@ -169,20 +169,24 @@ function connect(): void {
   ws = new WebSocket(wsURL);
 
   ws.onopen = async () => {
-    const wasErrored = errorCount > 0;
-    wsStore.$patch({ isConnected: true });
-    if (wasErrored) {
-      toast.success(
-        `WebSocket reconnected after ${errorCount} attempt${errorCount > 1 ? 's' : ''}`
-      );
-    }
-    log.info('WebSocket connected');
-    if (wasErrored) {
-      const { useShowStore } = await import('@/stores/show');
-      const showStore = useShowStore();
-      if (showStore.currentSession != null) {
-        await showStore.getShowSessionData();
+    try {
+      const wasErrored = errorCount > 0;
+      wsStore.$patch({ isConnected: true });
+      if (wasErrored) {
+        toast.success(
+          `WebSocket reconnected after ${errorCount} attempt${errorCount > 1 ? 's' : ''}`
+        );
       }
+      log.info('WebSocket connected');
+      if (wasErrored) {
+        const { useShowStore } = await import('@/stores/show');
+        const showStore = useShowStore();
+        if (showStore.currentSession != null) {
+          await showStore.getShowSessionData();
+        }
+      }
+    } catch (e) {
+      log.error('Error in WebSocket onopen handler:', e);
     }
   };
 

--- a/client-v3/src/js/http-interceptor.ts
+++ b/client-v3/src/js/http-interceptor.ts
@@ -19,9 +19,29 @@ function buildAuthenticatedOptions(
   return { ...options, headers };
 }
 
+type QueueEntry = {
+  resolve: (r: Response) => void;
+  resource: string;
+  options: RequestInit & { headers: Record<string, string> };
+};
+
 export default function setupHttpInterceptor(): void {
   const originalFetch = window.fetch;
-  const refreshState = { isRefreshing: false };
+  const refreshState = { isRefreshing: false, queue: [] as QueueEntry[] };
+
+  function flushQueue(newToken: string | null): void {
+    const entries = refreshState.queue.splice(0);
+    entries.forEach(({ resolve, resource, options }) => {
+      if (newToken) {
+        originalFetch(resource, {
+          ...options,
+          headers: { ...options.headers, Authorization: `Bearer ${newToken}` },
+        }).then(resolve);
+      } else {
+        resolve(new Response(JSON.stringify({ message: 'Session expired' }), { status: 401 }));
+      }
+    });
+  }
 
   async function handle401Response(
     resource: string,
@@ -30,16 +50,24 @@ export default function setupHttpInterceptor(): void {
     isRefreshRequest: boolean,
     response: Response
   ): Promise<Response> {
-    if (isRefreshRequest || refreshState.isRefreshing) {
-      log.warn('Token refresh failed with 401 or already refreshing, logging out');
+    if (isRefreshRequest) {
+      log.warn('Token refresh request received 401, logging out');
+      flushQueue(null);
       toast.warning('Your session has expired. Please log in again.');
       await userStore.logout();
       return response;
     }
 
+    if (refreshState.isRefreshing) {
+      return new Promise<Response>((resolve) => {
+        refreshState.queue.push({ resolve, resource, options: newOptions });
+      });
+    }
+
     log.info('Attempting token refresh');
     if (!userStore.authToken) {
       log.warn('401 received with no token present');
+      flushQueue(null);
       await userStore.logout();
       return response;
     }
@@ -51,18 +79,21 @@ export default function setupHttpInterceptor(): void {
 
       if (!refreshSuccess) {
         log.warn('Token refresh failed, logging out');
+        flushQueue(null);
         toast.warning('Your session has expired. Please log in again.');
         await userStore.logout();
         return response;
       }
 
       log.info('Token refresh successful, retrying original request');
+      flushQueue(userStore.authToken);
       return await originalFetch(resource, {
         ...newOptions,
         headers: { ...newOptions.headers, Authorization: `Bearer ${userStore.authToken}` },
       });
     } catch (refreshError) {
       refreshState.isRefreshing = false;
+      flushQueue(null);
       log.error('Error during token refresh:', refreshError);
       toast.error('Authentication error - please log in again');
       await userStore.logout();

--- a/client-v3/src/stores/show.ts
+++ b/client-v3/src/stores/show.ts
@@ -753,7 +753,14 @@ export const useShowStore = defineStore('show', {
         await this.getScriptRevisions();
         toast.success('Added new script revision!');
       } else {
-        toast.error('Unable to add new script revision');
+        let message = 'Unable to add new script revision';
+        try {
+          const data = await response.json();
+          if (data.message) message = data.message;
+        } catch {
+          /* non-JSON body */
+        }
+        toast.error(message);
       }
     },
 
@@ -767,7 +774,14 @@ export const useShowStore = defineStore('show', {
         await this.getScriptRevisions();
         toast.success('Deleted script revision!');
       } else {
-        toast.error('Unable to delete script revision');
+        let message = 'Unable to delete script revision';
+        try {
+          const data = await response.json();
+          if (data.message) message = data.message;
+        } catch {
+          /* non-JSON body */
+        }
+        toast.error(message);
       }
     },
 
@@ -781,7 +795,14 @@ export const useShowStore = defineStore('show', {
         await this.getScriptRevisions();
         toast.success('Loaded script revision!');
       } else {
-        toast.error('Unable to load script revision');
+        let message = 'Unable to load script revision';
+        try {
+          const data = await response.json();
+          if (data.message) message = data.message;
+        } catch {
+          /* non-JSON body */
+        }
+        toast.error(message);
       }
     },
 


### PR DESCRIPTION
## Summary

Post-merge action items from the PR #1036 review evaluation. The critical fixes (items 1–6) were shipped in PR #1074; this PR addresses the four remaining items plus a bug discovered during manual testing.

- **Item 7 — Concurrent 401 queuing** (`js/http-interceptor.ts`): When a token refresh is in progress, parallel requests that receive a 401 are now queued rather than immediately triggering logout. On refresh success they are replayed with the new token; on failure they resolve with a synthetic 401 so callers' `response.ok` guards handle it gracefully.
- **Item 8 — Revision mutation server messages** (`stores/show.ts`): `addScriptRevision`, `deleteScriptRevision`, and `loadScriptRevision` now parse the response body in their error branches and include `data.message` in the toast, so 409 conflict descriptions reach the user instead of being discarded.
- **Item 9 — `ws.onopen` unhandled rejection** (`composables/useWebSocket.ts`): The async `onopen` body is wrapped in try/catch. Previously a throw from `getShowSessionData()` became an unhandled promise rejection on reconnect.
- **Item 10 — Awaited logout** (`App.vue`): The Sign Out binding is moved from an inline fire-and-forget call to a named `handleLogout()` async handler so the full logout sequence (API call, navigation) completes before the UI updates.
- **Bug fix — Script line editor dropdown** (`ScriptLineViewer.vue`, `ScriptEditor.vue`): Two distinct bugs caused the arrow toggle on each line's Edit button to misbehave:
  1. `@click` on `BDropdown` is not declared in BVN's component emits, so Vue 3 falls it through as an attribute onto the root DOM element — meaning both the "Edit" text and the toggle arrow triggered `editLine`. Fixed by replacing the BVN split dropdown with a manual `BButtonGroup` containing a `BButton` for the edit action and a standalone `BDropdown` for the context menu.
  2. `boundary="window"` causes BVN to apply `position-static` to the `BDropdown` root, changing the menu's `offsetParent` and causing Floating UI to compute a `translate(0,0)` transform — placing the dropdown at the top-left of the script editor container. Removing `boundary="window"` restores correct right-aligned positioning next to the toggle button.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run ci-lint` — passes
- [x] `npm run test:run` — 23/23 tests pass
- [x] Playwright verified: clicking the "Edit" text enters edit mode; clicking the toggle arrow opens the context menu correctly positioned next to the button
- [ ] Manual: sign out from the navbar, verify redirect to `/` completes cleanly
- [ ] Manual: open browser devtools → Network → throttle to Slow 3G, trigger a page that fires multiple API calls at mount while logged in with an expired token — verify only one logout, no console errors about unhandled rejections

🤖 Generated with [Claude Code](https://claude.com/claude-code)