### PR TITLE
Fix remaining SonarQube maintainability issues (round 2)

### DIFF
--- a/client-v3/src/App.vue
+++ b/client-v3/src/App.vue
@@ -418,11 +418,11 @@ async function goToLivePage(): Promise<void> {
   border-radius: 0.25rem;
   padding-left: 0.5rem;
   padding-right: 0.5rem;
-  background-color: #e74c3c;
+  background-color: #a93226;
 }
 
 #connection-status.healthy {
-  background-color: #00bc8c;
+  background-color: #007a5e;
 }
 </style>
 

--- a/client-v3/src/components/show/config/cues/CueEditor.vue
+++ b/client-v3/src/components/show/config/cues/CueEditor.vue
@@ -128,7 +128,6 @@ onBeforeMount(async () => {
           userStore.getCueColourOverrides(),
         ]);
       }
-      return;
     }),
     showStore.getActList(),
     showStore.getSceneList(),

--- a/client-v3/src/components/show/config/mics/ResourceAvailability.vue
+++ b/client-v3/src/components/show/config/mics/ResourceAvailability.vue
@@ -334,19 +334,19 @@ function getMicTooltip(micStatus: MicStatus): string {
 }
 
 .stat-badge.available {
-  background-color: rgba(40, 167, 69, 0.2);
+  background-color: #d4edda;
   border-color: #28a745;
   color: #155724;
 }
 
 .stat-badge.in-use {
-  background-color: rgba(0, 123, 255, 0.2);
+  background-color: #cce5ff;
   border-color: #007bff;
   color: #004085;
 }
 
 .stat-badge.conflict {
-  background-color: rgba(220, 53, 69, 0.2);
+  background-color: #f8d7da;
   border-color: #dc3545;
   color: #721c24;
 }

--- a/client-v3/src/components/show/live/ScriptViewPane.vue
+++ b/client-v3/src/components/show/live/ScriptViewPane.vue
@@ -833,7 +833,6 @@ onMounted(async () => {
           userStore.getCueColourOverrides(),
         ]);
       }
-      return;
     }),
     showStore.getSceneList(),
     showStore.getCharacterList(),

--- a/client-v3/src/stores/system.ts
+++ b/client-v3/src/stores/system.ts
@@ -103,7 +103,7 @@ export const useSystemStore = defineStore('system', {
       const userRbac = getUserRbac();
       if (!userRbac?.cuetypes) return false;
       const readMask = getRbacMask(this.rbacRoles, 'READ');
-      return userRbac.cuetypes.filter((x) => (x[1] & readMask) !== 0).length > 0;
+      return userRbac.cuetypes.some((x) => (x[1] & readMask) !== 0);
     },
     isAllowedShowConfig(): boolean {
       return (
@@ -132,8 +132,7 @@ export const useSystemStore = defineStore('system', {
       const scriptAllowed =
         userRbac.script?.[0] && (userRbac.script[0][1] & (writeMask | readMask)) !== 0;
       const cueTypesAllowed =
-        userRbac.cuetypes &&
-        userRbac.cuetypes.filter((x) => (x[1] & (writeMask | readMask)) !== 0).length > 0;
+        userRbac.cuetypes && userRbac.cuetypes.some((x) => (x[1] & (writeMask | readMask)) !== 0);
 
       return !!(showAllowed || scriptAllowed || cueTypesAllowed);
     },

--- a/client-v3/src/types/api/script.ts
+++ b/client-v3/src/types/api/script.ts
@@ -41,7 +41,7 @@ export interface StageDirectionStyle {
   background_colour: string | null;
 }
 
-export type ScriptCut = number;
+export type ScriptCut = number; // NOSONAR
 
 export interface CompiledScript {
   revision_id: number;

--- a/client-v3/src/views/user/LoginView.vue
+++ b/client-v3/src/views/user/LoginView.vue
@@ -77,5 +77,3 @@ async function doLogin(): Promise<void> {
   }
 }
 </script>
-
-<style scoped></style>

--- a/client-v3/vite.config.ts
+++ b/client-v3/vite.config.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import Components from 'unplugin-vue-components/vite';

--- a/client-v3/vitest.config.ts
+++ b/client-v3/vitest.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import vue from '@vitejs/plugin-vue';
-import path from 'path';
+import path from 'node:path';
 
 export default defineConfig({
   plugins: [vue()],

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import fs from 'fs';
+import path from 'node:path';
+import fs from 'node:fs';
 import { defineConfig, type Plugin } from 'vite';
 import vue from '@vitejs/plugin-vue2';
 

--- a/server/controllers/controllers.py
+++ b/server/controllers/controllers.py
@@ -13,6 +13,8 @@ from utils.web.route import ApiRoute, ApiVersion, Route
 
 IMPORTED_CONTROLLERS = {}
 
+INDEX_HTML = "index.html"
+
 
 def import_all_controllers():
     get_logger().info("Importing controllers...")
@@ -32,13 +34,13 @@ class RootController(BaseController):
                 return
         if is_frozen():
             # In PyInstaller mode, use resource path
-            full_path = get_resource_path(os.path.join("static", "index.html"))
+            full_path = get_resource_path(os.path.join("static", INDEX_HTML))
         else:
             # In source mode, use relative path
             file_path = os.path.join(
                 os.path.abspath(os.path.dirname(__file__)), "..", "static"
             )
-            full_path = os.path.join(file_path, "index.html")
+            full_path = os.path.join(file_path, INDEX_HTML)
 
         if not os.path.isfile(full_path):
             get_logger().error(f"Index file not found: {full_path}")
@@ -50,21 +52,19 @@ class RootController(BaseController):
             )
             self.write(content)
         except Exception as e:
-            get_logger().error(f"Error serving index.html: {str(e)}")
+            get_logger().error(f"Error serving {INDEX_HTML}: {str(e)}")
             raise HTTPError(500) from e
 
 
 class RootControllerV3(BaseController):
     def get(self, _path):
         if is_frozen():
-            full_path = get_resource_path(
-                os.path.join("static", "ui-new", "index.html")
-            )
+            full_path = get_resource_path(os.path.join("static", "ui-new", INDEX_HTML))
         else:
             file_path = os.path.join(
                 os.path.abspath(os.path.dirname(__file__)), "..", "static", "ui-new"
             )
-            full_path = os.path.join(file_path, "index.html")
+            full_path = os.path.join(file_path, INDEX_HTML)
         if not os.path.isfile(full_path):
             raise HTTPError(404)
         with open(full_path, "r", encoding="utf-8") as file:


### PR DESCRIPTION
## Summary

- Remove redundant `return;` statements introduced by the S3626 fix in CueEditor and ScriptViewPane
- Replace two more `.filter().length > 0` patterns with `.some()` in `system.ts`
- Fix WCAG AA contrast failures in `App.vue` connection-status badge (`#e74c3c` → `#a93226`, `#00bc8c` → `#007a5e`)
- Use `node:` protocol prefix for built-in imports in `vite.config.ts` and `vitest.config.ts`
- Replace `rgba()` backgrounds with solid equivalents in `ResourceAvailability.vue` (contrast-detectable by SonarQube)
- Extract `"index.html"` string literal to a constant in `controllers/controllers.py`
- Remove empty `<style scoped>` block from `LoginView.vue`
- Mark `ScriptCut` type alias with `// NOSONAR` (descriptive alias with intentional purpose)

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run ci-lint` — passes
- [x] `npm run test:run` — 23/23 tests pass
- [x] `ruff check` / `ruff format --check` on modified Python file — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)