### PR TITLE
Fix V3 config backups tab errors

### DIFF
--- a/client-v3/src/components/config/ConfigBackups.vue
+++ b/client-v3/src/components/config/ConfigBackups.vue
@@ -5,7 +5,7 @@
         {{ count }} {{ count === 1 ? 'backup' : 'backups' }} &middot;
         {{ formatBytes(totalSizeBytes) }} total
       </p>
-      <BTable :items="backups" :fields="fields" sort-by="created_at" :sort-desc="true">
+      <BTable :items="backups" :fields="fields">
         <template #cell(size_bytes)="data">
           {{ formatBytes(data.item.size_bytes) }}
         </template>

--- a/client-v3/src/composables/useWebSocket.ts
+++ b/client-v3/src/composables/useWebSocket.ts
@@ -91,6 +91,8 @@ async function handleMessage(msg: WsMessage): Promise<void> {
     case 'RELOAD_CLIENT':
       window.location.reload();
       break;
+    case 'NOOP':
+      break;
     default:
       log.warn(`Unknown OP received from WebSocket: ${msg.OP}`);
   }


### PR DESCRIPTION
## Summary

- **NOOP WebSocket warning**: Added `case 'NOOP': break;` to the `handleMessage` switch in `useWebSocket.ts`. The backend intentionally sends `{"OP": "NOOP", "ACTION": "GET_SETTINGS"}` on every WS connection — NOOP is a carrier OP for ACTION-based messages — but the switch had no handler for it, causing a spurious "Unknown OP received from WebSocket: NOOP" warning on every connect.
- **BTable TypeError crash**: Removed invalid BVN 0.45.x props `sort-by="created_at"` and `:sort-desc="true"` from `ConfigBackups.vue`. BVN replaced the old Bootstrap Vue 2 string/bool sort pair with a unified `v-model:sort-by` accepting `BTableSortBy[]`. Passing a static string caused BVN's internal `computedItems` to call `"created_at"?.filter(fn)`, which threw `TypeError: o.value?.filter is not a function`. The backend already returns backups sorted newest-first, so no client-side initial sort is needed. Column-header sorting still works via the `sortable: true` field config.

## Test plan

- [ ] Navigate to `/config` → Backups tab
- [ ] Confirm no "Unknown OP received from WebSocket: NOOP" warning in the browser console
- [ ] Confirm no "TypeError: o.value?.filter is not a function" error
- [ ] Confirm backup files are displayed and the table renders correctly
- [ ] Confirm clicking "Size" or "Date Created" column headers sorts the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)