### PR TITLE
Highlight script row on add-cue button hover (#1081)

### DIFF
--- a/client-v3/src/components/show/config/cues/ScriptLineCueEditor.vue
+++ b/client-v3/src/components/show/config/cues/ScriptLineCueEditor.vue
@@ -13,6 +13,7 @@
     <!-- Main line row -->
     <BContainer fluid class="mx-0" style="margin: 0; padding: 0">
       <BRow
+        class="line-row"
         :class="{
           'stage-direction': line.line_type === LINE_TYPES.STAGE_DIRECTION,
         }"
@@ -36,7 +37,7 @@
               </BButton>
               <BButton
                 v-if="systemStore.isCueEditor"
-                class="cue-button"
+                class="cue-button add-cue-btn"
                 :disabled="isLineCut"
                 @click.stop="openNewForm"
               >
@@ -482,5 +483,11 @@ async function deleteCue(): Promise<void> {
 
 .cut-line-part {
   text-decoration: line-through;
+}
+
+.line-row:has(.add-cue-btn:hover) {
+  background-color: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
 }
 </style>

--- a/client/src/vue_components/show/config/cues/ScriptLineCueEditor.vue
+++ b/client/src/vue_components/show/config/cues/ScriptLineCueEditor.vue
@@ -6,7 +6,10 @@
         <h4>{{ actLabel }} - {{ sceneLabel }}</h4>
       </b-col>
     </b-row>
-    <b-row :class="{ 'stage-direction': line.line_type === LINE_TYPES.STAGE_DIRECTION }">
+    <b-row
+      class="line-row"
+      :class="{ 'stage-direction': line.line_type === LINE_TYPES.STAGE_DIRECTION }"
+    >
       <b-col cols="3" class="cue-column" style="text-align: right">
         <b-button-group v-if="line.line_type !== LINE_TYPES.SPACING">
           <b-button
@@ -24,7 +27,7 @@
           </b-button>
           <b-button
             v-if="IS_CUE_EDITOR"
-            class="cue-button"
+            class="cue-button add-cue-btn"
             :disabled="isWholeLineCut(line)"
             @click.stop="openNewForm"
           >
@@ -619,5 +622,10 @@ export default defineComponent({
 }
 .cut-line-part {
   text-decoration: line-through;
+}
+.line-row:has(.add-cue-btn:hover) {
+  background-color: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
 }
 </style>


### PR DESCRIPTION
## Summary

- Adds a subtle light-gray row highlight when hovering the add-cue (+) button in the cue editor, clarifying which script line the new cue will be attached to
- Applied to both Vue 2 (`client/`) and Vue 3 (`client-v3/`) for parity
- Implemented with pure CSS `:has()` — no JS state or event handlers needed

## Implementation

Added `line-row` class to the script row and `add-cue-btn` class to the add-cue button in both `ScriptLineCueEditor.vue` components, then used a scoped CSS rule:

```css
.line-row:has(.add-cue-btn:hover) {
  background-color: rgba(255, 255, 255, 0.06);
  border-radius: 4px;
  transition: background-color 0.15s ease;
}
```

## Test plan

- [x] Verified hover highlight appears on the correct row in Vue 3 (`/ui-new/`) using Playwright
- [x] Verified hover highlight appears on the correct row in Vue 2 (`/ui/`) using Playwright
- [x] `npm run lint` passes on both clients
- [x] `npm run typecheck` passes on both clients
- [x] Both frontend builds succeed

Closes #1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)