### PR TITLE
Fix JWT token uniqueness to prevent revoked-token collision on fast re-login

### DIFF
--- a/client-v3/playwright.config.ts
+++ b/client-v3/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   ],
   use: {
     baseURL: `http://localhost:${SERVER_PORT}`,
-    trace: 'on-first-retry',
+    trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
   },

--- a/server/utils/web/jwt_service.py
+++ b/server/utils/web/jwt_service.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
+from uuid import uuid4
 
 import tornado.locks
 from jwt import PyJWS, PyJWT, PyJWTError
@@ -34,8 +35,15 @@ class JWTService:
         self._revoked_token_lock = tornado.locks.Lock()
 
     async def revoke_token(self, token: str):
-        headers = self._jws.get_unverified_header(token)
-        expiry = headers.get("exp", -1)
+        try:
+            payload = self._jwt.decode(
+                token,
+                options={"verify_signature": False, "verify_exp": False},
+                algorithms=[self._jwt_algorithm],
+            )
+            expiry = payload.get("exp", -1)
+        except Exception:
+            expiry = -1
         async with self._revoked_token_lock:
             self._revoked_tokens[token] = expiry
 
@@ -91,7 +99,7 @@ class JWTService:
                 if user:
                     to_encode["token_version"] = user.token_version
 
-        to_encode.update({"exp": expire, "iat": datetime.now(tz=timezone.utc)})
+        to_encode.update({"exp": expire, "iat": datetime.now(tz=timezone.utc), "jti": str(uuid4())})
         encoded_jwt = self._jwt.encode(
             to_encode, self.get_secret(), algorithm=self._jwt_algorithm
         )

--- a/server/utils/web/jwt_service.py
+++ b/server/utils/web/jwt_service.py
@@ -99,7 +99,9 @@ class JWTService:
                 if user:
                     to_encode["token_version"] = user.token_version
 
-        to_encode.update({"exp": expire, "iat": datetime.now(tz=timezone.utc), "jti": str(uuid4())})
+        to_encode.update(
+            {"exp": expire, "iat": datetime.now(tz=timezone.utc), "jti": str(uuid4())}
+        )
         encoded_jwt = self._jwt.encode(
             to_encode, self.get_secret(), algorithm=self._jwt_algorithm
         )


### PR DESCRIPTION
## Summary

- Adds a unique `jti` (UUID) claim to every JWT token created by `JWTService.create_access_token()`, ensuring tokens are always cryptographically distinct even when issued within the same UTC second for the same user
- Fixes `revoke_token()` which was incorrectly reading `exp` from the JWT *header* (where it is absent → always -1) instead of the payload, causing revoked tokens to accumulate in memory forever and never be cleaned up

## Root cause

`PyJWT` encodes tokens deterministically: same payload + same secret + same algorithm = same token string. Without a unique-per-token field, two login calls for the same user within the same UTC second produced identical tokens. When a user logged out (revoking token T1) and immediately re-logged in (producing T2 = T1), `is_token_revoked(T2)` returned `true`, the server sent `WS_AUTH_ERROR`, and the client called `logout()` — clearing `currentUser` and making the UI show "Login" instead of the username.

This manifested as a flaky E2E test failure in `02-auth.spec.ts: can log back in after logout` on fast hardware where the full logout→re-login cycle can complete within one second.

## Test plan

- [x] All 4 existing JWT unit tests pass (`test/utils/web/test_jwt.py`)
- [x] Full 603-test backend suite passes
- [x] Full 148-test Playwright E2E suite (Chromium) passes locally — `02-auth.spec.ts: can log back in after logout` now passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)