### PR TITLE
Add E2E retry support with SQLite snapshot/restore

### DIFF
--- a/client-v3/e2e/db-snapshot.ts
+++ b/client-v3/e2e/db-snapshot.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { spawn } from 'child_process';
+import { test } from '@playwright/test';
 import { PID_FILE, TMPDIR_FILE, SERVER_PORT, waitForServer } from './global-setup.js';
 
 function getPaths() {
@@ -65,4 +66,18 @@ export async function restoreStateAndRestartServer(): Promise<void> {
   server.unref();
 
   await waitForServer();
+}
+
+/** Register beforeAll/afterEach hooks for retry support. Call once at the top of each spec file. */
+export function registerRetryHooks(): void {
+  test.beforeAll(async () => {
+    if (test.info().retry > 0 && snapshotExists()) {
+      await restoreStateAndRestartServer();
+    }
+  });
+  test.afterEach(async () => {
+    if (test.info().status === 'passed') {
+      snapshotState();
+    }
+  });
 }

--- a/client-v3/e2e/db-snapshot.ts
+++ b/client-v3/e2e/db-snapshot.ts
@@ -1,0 +1,68 @@
+import fs from 'fs';
+import path from 'path';
+import { spawn } from 'child_process';
+import { PID_FILE, TMPDIR_FILE, SERVER_PORT, waitForServer } from './global-setup.js';
+
+function getPaths() {
+  const tempDir = fs.readFileSync(TMPDIR_FILE, 'utf-8').trim();
+  return {
+    db: path.join(tempDir, 'digiscript.sqlite'),
+    dbSnapshot: path.join(tempDir, 'digiscript.sqlite.snapshot'),
+    config: path.join(tempDir, 'digiscript.json'),
+    configSnapshot: path.join(tempDir, 'digiscript.json.snapshot'),
+    serverDir: path.resolve(process.cwd(), '..', 'server'),
+  };
+}
+
+export function snapshotExists(): boolean {
+  const { dbSnapshot } = getPaths();
+  return fs.existsSync(dbSnapshot);
+}
+
+/** Copy the DB and config to snapshot files. Call after each passing test. */
+export function snapshotState(): void {
+  const { db, dbSnapshot, config, configSnapshot } = getPaths();
+  fs.copyFileSync(db, dbSnapshot);
+  fs.copyFileSync(config, configSnapshot);
+}
+
+/**
+ * Restore DB and config from the last snapshot, then restart the server.
+ * Call at the start of a retry to bring the backend back to last known-good state.
+ */
+export async function restoreStateAndRestartServer(): Promise<void> {
+  const { db, dbSnapshot, config, configSnapshot, serverDir } = getPaths();
+
+  // Kill existing server
+  if (fs.existsSync(PID_FILE)) {
+    const pid = parseInt(fs.readFileSync(PID_FILE, 'utf-8').trim(), 10);
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      // process already gone
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+
+  // Remove any stale journal file (server uses DELETE journal mode, not WAL)
+  try {
+    fs.rmSync(`${db}-journal`);
+  } catch {
+    // no journal file present
+  }
+
+  // Restore DB and config from snapshot
+  fs.copyFileSync(dbSnapshot, db);
+  fs.copyFileSync(configSnapshot, config);
+
+  // Respawn server with the restored config
+  const server = spawn(
+    'python3',
+    ['main.py', `--port=${SERVER_PORT}`, `--settings_path=${config}`, '--debug=false'],
+    { cwd: serverDir, detached: true, stdio: 'ignore' }
+  );
+  fs.writeFileSync(PID_FILE, String(server.pid!));
+  server.unref();
+
+  await waitForServer();
+}

--- a/client-v3/e2e/global-setup.ts
+++ b/client-v3/e2e/global-setup.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
-const SERVER_PORT = 8888;
+export const SERVER_PORT = 8888;
 const HEALTH_URL = `http://localhost:${SERVER_PORT}/api/v1/health`;
 
 export const PID_FILE = path.join(os.tmpdir(), 'digiscript-e2e-server.pid');
@@ -85,7 +85,7 @@ async function killStaleServer(): Promise<void> {
   }
 }
 
-async function waitForServer(timeoutMs = 30_000): Promise<void> {
+export async function waitForServer(timeoutMs = 30_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {

--- a/client-v3/e2e/tests/01-first-run.spec.ts
+++ b/client-v3/e2e/tests/01-first-run.spec.ts
@@ -5,21 +5,11 @@
  */
 import { test, expect, type BrowserContext, type Page } from '@playwright/test';
 import { UI_BASE, ADMIN_PASSWORD, waitForAppReady } from '../helpers.js';
-import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
+import { registerRetryHooks } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async () => {
-  if (test.info().retry > 0 && snapshotExists()) {
-    await restoreStateAndRestartServer();
-  }
-});
-
-test.afterEach(async () => {
-  if (test.info().status === 'passed') {
-    snapshotState();
-  }
-});
+registerRetryHooks();
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/01-first-run.spec.ts
+++ b/client-v3/e2e/tests/01-first-run.spec.ts
@@ -9,13 +9,13 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async ({}, testInfo) => {
+test.beforeAll(async (_fixtures, testInfo) => {
   if (testInfo.retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async ({}, testInfo) => {
+test.afterEach(async (_fixtures, testInfo) => {
   if (testInfo.status === 'passed') {
     snapshotState();
   }

--- a/client-v3/e2e/tests/01-first-run.spec.ts
+++ b/client-v3/e2e/tests/01-first-run.spec.ts
@@ -9,14 +9,14 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async (_fixtures, testInfo) => {
-  if (testInfo.retry > 0 && snapshotExists()) {
+test.beforeAll(async () => {
+  if (test.info().retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async (_fixtures, testInfo) => {
-  if (testInfo.status === 'passed') {
+test.afterEach(async () => {
+  if (test.info().status === 'passed') {
     snapshotState();
   }
 });

--- a/client-v3/e2e/tests/01-first-run.spec.ts
+++ b/client-v3/e2e/tests/01-first-run.spec.ts
@@ -5,8 +5,21 @@
  */
 import { test, expect, type BrowserContext, type Page } from '@playwright/test';
 import { UI_BASE, ADMIN_PASSWORD, waitForAppReady } from '../helpers.js';
+import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async ({}, testInfo) => {
+  if (testInfo.retry > 0 && snapshotExists()) {
+    await restoreStateAndRestartServer();
+  }
+});
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === 'passed') {
+    snapshotState();
+  }
+});
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/02-auth.spec.ts
+++ b/client-v3/e2e/tests/02-auth.spec.ts
@@ -14,14 +14,14 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async (_fixtures, testInfo) => {
-  if (testInfo.retry > 0 && snapshotExists()) {
+test.beforeAll(async () => {
+  if (test.info().retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async (_fixtures, testInfo) => {
-  if (testInfo.status === 'passed') {
+test.afterEach(async () => {
+  if (test.info().status === 'passed') {
     snapshotState();
   }
 });

--- a/client-v3/e2e/tests/02-auth.spec.ts
+++ b/client-v3/e2e/tests/02-auth.spec.ts
@@ -10,21 +10,11 @@ import {
   waitForAppReady,
   loginAsAdmin,
 } from '../helpers.js';
-import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
+import { registerRetryHooks } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async () => {
-  if (test.info().retry > 0 && snapshotExists()) {
-    await restoreStateAndRestartServer();
-  }
-});
-
-test.afterEach(async () => {
-  if (test.info().status === 'passed') {
-    snapshotState();
-  }
-});
+registerRetryHooks();
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/02-auth.spec.ts
+++ b/client-v3/e2e/tests/02-auth.spec.ts
@@ -14,13 +14,13 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async ({}, testInfo) => {
+test.beforeAll(async (_fixtures, testInfo) => {
   if (testInfo.retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async ({}, testInfo) => {
+test.afterEach(async (_fixtures, testInfo) => {
   if (testInfo.status === 'passed') {
     snapshotState();
   }

--- a/client-v3/e2e/tests/02-auth.spec.ts
+++ b/client-v3/e2e/tests/02-auth.spec.ts
@@ -10,8 +10,21 @@ import {
   waitForAppReady,
   loginAsAdmin,
 } from '../helpers.js';
+import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async ({}, testInfo) => {
+  if (testInfo.retry > 0 && snapshotExists()) {
+    await restoreStateAndRestartServer();
+  }
+});
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === 'passed') {
+    snapshotState();
+  }
+});
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/03-system-config.spec.ts
+++ b/client-v3/e2e/tests/03-system-config.spec.ts
@@ -15,14 +15,14 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async (_fixtures, testInfo) => {
-  if (testInfo.retry > 0 && snapshotExists()) {
+test.beforeAll(async () => {
+  if (test.info().retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async (_fixtures, testInfo) => {
-  if (testInfo.status === 'passed') {
+test.afterEach(async () => {
+  if (test.info().status === 'passed') {
     snapshotState();
   }
 });

--- a/client-v3/e2e/tests/03-system-config.spec.ts
+++ b/client-v3/e2e/tests/03-system-config.spec.ts
@@ -11,21 +11,11 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
-import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
+import { registerRetryHooks } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async () => {
-  if (test.info().retry > 0 && snapshotExists()) {
-    await restoreStateAndRestartServer();
-  }
-});
-
-test.afterEach(async () => {
-  if (test.info().status === 'passed') {
-    snapshotState();
-  }
-});
+registerRetryHooks();
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/03-system-config.spec.ts
+++ b/client-v3/e2e/tests/03-system-config.spec.ts
@@ -11,8 +11,21 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
+import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async ({}, testInfo) => {
+  if (testInfo.retry > 0 && snapshotExists()) {
+    await restoreStateAndRestartServer();
+  }
+});
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === 'passed') {
+    snapshotState();
+  }
+});
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/03-system-config.spec.ts
+++ b/client-v3/e2e/tests/03-system-config.spec.ts
@@ -15,13 +15,13 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async ({}, testInfo) => {
+test.beforeAll(async (_fixtures, testInfo) => {
   if (testInfo.retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async ({}, testInfo) => {
+test.afterEach(async (_fixtures, testInfo) => {
   if (testInfo.status === 'passed') {
     snapshotState();
   }

--- a/client-v3/e2e/tests/04-show-config-show.spec.ts
+++ b/client-v3/e2e/tests/04-show-config-show.spec.ts
@@ -14,14 +14,14 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async (_fixtures, testInfo) => {
-  if (testInfo.retry > 0 && snapshotExists()) {
+test.beforeAll(async () => {
+  if (test.info().retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async (_fixtures, testInfo) => {
-  if (testInfo.status === 'passed') {
+test.afterEach(async () => {
+  if (test.info().status === 'passed') {
     snapshotState();
   }
 });

--- a/client-v3/e2e/tests/04-show-config-show.spec.ts
+++ b/client-v3/e2e/tests/04-show-config-show.spec.ts
@@ -10,8 +10,21 @@ import {
   confirmModal,
   waitForModalClosed,
 } from '../helpers.js';
+import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async ({}, testInfo) => {
+  if (testInfo.retry > 0 && snapshotExists()) {
+    await restoreStateAndRestartServer();
+  }
+});
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === 'passed') {
+    snapshotState();
+  }
+});
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/04-show-config-show.spec.ts
+++ b/client-v3/e2e/tests/04-show-config-show.spec.ts
@@ -10,21 +10,11 @@ import {
   confirmModal,
   waitForModalClosed,
 } from '../helpers.js';
-import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
+import { registerRetryHooks } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async () => {
-  if (test.info().retry > 0 && snapshotExists()) {
-    await restoreStateAndRestartServer();
-  }
-});
-
-test.afterEach(async () => {
-  if (test.info().status === 'passed') {
-    snapshotState();
-  }
-});
+registerRetryHooks();
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/04-show-config-show.spec.ts
+++ b/client-v3/e2e/tests/04-show-config-show.spec.ts
@@ -14,13 +14,13 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async ({}, testInfo) => {
+test.beforeAll(async (_fixtures, testInfo) => {
   if (testInfo.retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async ({}, testInfo) => {
+test.afterEach(async (_fixtures, testInfo) => {
   if (testInfo.status === 'passed') {
     snapshotState();
   }

--- a/client-v3/e2e/tests/05-show-config-acts-scenes.spec.ts
+++ b/client-v3/e2e/tests/05-show-config-acts-scenes.spec.ts
@@ -16,13 +16,13 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async ({}, testInfo) => {
+test.beforeAll(async (_fixtures, testInfo) => {
   if (testInfo.retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async ({}, testInfo) => {
+test.afterEach(async (_fixtures, testInfo) => {
   if (testInfo.status === 'passed') {
     snapshotState();
   }

--- a/client-v3/e2e/tests/05-show-config-acts-scenes.spec.ts
+++ b/client-v3/e2e/tests/05-show-config-acts-scenes.spec.ts
@@ -12,21 +12,11 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
-import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
+import { registerRetryHooks } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async () => {
-  if (test.info().retry > 0 && snapshotExists()) {
-    await restoreStateAndRestartServer();
-  }
-});
-
-test.afterEach(async () => {
-  if (test.info().status === 'passed') {
-    snapshotState();
-  }
-});
+registerRetryHooks();
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/05-show-config-acts-scenes.spec.ts
+++ b/client-v3/e2e/tests/05-show-config-acts-scenes.spec.ts
@@ -12,8 +12,21 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
+import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async ({}, testInfo) => {
+  if (testInfo.retry > 0 && snapshotExists()) {
+    await restoreStateAndRestartServer();
+  }
+});
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === 'passed') {
+    snapshotState();
+  }
+});
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/05-show-config-acts-scenes.spec.ts
+++ b/client-v3/e2e/tests/05-show-config-acts-scenes.spec.ts
@@ -16,14 +16,14 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async (_fixtures, testInfo) => {
-  if (testInfo.retry > 0 && snapshotExists()) {
+test.beforeAll(async () => {
+  if (test.info().retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async (_fixtures, testInfo) => {
-  if (testInfo.status === 'passed') {
+test.afterEach(async () => {
+  if (test.info().status === 'passed') {
     snapshotState();
   }
 });

--- a/client-v3/e2e/tests/06-show-config-characters.spec.ts
+++ b/client-v3/e2e/tests/06-show-config-characters.spec.ts
@@ -15,14 +15,14 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async (_fixtures, testInfo) => {
-  if (testInfo.retry > 0 && snapshotExists()) {
+test.beforeAll(async () => {
+  if (test.info().retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async (_fixtures, testInfo) => {
-  if (testInfo.status === 'passed') {
+test.afterEach(async () => {
+  if (test.info().status === 'passed') {
     snapshotState();
   }
 });

--- a/client-v3/e2e/tests/06-show-config-characters.spec.ts
+++ b/client-v3/e2e/tests/06-show-config-characters.spec.ts
@@ -11,21 +11,11 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
-import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
+import { registerRetryHooks } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async () => {
-  if (test.info().retry > 0 && snapshotExists()) {
-    await restoreStateAndRestartServer();
-  }
-});
-
-test.afterEach(async () => {
-  if (test.info().status === 'passed') {
-    snapshotState();
-  }
-});
+registerRetryHooks();
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/06-show-config-characters.spec.ts
+++ b/client-v3/e2e/tests/06-show-config-characters.spec.ts
@@ -11,8 +11,21 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
+import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async ({}, testInfo) => {
+  if (testInfo.retry > 0 && snapshotExists()) {
+    await restoreStateAndRestartServer();
+  }
+});
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === 'passed') {
+    snapshotState();
+  }
+});
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/06-show-config-characters.spec.ts
+++ b/client-v3/e2e/tests/06-show-config-characters.spec.ts
@@ -15,13 +15,13 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async ({}, testInfo) => {
+test.beforeAll(async (_fixtures, testInfo) => {
   if (testInfo.retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async ({}, testInfo) => {
+test.afterEach(async (_fixtures, testInfo) => {
   if (testInfo.status === 'passed') {
     snapshotState();
   }

--- a/client-v3/e2e/tests/07-show-config-stage.spec.ts
+++ b/client-v3/e2e/tests/07-show-config-stage.spec.ts
@@ -16,13 +16,13 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async ({}, testInfo) => {
+test.beforeAll(async (_fixtures, testInfo) => {
   if (testInfo.retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async ({}, testInfo) => {
+test.afterEach(async (_fixtures, testInfo) => {
   if (testInfo.status === 'passed') {
     snapshotState();
   }

--- a/client-v3/e2e/tests/07-show-config-stage.spec.ts
+++ b/client-v3/e2e/tests/07-show-config-stage.spec.ts
@@ -12,21 +12,11 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
-import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
+import { registerRetryHooks } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async () => {
-  if (test.info().retry > 0 && snapshotExists()) {
-    await restoreStateAndRestartServer();
-  }
-});
-
-test.afterEach(async () => {
-  if (test.info().status === 'passed') {
-    snapshotState();
-  }
-});
+registerRetryHooks();
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/07-show-config-stage.spec.ts
+++ b/client-v3/e2e/tests/07-show-config-stage.spec.ts
@@ -12,8 +12,21 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
+import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async ({}, testInfo) => {
+  if (testInfo.retry > 0 && snapshotExists()) {
+    await restoreStateAndRestartServer();
+  }
+});
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === 'passed') {
+    snapshotState();
+  }
+});
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/07-show-config-stage.spec.ts
+++ b/client-v3/e2e/tests/07-show-config-stage.spec.ts
@@ -16,14 +16,14 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async (_fixtures, testInfo) => {
-  if (testInfo.retry > 0 && snapshotExists()) {
+test.beforeAll(async () => {
+  if (test.info().retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async (_fixtures, testInfo) => {
-  if (testInfo.status === 'passed') {
+test.afterEach(async () => {
+  if (test.info().status === 'passed') {
     snapshotState();
   }
 });

--- a/client-v3/e2e/tests/08-show-config-cues.spec.ts
+++ b/client-v3/e2e/tests/08-show-config-cues.spec.ts
@@ -15,14 +15,14 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async (_fixtures, testInfo) => {
-  if (testInfo.retry > 0 && snapshotExists()) {
+test.beforeAll(async () => {
+  if (test.info().retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async (_fixtures, testInfo) => {
-  if (testInfo.status === 'passed') {
+test.afterEach(async () => {
+  if (test.info().status === 'passed') {
     snapshotState();
   }
 });

--- a/client-v3/e2e/tests/08-show-config-cues.spec.ts
+++ b/client-v3/e2e/tests/08-show-config-cues.spec.ts
@@ -11,21 +11,11 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
-import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
+import { registerRetryHooks } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async () => {
-  if (test.info().retry > 0 && snapshotExists()) {
-    await restoreStateAndRestartServer();
-  }
-});
-
-test.afterEach(async () => {
-  if (test.info().status === 'passed') {
-    snapshotState();
-  }
-});
+registerRetryHooks();
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/08-show-config-cues.spec.ts
+++ b/client-v3/e2e/tests/08-show-config-cues.spec.ts
@@ -11,8 +11,21 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
+import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async ({}, testInfo) => {
+  if (testInfo.retry > 0 && snapshotExists()) {
+    await restoreStateAndRestartServer();
+  }
+});
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === 'passed') {
+    snapshotState();
+  }
+});
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/08-show-config-cues.spec.ts
+++ b/client-v3/e2e/tests/08-show-config-cues.spec.ts
@@ -15,13 +15,13 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async ({}, testInfo) => {
+test.beforeAll(async (_fixtures, testInfo) => {
   if (testInfo.retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async ({}, testInfo) => {
+test.afterEach(async (_fixtures, testInfo) => {
   if (testInfo.status === 'passed') {
     snapshotState();
   }

--- a/client-v3/e2e/tests/09-show-config-mics.spec.ts
+++ b/client-v3/e2e/tests/09-show-config-mics.spec.ts
@@ -15,14 +15,14 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async (_fixtures, testInfo) => {
-  if (testInfo.retry > 0 && snapshotExists()) {
+test.beforeAll(async () => {
+  if (test.info().retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async (_fixtures, testInfo) => {
-  if (testInfo.status === 'passed') {
+test.afterEach(async () => {
+  if (test.info().status === 'passed') {
     snapshotState();
   }
 });

--- a/client-v3/e2e/tests/09-show-config-mics.spec.ts
+++ b/client-v3/e2e/tests/09-show-config-mics.spec.ts
@@ -11,21 +11,11 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
-import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
+import { registerRetryHooks } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async () => {
-  if (test.info().retry > 0 && snapshotExists()) {
-    await restoreStateAndRestartServer();
-  }
-});
-
-test.afterEach(async () => {
-  if (test.info().status === 'passed') {
-    snapshotState();
-  }
-});
+registerRetryHooks();
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/09-show-config-mics.spec.ts
+++ b/client-v3/e2e/tests/09-show-config-mics.spec.ts
@@ -11,8 +11,21 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
+import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async ({}, testInfo) => {
+  if (testInfo.retry > 0 && snapshotExists()) {
+    await restoreStateAndRestartServer();
+  }
+});
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === 'passed') {
+    snapshotState();
+  }
+});
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/09-show-config-mics.spec.ts
+++ b/client-v3/e2e/tests/09-show-config-mics.spec.ts
@@ -15,13 +15,13 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async ({}, testInfo) => {
+test.beforeAll(async (_fixtures, testInfo) => {
   if (testInfo.retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async ({}, testInfo) => {
+test.afterEach(async (_fixtures, testInfo) => {
   if (testInfo.status === 'passed') {
     snapshotState();
   }

--- a/client-v3/e2e/tests/10-show-config-script.spec.ts
+++ b/client-v3/e2e/tests/10-show-config-script.spec.ts
@@ -16,13 +16,13 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async ({}, testInfo) => {
+test.beforeAll(async (_fixtures, testInfo) => {
   if (testInfo.retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async ({}, testInfo) => {
+test.afterEach(async (_fixtures, testInfo) => {
   if (testInfo.status === 'passed') {
     snapshotState();
   }

--- a/client-v3/e2e/tests/10-show-config-script.spec.ts
+++ b/client-v3/e2e/tests/10-show-config-script.spec.ts
@@ -12,21 +12,11 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
-import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
+import { registerRetryHooks } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async () => {
-  if (test.info().retry > 0 && snapshotExists()) {
-    await restoreStateAndRestartServer();
-  }
-});
-
-test.afterEach(async () => {
-  if (test.info().status === 'passed') {
-    snapshotState();
-  }
-});
+registerRetryHooks();
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/10-show-config-script.spec.ts
+++ b/client-v3/e2e/tests/10-show-config-script.spec.ts
@@ -12,8 +12,21 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
+import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async ({}, testInfo) => {
+  if (testInfo.retry > 0 && snapshotExists()) {
+    await restoreStateAndRestartServer();
+  }
+});
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === 'passed') {
+    snapshotState();
+  }
+});
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/10-show-config-script.spec.ts
+++ b/client-v3/e2e/tests/10-show-config-script.spec.ts
@@ -16,14 +16,14 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async (_fixtures, testInfo) => {
-  if (testInfo.retry > 0 && snapshotExists()) {
+test.beforeAll(async () => {
+  if (test.info().retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async (_fixtures, testInfo) => {
-  if (testInfo.status === 'passed') {
+test.afterEach(async () => {
+  if (test.info().status === 'passed') {
     snapshotState();
   }
 });

--- a/client-v3/e2e/tests/11-show-config-revisions.spec.ts
+++ b/client-v3/e2e/tests/11-show-config-revisions.spec.ts
@@ -15,14 +15,14 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async (_fixtures, testInfo) => {
-  if (testInfo.retry > 0 && snapshotExists()) {
+test.beforeAll(async () => {
+  if (test.info().retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async (_fixtures, testInfo) => {
-  if (testInfo.status === 'passed') {
+test.afterEach(async () => {
+  if (test.info().status === 'passed') {
     snapshotState();
   }
 });

--- a/client-v3/e2e/tests/11-show-config-revisions.spec.ts
+++ b/client-v3/e2e/tests/11-show-config-revisions.spec.ts
@@ -11,21 +11,11 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
-import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
+import { registerRetryHooks } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async () => {
-  if (test.info().retry > 0 && snapshotExists()) {
-    await restoreStateAndRestartServer();
-  }
-});
-
-test.afterEach(async () => {
-  if (test.info().status === 'passed') {
-    snapshotState();
-  }
-});
+registerRetryHooks();
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/11-show-config-revisions.spec.ts
+++ b/client-v3/e2e/tests/11-show-config-revisions.spec.ts
@@ -11,8 +11,21 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
+import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async ({}, testInfo) => {
+  if (testInfo.retry > 0 && snapshotExists()) {
+    await restoreStateAndRestartServer();
+  }
+});
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === 'passed') {
+    snapshotState();
+  }
+});
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/11-show-config-revisions.spec.ts
+++ b/client-v3/e2e/tests/11-show-config-revisions.spec.ts
@@ -15,13 +15,13 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async ({}, testInfo) => {
+test.beforeAll(async (_fixtures, testInfo) => {
   if (testInfo.retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async ({}, testInfo) => {
+test.afterEach(async (_fixtures, testInfo) => {
   if (testInfo.status === 'passed') {
     snapshotState();
   }

--- a/client-v3/e2e/tests/12-show-config-sessions.spec.ts
+++ b/client-v3/e2e/tests/12-show-config-sessions.spec.ts
@@ -16,13 +16,13 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async ({}, testInfo) => {
+test.beforeAll(async (_fixtures, testInfo) => {
   if (testInfo.retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async ({}, testInfo) => {
+test.afterEach(async (_fixtures, testInfo) => {
   if (testInfo.status === 'passed') {
     snapshotState();
   }

--- a/client-v3/e2e/tests/12-show-config-sessions.spec.ts
+++ b/client-v3/e2e/tests/12-show-config-sessions.spec.ts
@@ -12,21 +12,11 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
-import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
+import { registerRetryHooks } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async () => {
-  if (test.info().retry > 0 && snapshotExists()) {
-    await restoreStateAndRestartServer();
-  }
-});
-
-test.afterEach(async () => {
-  if (test.info().status === 'passed') {
-    snapshotState();
-  }
-});
+registerRetryHooks();
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/12-show-config-sessions.spec.ts
+++ b/client-v3/e2e/tests/12-show-config-sessions.spec.ts
@@ -12,8 +12,21 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
+import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async ({}, testInfo) => {
+  if (testInfo.retry > 0 && snapshotExists()) {
+    await restoreStateAndRestartServer();
+  }
+});
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === 'passed') {
+    snapshotState();
+  }
+});
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/12-show-config-sessions.spec.ts
+++ b/client-v3/e2e/tests/12-show-config-sessions.spec.ts
@@ -16,14 +16,14 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async (_fixtures, testInfo) => {
-  if (testInfo.retry > 0 && snapshotExists()) {
+test.beforeAll(async () => {
+  if (test.info().retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async (_fixtures, testInfo) => {
-  if (testInfo.status === 'passed') {
+test.afterEach(async () => {
+  if (test.info().status === 'passed') {
     snapshotState();
   }
 });

--- a/client-v3/e2e/tests/13-live-show.spec.ts
+++ b/client-v3/e2e/tests/13-live-show.spec.ts
@@ -16,21 +16,11 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
-import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
+import { registerRetryHooks } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async () => {
-  if (test.info().retry > 0 && snapshotExists()) {
-    await restoreStateAndRestartServer();
-  }
-});
-
-test.afterEach(async () => {
-  if (test.info().status === 'passed') {
-    snapshotState();
-  }
-});
+registerRetryHooks();
 
 let leaderCtx: BrowserContext;
 let followerCtx: BrowserContext;

--- a/client-v3/e2e/tests/13-live-show.spec.ts
+++ b/client-v3/e2e/tests/13-live-show.spec.ts
@@ -20,13 +20,13 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async ({}, testInfo) => {
+test.beforeAll(async (_fixtures, testInfo) => {
   if (testInfo.retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async ({}, testInfo) => {
+test.afterEach(async (_fixtures, testInfo) => {
   if (testInfo.status === 'passed') {
     snapshotState();
   }

--- a/client-v3/e2e/tests/13-live-show.spec.ts
+++ b/client-v3/e2e/tests/13-live-show.spec.ts
@@ -20,14 +20,14 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async (_fixtures, testInfo) => {
-  if (testInfo.retry > 0 && snapshotExists()) {
+test.beforeAll(async () => {
+  if (test.info().retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async (_fixtures, testInfo) => {
-  if (testInfo.status === 'passed') {
+test.afterEach(async () => {
+  if (test.info().status === 'passed') {
     snapshotState();
   }
 });

--- a/client-v3/e2e/tests/13-live-show.spec.ts
+++ b/client-v3/e2e/tests/13-live-show.spec.ts
@@ -16,8 +16,21 @@ import {
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';
+import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async ({}, testInfo) => {
+  if (testInfo.retry > 0 && snapshotExists()) {
+    await restoreStateAndRestartServer();
+  }
+});
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === 'passed') {
+    snapshotState();
+  }
+});
 
 let leaderCtx: BrowserContext;
 let followerCtx: BrowserContext;

--- a/client-v3/e2e/tests/14-user-settings.spec.ts
+++ b/client-v3/e2e/tests/14-user-settings.spec.ts
@@ -10,21 +10,11 @@ import {
   waitForAppReady,
   confirmDialog,
 } from '../helpers.js';
-import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
+import { registerRetryHooks } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async () => {
-  if (test.info().retry > 0 && snapshotExists()) {
-    await restoreStateAndRestartServer();
-  }
-});
-
-test.afterEach(async () => {
-  if (test.info().status === 'passed') {
-    snapshotState();
-  }
-});
+registerRetryHooks();
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/e2e/tests/14-user-settings.spec.ts
+++ b/client-v3/e2e/tests/14-user-settings.spec.ts
@@ -14,14 +14,14 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async (_fixtures, testInfo) => {
-  if (testInfo.retry > 0 && snapshotExists()) {
+test.beforeAll(async () => {
+  if (test.info().retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async (_fixtures, testInfo) => {
-  if (testInfo.status === 'passed') {
+test.afterEach(async () => {
+  if (test.info().status === 'passed') {
     snapshotState();
   }
 });

--- a/client-v3/e2e/tests/14-user-settings.spec.ts
+++ b/client-v3/e2e/tests/14-user-settings.spec.ts
@@ -14,13 +14,13 @@ import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../
 
 test.describe.configure({ mode: 'serial' });
 
-test.beforeAll(async ({}, testInfo) => {
+test.beforeAll(async (_fixtures, testInfo) => {
   if (testInfo.retry > 0 && snapshotExists()) {
     await restoreStateAndRestartServer();
   }
 });
 
-test.afterEach(async ({}, testInfo) => {
+test.afterEach(async (_fixtures, testInfo) => {
   if (testInfo.status === 'passed') {
     snapshotState();
   }

--- a/client-v3/e2e/tests/14-user-settings.spec.ts
+++ b/client-v3/e2e/tests/14-user-settings.spec.ts
@@ -10,8 +10,21 @@ import {
   waitForAppReady,
   confirmDialog,
 } from '../helpers.js';
+import { snapshotExists, snapshotState, restoreStateAndRestartServer } from '../db-snapshot.js';
 
 test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async ({}, testInfo) => {
+  if (testInfo.retry > 0 && snapshotExists()) {
+    await restoreStateAndRestartServer();
+  }
+});
+
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === 'passed') {
+    snapshotState();
+  }
+});
 
 let ctx: BrowserContext;
 let page: Page;

--- a/client-v3/playwright.config.ts
+++ b/client-v3/playwright.config.ts
@@ -6,7 +6,8 @@ export default defineConfig({
   testDir: './e2e/tests',
   fullyParallel: false,
   workers: 1,
-  retries: 0,
+  retries: 3,
+  maxFailures: 1,
   reporter: [
     ['html', { outputFolder: 'playwright-report', open: 'never' }],
     ['junit', { outputFile: 'junit/playwright-results.xml' }],


### PR DESCRIPTION
## Summary

- Enables Playwright retries (3 attempts) for the full E2E suite without compromising the serial, state-dependent test design
- On retry, the backend server is killed, both the SQLite DB and `digiscript.json` settings file are restored from the last known-good snapshot (taken after each passing test), and the server is restarted before the spec group re-runs from test 1
- Adds `maxFailures: 1` so that once a spec exhausts all retries, downstream specs are immediately skipped — preventing meaningless results from running against incomplete state

## Changes

**New file — `client-v3/e2e/db-snapshot.ts`**
- `snapshotState()` — copies `digiscript.sqlite` + `digiscript.json` to `.snapshot` sibling files after each passing test
- `snapshotExists()` — guards the restore path (handles the spec 01 edge case where no snapshot exists yet)
- `restoreStateAndRestartServer()` — SIGKILLs the server, restores both files, respawns the server, polls the health endpoint

**`client-v3/e2e/global-setup.ts`** — exports `SERVER_PORT` and `waitForServer` so `db-snapshot.ts` reuses them without duplication

**`client-v3/playwright.config.ts`** — `retries: 0 → 3`, adds `maxFailures: 1`

**All 14 spec files** — identical change to each: import from `db-snapshot.js`, add a restore `beforeAll` (registered before the existing one so it fires first on retry), add a snapshot `afterEach`

## How it works

```
First attempt:
  beforeAll (retry=0 → no restore)
  beforeAll (existing: new ctx, login, navigate)
  T1 ✓ → afterEach → snapshotState()
  T2 ✓ → afterEach → snapshotState()
  T3 ✗ → no snapshot

Retry (testInfo.retry=1 in beforeAll):
  beforeAll → restoreStateAndRestartServer()
              [SIGKILL → files restored → server restarted → health check]
  beforeAll (existing: new ctx, login, navigate — against clean server)
  T1 ✓ → T2 ✓ → T3 → ...
```

The Python server uses SQLite's DELETE journal mode (no WAL/SHM files) and per-request SQLAlchemy sessions with no persistent connections, so SIGKILL + file swap + restart is safe.

## Test plan

- [x] Full suite passes clean (148/148) with retries enabled and no actual failures
- [x] Deliberate failure in spec 04 triggers 3 retries with restore, then `maxFailures: 1` stops the suite — downstream specs 05–14 do not run
- [x] TypeScript typecheck passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)