### PR TITLE
Fix Firefox E2E: toast blocks modal close + retry cascade in db-snapshot

### DIFF
--- a/client-v3/e2e/db-snapshot.ts
+++ b/client-v3/e2e/db-snapshot.ts
@@ -6,35 +6,36 @@ import { PID_FILE, TMPDIR_FILE, SERVER_PORT, waitForServer } from './global-setu
 
 function getPaths() {
   const tempDir = fs.readFileSync(TMPDIR_FILE, 'utf-8').trim();
+  const db = path.join(tempDir, 'digiscript.sqlite');
+  const config = path.join(tempDir, 'digiscript.json');
   return {
-    db: path.join(tempDir, 'digiscript.sqlite'),
-    dbSnapshot: path.join(tempDir, 'digiscript.sqlite.snapshot'),
-    config: path.join(tempDir, 'digiscript.json'),
-    configSnapshot: path.join(tempDir, 'digiscript.json.snapshot'),
+    db,
+    dbSpecStart: `${db}.specstart`,
+    config,
+    configSpecStart: `${config}.specstart`,
     serverDir: path.resolve(process.cwd(), '..', 'server'),
   };
 }
 
-export function snapshotExists(): boolean {
-  const { dbSnapshot } = getPaths();
-  return fs.existsSync(dbSnapshot);
+export function specStartExists(): boolean {
+  return fs.existsSync(getPaths().dbSpecStart);
 }
 
-/** Copy the DB and config to snapshot files. Call after each passing test. */
-export function snapshotState(): void {
-  const { db, dbSnapshot, config, configSnapshot } = getPaths();
-  fs.copyFileSync(db, dbSnapshot);
-  fs.copyFileSync(config, configSnapshot);
+/** Copy the current DB and config to the spec-start snapshot files. */
+export function snapshotSpecStart(): void {
+  const { db, dbSpecStart, config, configSpecStart } = getPaths();
+  fs.copyFileSync(db, dbSpecStart);
+  fs.copyFileSync(config, configSpecStart);
 }
 
 /**
- * Restore DB and config from the last snapshot, then restart the server.
- * Call at the start of a retry to bring the backend back to last known-good state.
+ * Restore DB and config from the spec-start snapshot, then restart the server.
+ * This returns the backend to the state it was in before this spec's first test ran,
+ * so every test in the spec can re-run cleanly without hitting its own prior side effects.
  */
-export async function restoreStateAndRestartServer(): Promise<void> {
-  const { db, dbSnapshot, config, configSnapshot, serverDir } = getPaths();
+export async function restoreSpecStartAndRestartServer(): Promise<void> {
+  const { db, dbSpecStart, config, configSpecStart, serverDir } = getPaths();
 
-  // Kill existing server
   if (fs.existsSync(PID_FILE)) {
     const pid = parseInt(fs.readFileSync(PID_FILE, 'utf-8').trim(), 10);
     try {
@@ -52,11 +53,9 @@ export async function restoreStateAndRestartServer(): Promise<void> {
     // no journal file present
   }
 
-  // Restore DB and config from snapshot
-  fs.copyFileSync(dbSnapshot, db);
-  fs.copyFileSync(configSnapshot, config);
+  fs.copyFileSync(dbSpecStart, db);
+  fs.copyFileSync(configSpecStart, config);
 
-  // Respawn server with the restored config
   const server = spawn(
     'python3',
     ['main.py', `--port=${SERVER_PORT}`, `--settings_path=${config}`, '--debug=false'],
@@ -68,16 +67,22 @@ export async function restoreStateAndRestartServer(): Promise<void> {
   await waitForServer();
 }
 
-/** Register beforeAll/afterEach hooks for retry support. Call once at the top of each spec file. */
+/**
+ * Register beforeAll hooks for retry support. Call once at the top of each spec file.
+ *
+ * On first run (retry=0): captures the DB state at spec start so retries have a clean baseline.
+ * On retry: restores from that spec-start snapshot before tests run again, ensuring every test
+ * in the spec sees the same starting conditions regardless of side effects from prior attempts.
+ */
 export function registerRetryHooks(): void {
   test.beforeAll(async () => {
-    if (test.info().retry > 0 && snapshotExists()) {
-      await restoreStateAndRestartServer();
+    if (test.info().retry > 0 && specStartExists()) {
+      await restoreSpecStartAndRestartServer();
     }
   });
-  test.afterEach(async () => {
-    if (test.info().status === 'passed') {
-      snapshotState();
+  test.beforeAll(async () => {
+    if (test.info().retry === 0) {
+      snapshotSpecStart();
     }
   });
 }

--- a/client-v3/e2e/tests/03-system-config.spec.ts
+++ b/client-v3/e2e/tests/03-system-config.spec.ts
@@ -120,6 +120,12 @@ test('can configure RBAC permissions for testuser', async () => {
     timeout: 5_000,
   });
 
+  // Wait for the "Revoked role from user" toast to clear before clicking the modal close button.
+  // In Firefox the toast persists long enough to intercept pointer events to .btn-close.
+  await page
+    .locator('.v-toast')
+    .waitFor({ state: 'detached', timeout: 10_000 })
+    .catch(() => {});
   await page.locator('.modal.show .modal-header .btn-close').click();
   await waitForModalClosed(page);
 });


### PR DESCRIPTION
## Summary

- **Root cause**: After revoking an RBAC role in spec 03, Firefox kept the `v-toast` notification visible long enough to intercept pointer events to the modal's `.btn-close`, causing a 30-second timeout on every retry.
- **Cascade bug**: The original rolling-checkpoint snapshot strategy had an inherent flaw — when test N passes (side effect: creates `testuser`) and test N+1 fails, the retry restores to the post-N snapshot and re-runs all tests from the top, but test N hits its own prior side effect (duplicate username → Save stays disabled forever).
- **Design fix**: Switch from rolling-checkpoint to **spec-start snapshots**. Each spec captures the DB state at its `beforeAll` on the first run. On retry, the entire spec is restored to that pre-spec state, so every test re-runs cleanly regardless of which test originally failed.

## Changes

### `e2e/db-snapshot.ts`
- Replace `snapshotState()` / `snapshotExists()` / `restoreStateAndRestartServer()` with `snapshotSpecStart()` / `specStartExists()` / `restoreSpecStartAndRestartServer()`
- Snapshot files are now `digiscript.sqlite.specstart` / `digiscript.json.specstart` (taken once per spec, not after every test)
- `registerRetryHooks()` now uses two `beforeAll` calls: restore-if-retry and capture-spec-start; the `afterEach` snapshot is removed entirely

### `e2e/tests/03-system-config.spec.ts`
- Before clicking `.btn-close`, wait for `.v-toast` to detach (with a 10s timeout and `.catch(() => {})` so a missing toast doesn't fail the test)

## Test plan

- [ ] Full Playwright suite (`npm run test:e2e`) passes on Chromium
- [ ] Full Playwright suite passes on Firefox (previously failing on spec 03)
- [ ] CI E2E checks green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)