### PR TITLE
Fix session start from show config Sessions tab

### DIFF
--- a/client-v3/e2e/tests/12-show-config-sessions.spec.ts
+++ b/client-v3/e2e/tests/12-show-config-sessions.spec.ts
@@ -78,11 +78,13 @@ test('deletes a session tag', async () => {
 
 test('switches back to Sessions sub-tab', async () => {
   await page.click('button[role="tab"]:has-text("Sessions")');
-  await expect(page.locator('button:has-text("Start Session")')).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator('button.btn-success:has-text("Start Session")')).toBeVisible({
+    timeout: 10_000,
+  });
 });
 
 test('starts a session via the Sessions tab Start button', async () => {
-  await page.click('button:has-text("Start Session")');
+  await page.click('button.btn-success:has-text("Start Session")');
   // START_SHOW WS message pushes all clients to /live
   await page.waitForURL(`${UI_BASE}/live`, { timeout: 10_000 });
 });

--- a/client-v3/e2e/tests/12-show-config-sessions.spec.ts
+++ b/client-v3/e2e/tests/12-show-config-sessions.spec.ts
@@ -1,6 +1,6 @@
 /**
- * Show Config — Sessions tab: session tags CRUD.
- * Note: actual session start/stop is tested in 13-live-show.spec.ts.
+ * Show Config — Sessions tab: session start via the tab button + session tags CRUD.
+ * Spec 13 covers session start/stop via the navbar.
  */
 import { test, expect, type BrowserContext, type Page } from '@playwright/test';
 import {
@@ -72,4 +72,24 @@ test('deletes a session tag', async () => {
   await expect(page.locator('td:has-text("Tech Run (Edited)")')).not.toBeVisible({
     timeout: 5_000,
   });
+});
+
+// ── Session start via the tab button ─────────────────────────────────────
+
+test('switches back to Sessions sub-tab', async () => {
+  await page.click('button[role="tab"]:has-text("Sessions")');
+  await expect(page.locator('button:has-text("Start Session")')).toBeVisible({ timeout: 10_000 });
+});
+
+test('starts a session via the Sessions tab Start button', async () => {
+  await page.click('button:has-text("Start Session")');
+  // START_SHOW WS message pushes all clients to /live
+  await page.waitForURL(`${UI_BASE}/live`, { timeout: 10_000 });
+});
+
+test('stops the session via the navbar to restore state for later specs', async () => {
+  await page.locator('text=Live Config').click();
+  await page.click('button:has-text("Stop Session")');
+  await confirmDialog(page);
+  await expect(page.locator('a:has-text("Live")')).toHaveClass(/disabled/, { timeout: 10_000 });
 });

--- a/client-v3/src/components/show/config/sessions/SessionList.vue
+++ b/client-v3/src/components/show/config/sessions/SessionList.vue
@@ -2,22 +2,13 @@
   <BContainer class="mx-0" fluid>
     <BRow v-if="systemStore.isShowExecutor" style="margin-bottom: 0.5rem">
       <BCol class="text-start ps-0">
-        <BButtonGroup>
-          <BButton
-            variant="success"
-            :disabled="systemStore.currentShow?.current_session_id !== null || startingSession"
-            @click.stop="startSession"
-          >
-            Start Session
-          </BButton>
-          <BButton
-            variant="danger"
-            :disabled="systemStore.currentShow?.current_session_id === null || stoppingSession"
-            @click.stop="stopSession"
-          >
-            Stop Session
-          </BButton>
-        </BButtonGroup>
+        <BButton
+          variant="success"
+          :disabled="systemStore.currentShow?.current_session_id !== null || startingSession"
+          @click.stop="startSession"
+        >
+          Start Session
+        </BButton>
       </BCol>
     </BRow>
     <BRow>
@@ -65,14 +56,15 @@ import log from 'loglevel';
 import { makeURL, msToTimerString, contrastColor } from '@/js/utils';
 import { useSystemStore } from '@/stores/system';
 import { useShowStore } from '@/stores/show';
+import { useWebSocketStore } from '@/stores/websocket';
 import { toast } from '@/js/toast';
 import SessionTagDropdown from './SessionTagDropdown.vue';
 
 const systemStore = useSystemStore();
 const showStore = useShowStore();
+const wsStore = useWebSocketStore();
 
 const startingSession = ref(false);
-const stoppingSession = ref(false);
 
 const sessionFields = [
   { key: 'start_date_time', label: 'Start Time' },
@@ -96,9 +88,17 @@ function revisionLabel(revisionId: number | null): string {
 }
 
 async function startSession(): Promise<void> {
+  if (!wsStore.internalUUID) {
+    toast.error('Unable to start new show session');
+    return;
+  }
   startingSession.value = true;
   try {
-    const response = await fetch(makeURL('/api/v1/show/sessions/start'), { method: 'POST' });
+    const response = await fetch(makeURL('/api/v1/show/sessions/start'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_id: wsStore.internalUUID }),
+    });
     if (response.ok) {
       toast.success('Started new show session');
       await showStore.getShowSessionData();
@@ -108,22 +108,6 @@ async function startSession(): Promise<void> {
     }
   } finally {
     startingSession.value = false;
-  }
-}
-
-async function stopSession(): Promise<void> {
-  stoppingSession.value = true;
-  try {
-    const response = await fetch(makeURL('/api/v1/show/sessions/stop'), { method: 'POST' });
-    if (response.ok) {
-      toast.success('Stopped show session');
-      await showStore.getShowSessionData();
-    } else {
-      log.error('Unable to stop show session');
-      toast.error('Unable to stop show session');
-    }
-  } finally {
-    stoppingSession.value = false;
   }
 }
 </script>

--- a/client/src/vue_components/show/config/sessions/SessionList.vue
+++ b/client/src/vue_components/show/config/sessions/SessionList.vue
@@ -2,22 +2,14 @@
   <b-container class="mx-0" fluid>
     <b-row style="margin-bottom: 0.5rem">
       <b-col class="text-left pl-0">
-        <b-button-group v-if="IS_SHOW_EXECUTOR">
-          <b-button
-            variant="success"
-            :disabled="CURRENT_SHOW_SESSION !== null || startingSession"
-            @click.stop="startSession"
-          >
-            Start Session
-          </b-button>
-          <b-button
-            variant="danger"
-            :disabled="CURRENT_SHOW_SESSION === null || stoppingSession"
-            @click.stop="stopSession"
-          >
-            Stop Session
-          </b-button>
-        </b-button-group>
+        <b-button
+          v-if="IS_SHOW_EXECUTOR"
+          variant="success"
+          :disabled="CURRENT_SHOW_SESSION !== null || startingSession"
+          @click.stop="startSession"
+        >
+          Start Session
+        </b-button>
       </b-col>
     </b-row>
     <b-row>
@@ -87,7 +79,6 @@ export default defineComponent({
         { key: 'tags', label: 'Tags' },
       ],
       startingSession: false,
-      stoppingSession: false,
     };
   },
   computed: {
@@ -121,19 +112,6 @@ export default defineComponent({
         (this as any).$toast.error('Unable to start new show session');
       }
       this.startingSession = false;
-    },
-    async stopSession(): Promise<void> {
-      this.stoppingSession = true;
-      const response = await fetch(`${makeURL('/api/v1/show/sessions/stop')}`, {
-        method: 'POST',
-      });
-      if (response.ok) {
-        (this as any).$toast.success('Stopped show session');
-      } else {
-        log.error('Unable to stop show session');
-        (this as any).$toast.error('Unable to stop show session');
-      }
-      this.stoppingSession = false;
     },
     runTimeCalc(start: string, end: string): string {
       const startDate = Date.parse(start);


### PR DESCRIPTION
## Summary

- **Bug fix**: `SessionList.vue` (Vue 3) was sending an empty POST body to `POST /api/v1/show/sessions/start`, causing a `JSONDecodeError` on the server. The endpoint requires `{"session_id": "<uuid>"}` to identify the initiating client — matching the pattern already used by the navbar button in `App.vue`.
- **Dead code removal**: Removes the unreachable Stop Session button from both the Vue 2 and Vue 3 `SessionList` components. The `START_SHOW` WebSocket message (`useWebSocket.ts:81` / `websocket.ts:113`) pushes all clients to `/live` the moment a session starts, making the button inaccessible. Stop Session remains available via the navbar Live Config dropdown.
- **E2E coverage**: Adds three tests to spec 12 covering the sessions tab Start Session button, including cleanup via the navbar to restore state for spec 13.

## Test plan

- [ ] Full Playwright E2E suite passes (`npm run test:e2e` in `client-v3/`) — spec 12 new tests exercise the fix, spec 13 continues to pass
- [ ] `npm run typecheck` passes in both `client/` and `client-v3/`
- [ ] `npm run ci-lint` passes in both `client/` and `client-v3/`
- [ ] Manually verify starting a session from Show Config → Sessions tab no longer returns a 500 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)