### PR TITLE
Add server hostname, IP address, and port to System Config page

### DIFF
--- a/client-v3/e2e/tests/03-system-config.spec.ts
+++ b/client-v3/e2e/tests/03-system-config.spec.ts
@@ -235,6 +235,12 @@ test('switches to the System tab', async () => {
   });
 });
 
+test('System tab shows server info rows', async () => {
+  await expect(page.locator('strong:has-text("Hostname")')).toBeVisible();
+  await expect(page.locator('strong:has-text("IP Address")')).toBeVisible();
+  await expect(page.locator('strong:has-text("Port")')).toBeVisible();
+});
+
 test('can open the View Clients modal', async () => {
   await page.click('button:has-text("View Clients")');
   await waitForModal(page, 'Connected Clients');

--- a/client-v3/src/components/config/ConfigSystem.vue
+++ b/client-v3/src/components/config/ConfigSystem.vue
@@ -46,6 +46,21 @@
             </BButton>
           </BTd>
         </BTr>
+        <BTr>
+          <BTd><strong>Hostname</strong></BTd>
+          <BTd>{{ serverInfo?.hostname ?? 'Unknown' }}</BTd>
+          <BTd />
+        </BTr>
+        <BTr>
+          <BTd><strong>IP Address</strong></BTd>
+          <BTd>{{ serverInfo?.ip_address ?? 'Unknown' }}</BTd>
+          <BTd />
+        </BTr>
+        <BTr>
+          <BTd><strong>Port</strong></BTd>
+          <BTd>{{ serverInfo?.port ?? 'Unknown' }}</BTd>
+          <BTd />
+        </BTr>
       </BTbody>
     </BTableSimple>
 
@@ -80,7 +95,7 @@ import { useSystemStore } from '@/stores/system';
 import { toast } from '@/js/toast';
 
 const systemStore = useSystemStore();
-const { connectedSessions, versionStatus } = storeToRefs(systemStore);
+const { connectedSessions, versionStatus, serverInfo } = storeToRefs(systemStore);
 
 const loading = ref(true);
 const isCheckingVersion = ref(false);
@@ -137,7 +152,11 @@ function scheduleSessionPoll(): void {
 }
 
 onMounted(async () => {
-  await Promise.all([systemStore.getVersionStatus(), systemStore.getConnectedSessions()]);
+  await Promise.all([
+    systemStore.getVersionStatus(),
+    systemStore.getConnectedSessions(),
+    systemStore.getServerInfo(),
+  ]);
   loading.value = false;
   scheduleSessionPoll();
 });

--- a/client-v3/src/stores/system.ts
+++ b/client-v3/src/stores/system.ts
@@ -24,6 +24,12 @@ interface VersionStatus {
   check_error: string | null;
 }
 
+interface ServerInfo {
+  hostname: string;
+  ip_address: string;
+  port: number;
+}
+
 interface RbacRole {
   key: string;
   value: number;
@@ -49,6 +55,7 @@ export const useSystemStore = defineStore('system', {
     currentShow: null as Show | null,
     connectedSessions: [] as ConnectedSession[],
     versionStatus: null as VersionStatus | null,
+    serverInfo: null as ServerInfo | null,
   }),
   getters: {
     isAdminUser(): boolean {
@@ -244,6 +251,14 @@ export const useSystemStore = defineStore('system', {
         this.versionStatus = await response.json();
       } else {
         log.error('Unable to fetch version status');
+      }
+    },
+    async getServerInfo() {
+      const response = await fetch(makeURL('/api/v1/system/info'));
+      if (response.ok) {
+        this.serverInfo = await response.json();
+      } else {
+        log.error('Unable to fetch server info');
       }
     },
     async checkForUpdates() {

--- a/client/src/vue_components/config/ConfigSystem.vue
+++ b/client/src/vue_components/config/ConfigSystem.vue
@@ -54,6 +54,21 @@
             </b-button>
           </b-td>
         </b-tr>
+        <b-tr>
+          <b-td><b>Hostname</b></b-td>
+          <b-td>{{ systemInfo ? systemInfo.hostname : 'Unknown' }}</b-td>
+          <b-td />
+        </b-tr>
+        <b-tr>
+          <b-td><b>IP Address</b></b-td>
+          <b-td>{{ systemInfo ? systemInfo.ip_address : 'Unknown' }}</b-td>
+          <b-td />
+        </b-tr>
+        <b-tr>
+          <b-td><b>Port</b></b-td>
+          <b-td>{{ systemInfo ? systemInfo.port : 'Unknown' }}</b-td>
+          <b-td />
+        </b-tr>
       </b-tbody>
     </b-table-simple>
     <b-modal
@@ -125,10 +140,11 @@ export default defineComponent({
       isCheckingVersion: false,
       currentTime: Date.now(),
       timeUpdateInterval: null as ReturnType<typeof setInterval> | null,
+      systemInfo: null as { hostname: string | null; ip_address: string | null; port: number | null } | null,
     };
   },
   async mounted() {
-    await Promise.all([this.getConnectedClients(), this.getVersionStatus()]);
+    await Promise.all([this.getConnectedClients(), this.getVersionStatus(), this.getSystemInfo()]);
     this.loading = false;
     this.timeUpdateInterval = setInterval(() => {
       this.currentTime = Date.now();
@@ -200,6 +216,18 @@ export default defineComponent({
       if (this.versionStatus.check_error) return 'Unable to check';
       if (this.versionStatus.update_available) return 'Update Available';
       return 'Up to date';
+    },
+    async getSystemInfo(): Promise<void> {
+      try {
+        const response = await fetch(`${makeURL('/api/v1/system/info')}`);
+        if (response.ok) {
+          this.systemInfo = await response.json();
+        } else {
+          log.error('Unable to get system info');
+        }
+      } catch (error) {
+        log.error('Error fetching system info:', error);
+      }
     },
     formatTimeAgo(isoTimestamp: string | null): string {
       if (!isoTimestamp) return 'Never';

--- a/client/src/vue_components/config/ConfigSystem.vue
+++ b/client/src/vue_components/config/ConfigSystem.vue
@@ -140,7 +140,11 @@ export default defineComponent({
       isCheckingVersion: false,
       currentTime: Date.now(),
       timeUpdateInterval: null as ReturnType<typeof setInterval> | null,
-      systemInfo: null as { hostname: string | null; ip_address: string | null; port: number | null } | null,
+      systemInfo: null as {
+        hostname: string | null;
+        ip_address: string | null;
+        port: number | null;
+      } | null,
     };
   },
   async mounted() {

--- a/docs/pages/user_config.md
+++ b/docs/pages/user_config.md
@@ -8,9 +8,11 @@ The **System Config** section, accessible from the top navigation bar, provides 
 
 The **System** tab provides an overview of the current system state:
 
-- **Current Show**: Displays the currently loaded show name, with buttons to load an existing show or set up a new one.
-- **Connected Clients**: Shows the number of WebSocket clients currently connected to the server. Click "View Clients" to see details about each connected session.
 - **Version**: Displays the current DigiScript version and checks for available updates.
+- **Connected Clients**: Shows the number of WebSocket clients currently connected to the server. Click "View Clients" to see details about each connected session.
+- **Hostname**: The fully-qualified domain name (FQDN) of the server machine.
+- **IP Address**: The primary outbound IP address the server is reachable on.
+- **Port**: The port the server is listening on.
 
 #### Version Checker
 

--- a/server/controllers/api/system_info.py
+++ b/server/controllers/api/system_info.py
@@ -5,6 +5,12 @@ from utils.web.route import ApiRoute, ApiVersion
 from utils.web.web_decorators import api_authenticated, require_admin
 
 
+# Well-known public DNS address used only to determine the local outbound interface.
+# No data is ever sent — the UDP socket is closed immediately after getsockname().
+_PROBE_HOST = "8.8.8.8"
+_PROBE_PORT = 80
+
+
 @ApiRoute("system/info", ApiVersion.V1)
 class SystemInfoController(BaseAPIController):
     @api_authenticated
@@ -39,7 +45,7 @@ def _get_primary_ip() -> str:
     try:
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         try:
-            s.connect(("8.8.8.8", 80))
+            s.connect((_PROBE_HOST, _PROBE_PORT))
             return s.getsockname()[0]
         finally:
             s.close()

--- a/server/controllers/api/system_info.py
+++ b/server/controllers/api/system_info.py
@@ -1,0 +1,46 @@
+import socket
+
+from utils.web.base_controller import BaseAPIController
+from utils.web.route import ApiRoute, ApiVersion
+from utils.web.web_decorators import api_authenticated
+
+
+@ApiRoute("system/info", ApiVersion.V1)
+class SystemInfoController(BaseAPIController):
+    @api_authenticated
+    async def get(self):
+        """
+        Get server network information.
+
+        Returns the server's fully-qualified hostname, primary outbound IP address,
+        and the port it is listening on.
+
+        :returns: JSON response with hostname, ip_address, and port.
+        """
+        await self.finish(
+            {
+                "hostname": socket.getfqdn(),
+                "ip_address": _get_primary_ip(),
+                "port": self.application._port,
+            }
+        )
+
+
+def _get_primary_ip() -> str:
+    """
+    Return the primary outbound IP address.
+
+    Uses the connect-to-8.8.8.8 trick: opening a UDP socket and calling connect()
+    causes the OS to select the correct source address without sending any data.
+
+    :returns: IP address string, or ``"Unknown"`` on failure.
+    """
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(("8.8.8.8", 80))
+            return s.getsockname()[0]
+        finally:
+            s.close()
+    except Exception:
+        return "Unknown"

--- a/server/controllers/api/system_info.py
+++ b/server/controllers/api/system_info.py
@@ -2,12 +2,13 @@ import socket
 
 from utils.web.base_controller import BaseAPIController
 from utils.web.route import ApiRoute, ApiVersion
-from utils.web.web_decorators import api_authenticated
+from utils.web.web_decorators import api_authenticated, require_admin
 
 
 @ApiRoute("system/info", ApiVersion.V1)
 class SystemInfoController(BaseAPIController):
     @api_authenticated
+    @require_admin
     async def get(self):
         """
         Get server network information.

--- a/server/test/conftest.py
+++ b/server/test/conftest.py
@@ -2,6 +2,7 @@ import json
 import os
 
 from sqlalchemy import inspect
+from tornado import escape
 from tornado.testing import AsyncHTTPTestCase
 
 from digi_server.app_server import DigiScriptServer
@@ -43,3 +44,34 @@ class DigiScriptTestCase(AsyncHTTPTestCase):
         models.db.engine.dispose()
 
         super().tearDown()
+
+    def _create_and_login_admin(self, username="admin", password="adminpass"):
+        self.fetch(
+            "/api/v1/auth/create",
+            method="POST",
+            body=escape.json_encode(
+                {"username": username, "password": password, "is_admin": True}
+            ),
+        )
+        resp = self.fetch(
+            "/api/v1/auth/login",
+            method="POST",
+            body=escape.json_encode({"username": username, "password": password}),
+        )
+        return escape.json_decode(resp.body)["access_token"]
+
+    def _create_and_login_user(self, admin_token, username="user", password="userpass"):
+        self.fetch(
+            "/api/v1/auth/create",
+            method="POST",
+            body=escape.json_encode(
+                {"username": username, "password": password, "is_admin": False}
+            ),
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        resp = self.fetch(
+            "/api/v1/auth/login",
+            method="POST",
+            body=escape.json_encode({"username": username, "password": password}),
+        )
+        return escape.json_decode(resp.body)["access_token"]

--- a/server/test/controllers/api/test_db_backups.py
+++ b/server/test/controllers/api/test_db_backups.py
@@ -34,37 +34,6 @@ class TestDbBackupsController(DigiScriptTestCase):
             f.write(b"x" * 1024)
         return backup_path
 
-    def _create_and_login_admin(self, username="admin", password="adminpass"):
-        self.fetch(
-            "/api/v1/auth/create",
-            method="POST",
-            body=escape.json_encode(
-                {"username": username, "password": password, "is_admin": True}
-            ),
-        )
-        resp = self.fetch(
-            "/api/v1/auth/login",
-            method="POST",
-            body=escape.json_encode({"username": username, "password": password}),
-        )
-        return escape.json_decode(resp.body)["access_token"]
-
-    def _create_and_login_user(self, admin_token, username="user", password="userpass"):
-        self.fetch(
-            "/api/v1/auth/create",
-            method="POST",
-            body=escape.json_encode(
-                {"username": username, "password": password, "is_admin": False}
-            ),
-            headers={"Authorization": f"Bearer {admin_token}"},
-        )
-        resp = self.fetch(
-            "/api/v1/auth/login",
-            method="POST",
-            body=escape.json_encode({"username": username, "password": password}),
-        )
-        return escape.json_decode(resp.body)["access_token"]
-
     def _fetch_backups(self, token=None):
         headers = {}
         if token:

--- a/server/test/controllers/api/test_system_info.py
+++ b/server/test/controllers/api/test_system_info.py
@@ -21,6 +21,22 @@ class TestSystemInfoController(DigiScriptTestCase):
         )
         return escape.json_decode(resp.body)["access_token"]
 
+    def _create_and_login_user(self, admin_token, username="user", password="userpass"):
+        self.fetch(
+            "/api/v1/auth/create",
+            method="POST",
+            body=escape.json_encode(
+                {"username": username, "password": password, "is_admin": False}
+            ),
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        resp = self.fetch(
+            "/api/v1/auth/login",
+            method="POST",
+            body=escape.json_encode({"username": username, "password": password}),
+        )
+        return escape.json_decode(resp.body)["access_token"]
+
     def _fetch_system_info(self, token=None):
         headers = {}
         if token:
@@ -29,6 +45,12 @@ class TestSystemInfoController(DigiScriptTestCase):
 
     def test_unauthenticated_returns_401(self):
         resp = self._fetch_system_info()
+        self.assertEqual(401, resp.code)
+
+    def test_non_admin_returns_401(self):
+        admin_token = self._create_and_login_admin()
+        user_token = self._create_and_login_user(admin_token)
+        resp = self._fetch_system_info(token=user_token)
         self.assertEqual(401, resp.code)
 
     def test_authenticated_returns_200_with_expected_keys(self):

--- a/server/test/controllers/api/test_system_info.py
+++ b/server/test/controllers/api/test_system_info.py
@@ -1,0 +1,61 @@
+"""Integration tests for GET /api/v1/system/info."""
+
+from tornado import escape
+
+from test.conftest import DigiScriptTestCase
+
+
+class TestSystemInfoController(DigiScriptTestCase):
+    def _create_and_login_admin(self, username="admin", password="adminpass"):
+        self.fetch(
+            "/api/v1/auth/create",
+            method="POST",
+            body=escape.json_encode(
+                {"username": username, "password": password, "is_admin": True}
+            ),
+        )
+        resp = self.fetch(
+            "/api/v1/auth/login",
+            method="POST",
+            body=escape.json_encode({"username": username, "password": password}),
+        )
+        return escape.json_decode(resp.body)["access_token"]
+
+    def _fetch_system_info(self, token=None):
+        headers = {}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        return self.fetch("/api/v1/system/info", headers=headers, raise_error=False)
+
+    def test_unauthenticated_returns_401(self):
+        resp = self._fetch_system_info()
+        self.assertEqual(401, resp.code)
+
+    def test_authenticated_returns_200_with_expected_keys(self):
+        token = self._create_and_login_admin()
+        resp = self._fetch_system_info(token=token)
+        self.assertEqual(200, resp.code)
+        body = escape.json_decode(resp.body)
+        self.assertIn("hostname", body)
+        self.assertIn("ip_address", body)
+        self.assertIn("port", body)
+
+    def test_hostname_is_non_empty_string(self):
+        token = self._create_and_login_admin()
+        resp = self._fetch_system_info(token=token)
+        body = escape.json_decode(resp.body)
+        self.assertIsInstance(body["hostname"], str)
+        self.assertGreater(len(body["hostname"]), 0)
+
+    def test_ip_address_is_non_empty_string(self):
+        token = self._create_and_login_admin()
+        resp = self._fetch_system_info(token=token)
+        body = escape.json_decode(resp.body)
+        self.assertIsInstance(body["ip_address"], str)
+        self.assertGreater(len(body["ip_address"]), 0)
+
+    def test_port_is_integer(self):
+        token = self._create_and_login_admin()
+        resp = self._fetch_system_info(token=token)
+        body = escape.json_decode(resp.body)
+        self.assertIsInstance(body["port"], int)

--- a/server/test/controllers/api/test_system_info.py
+++ b/server/test/controllers/api/test_system_info.py
@@ -6,37 +6,6 @@ from test.conftest import DigiScriptTestCase
 
 
 class TestSystemInfoController(DigiScriptTestCase):
-    def _create_and_login_admin(self, username="admin", password="adminpass"):
-        self.fetch(
-            "/api/v1/auth/create",
-            method="POST",
-            body=escape.json_encode(
-                {"username": username, "password": password, "is_admin": True}
-            ),
-        )
-        resp = self.fetch(
-            "/api/v1/auth/login",
-            method="POST",
-            body=escape.json_encode({"username": username, "password": password}),
-        )
-        return escape.json_decode(resp.body)["access_token"]
-
-    def _create_and_login_user(self, admin_token, username="user", password="userpass"):
-        self.fetch(
-            "/api/v1/auth/create",
-            method="POST",
-            body=escape.json_encode(
-                {"username": username, "password": password, "is_admin": False}
-            ),
-            headers={"Authorization": f"Bearer {admin_token}"},
-        )
-        resp = self.fetch(
-            "/api/v1/auth/login",
-            method="POST",
-            body=escape.json_encode({"username": username, "password": password}),
-        )
-        return escape.json_decode(resp.body)["access_token"]
-
     def _fetch_system_info(self, token=None):
         headers = {}
         if token:


### PR DESCRIPTION
## Summary

- Adds a new authenticated `GET /api/v1/system/info` endpoint returning the server's FQDN (`socket.getfqdn()`), primary outbound IP (connect-to-8.8.8.8 trick), and listening port
- Both Vue 2 (`client/`) and Vue 3 (`client-v3/`) System Config → System tabs now display three new rows: **Hostname**, **IP Address**, and **Port**
- Server info is fetched once on mount (no polling — the data is static)

## Test plan

- [ ] Backend: `pytest server/test/controllers/api/test_system_info.py` — 5 tests covering auth enforcement and response shape
- [ ] TypeScript: `npm run typecheck` passes in both `client/` and `client-v3/`
- [ ] Manually verify new rows appear in both `/ui/` and `/ui-new/` System Config → System tab with correct values after server restart
- [ ] E2E: `npm run test:e2e` (full suite) in `client-v3/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)