### PR TITLE
Add merge characters feature

### DIFF
--- a/client-v3/e2e/tests/06-show-config-characters.spec.ts
+++ b/client-v3/e2e/tests/06-show-config-characters.spec.ts
@@ -127,7 +127,9 @@ test('merges a character into another', async () => {
   await confirmModal(page);
   await waitForModalClosed(page);
   // Scope to the character table to avoid matching cells in the Line Counts tab (always in DOM).
-  await expect(page.locator('#character-table td:has-text("Horatio")')).not.toBeVisible({ timeout: 5_000 });
+  await expect(page.locator('#character-table td:has-text("Horatio")')).not.toBeVisible({
+    timeout: 5_000,
+  });
   await expect(page.locator('#character-table td:has-text("Hamlet")')).toBeVisible();
 });
 

--- a/client-v3/e2e/tests/06-show-config-characters.spec.ts
+++ b/client-v3/e2e/tests/06-show-config-characters.spec.ts
@@ -121,12 +121,14 @@ test('merges a character into another', async () => {
   const row = page.locator('tr', { has: page.locator('td:has-text("Horatio")') });
   await row.locator('button:has-text("Merge")').click();
   await waitForModal(page, /Merge Horatio/);
-  await page.locator('.modal.show .multiselect__input').fill('Hamlet');
+  // Open the dropdown by clicking the multiselect container, then select the option.
+  await page.locator('.modal.show .multiselect').click();
   await page.locator('.modal.show .multiselect__option', { hasText: 'Hamlet' }).click();
   await confirmModal(page);
   await waitForModalClosed(page);
-  await expect(page.locator('td:has-text("Horatio")')).not.toBeVisible({ timeout: 5_000 });
-  await expect(page.locator('td:has-text("Hamlet")')).toBeVisible();
+  // Scope to the character table to avoid matching cells in the Line Counts tab (always in DOM).
+  await expect(page.locator('#character-table td:has-text("Horatio")')).not.toBeVisible({ timeout: 5_000 });
+  await expect(page.locator('#character-table td:has-text("Hamlet")')).toBeVisible();
 });
 
 // ── Character Groups ──────────────────────────────────────────────────────

--- a/client-v3/e2e/tests/06-show-config-characters.spec.ts
+++ b/client-v3/e2e/tests/06-show-config-characters.spec.ts
@@ -82,6 +82,52 @@ test('deletes a character', async () => {
   });
 });
 
+// ── Character Merge ────────────────────────────────────────────────────────
+
+test('Merge button is visible for each character row', async () => {
+  const row = page.locator('tr', { has: page.locator('td:has-text("Hamlet")') });
+  await expect(row.locator('button:has-text("Merge")')).toBeVisible();
+});
+
+test('creates a character for merge testing', async () => {
+  await page.getByRole('button', { name: 'New Character', exact: true }).click();
+  await waitForModal(page, 'New Character');
+  await page.fill('.modal.show input[type="text"]', 'Horatio');
+  await confirmModal(page);
+  await waitForModalClosed(page);
+  await expect(page.locator('td:has-text("Horatio")').first()).toBeVisible();
+});
+
+test('merge modal opens with correct title', async () => {
+  const row = page.locator('tr', { has: page.locator('td:has-text("Horatio")') });
+  await row.locator('button:has-text("Merge")').click();
+  await waitForModal(page, /Merge Horatio/);
+  await cancelModal(page);
+  await waitForModalClosed(page);
+});
+
+test('merge OK button is disabled with no destination selected', async () => {
+  const row = page.locator('tr', { has: page.locator('td:has-text("Horatio")') });
+  await row.locator('button:has-text("Merge")').click();
+  await waitForModal(page, /Merge Horatio/);
+  const okBtn = page.locator('.modal.show .modal-footer button.btn-primary');
+  await expect(okBtn).toBeDisabled();
+  await cancelModal(page);
+  await waitForModalClosed(page);
+});
+
+test('merges a character into another', async () => {
+  const row = page.locator('tr', { has: page.locator('td:has-text("Horatio")') });
+  await row.locator('button:has-text("Merge")').click();
+  await waitForModal(page, /Merge Horatio/);
+  await page.locator('.modal.show .multiselect__input').fill('Hamlet');
+  await page.locator('.modal.show .multiselect__option', { hasText: 'Hamlet' }).click();
+  await confirmModal(page);
+  await waitForModalClosed(page);
+  await expect(page.locator('td:has-text("Horatio")')).not.toBeVisible({ timeout: 5_000 });
+  await expect(page.locator('td:has-text("Hamlet")')).toBeVisible();
+});
+
 // ── Character Groups ──────────────────────────────────────────────────────
 
 test('switches to Character Groups sub-tab', async () => {

--- a/client-v3/e2e/tests/06-show-config-characters.spec.ts
+++ b/client-v3/e2e/tests/06-show-config-characters.spec.ts
@@ -8,6 +8,7 @@ import {
   waitForAppReady,
   waitForModal,
   confirmModal,
+  cancelModal,
   waitForModalClosed,
   confirmDialog,
 } from '../helpers.js';

--- a/client-v3/src/stores/show.ts
+++ b/client-v3/src/stores/show.ts
@@ -301,6 +301,22 @@ export const useShowStore = defineStore('show', {
       }
     },
 
+    async mergeCharacter(sourceId: number, destinationId: number): Promise<void> {
+      const response = await fetch(makeURL('/api/v1/show/character/merge'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ source_id: sourceId, destination_id: destinationId }),
+      });
+      if (response.ok) {
+        // getCharacterGroupList calls getCharacterList internally
+        await this.getCharacterGroupList();
+        toast.success('Merged character!');
+      } else {
+        log.error('Unable to merge characters');
+        toast.error('Unable to merge characters');
+      }
+    },
+
     // Character Groups
     async getCharacterGroupList(): Promise<void> {
       const response = await fetch(makeURL('/api/v1/show/character/group'));

--- a/client-v3/src/views/show/config/ConfigCharacters.vue
+++ b/client-v3/src/views/show/config/ConfigCharacters.vue
@@ -237,8 +237,8 @@ const editV$ = useVuelidate(editRules, { editFormState });
 
 const mergeDestinationOptions = computed(() =>
   showStore.characterList.filter(
-    (c) => mergeSourceCharacter.value === null || c.id !== mergeSourceCharacter.value.id,
-  ),
+    (c) => mergeSourceCharacter.value === null || c.id !== mergeSourceCharacter.value.id
+  )
 );
 
 const castOptions = computed(() => [
@@ -340,10 +340,7 @@ async function onSubmitMerge(event: Event): Promise<void> {
   }
   mergingCharacter.value = true;
   try {
-    await showStore.mergeCharacter(
-      mergeSourceCharacter.value!.id,
-      mergeDestinationObject.value.id,
-    );
+    await showStore.mergeCharacter(mergeSourceCharacter.value!.id, mergeDestinationObject.value.id);
     mergeCharacterModal.value?.hide();
     resetMergeForm();
   } catch (error) {

--- a/client-v3/src/views/show/config/ConfigCharacters.vue
+++ b/client-v3/src/views/show/config/ConfigCharacters.vue
@@ -33,14 +33,21 @@
                 <BButtonGroup v-if="systemStore.isShowEditor">
                   <BButton
                     variant="warning"
-                    :disabled="submittingEditCharacter || deletingCharacter"
+                    :disabled="submittingEditCharacter || deletingCharacter || mergingCharacter"
                     @click="openEditForm(data.item)"
                   >
                     Edit
                   </BButton>
                   <BButton
+                    variant="info"
+                    :disabled="submittingEditCharacter || deletingCharacter || mergingCharacter"
+                    @click="openMergeForm(data.item)"
+                  >
+                    Merge
+                  </BButton>
+                  <BButton
                     variant="danger"
-                    :disabled="submittingEditCharacter || deletingCharacter"
+                    :disabled="submittingEditCharacter || deletingCharacter || mergingCharacter"
                     @click="deleteCharacter(data.item)"
                   >
                     Delete
@@ -100,6 +107,33 @@
     </BModal>
 
     <BModal
+      id="merge-character"
+      ref="mergeCharacterModal"
+      :title="`Merge ${mergeSourceCharacter?.name ?? 'Character'}`"
+      size="md"
+      :ok-disabled="!mergeDestinationObject || mergingCharacter"
+      @hide="resetMergeForm"
+      @ok="onSubmitMerge"
+    >
+      <p>
+        Select a destination character. All script lines and group memberships from
+        <strong>{{ mergeSourceCharacter?.name }}</strong> will be transferred to the selected
+        character, and <strong>{{ mergeSourceCharacter?.name }}</strong> will be deleted.
+      </p>
+      <BFormGroup label="Merge into" label-for="merge-destination-input" label-cols="4">
+        <VueMultiselect
+          id="merge-destination-input"
+          v-model="mergeDestinationObject"
+          :multiple="false"
+          :options="mergeDestinationOptions"
+          track-by="id"
+          label="name"
+          placeholder="Select destination character"
+        />
+      </BFormGroup>
+    </BModal>
+
+    <BModal
       id="edit-character"
       ref="editCharacterModal"
       title="Edit Character"
@@ -138,6 +172,8 @@ import { useVuelidate } from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
 import { BModal } from 'bootstrap-vue-next';
 import log from 'loglevel';
+import VueMultiselect from 'vue-multiselect';
+import 'vue-multiselect/dist/vue-multiselect.css';
 import { useSystemStore } from '@/stores/system';
 import { useShowStore } from '@/stores/show';
 import { useConfirm } from '@/composables/useConfirm';
@@ -157,6 +193,11 @@ const deletingCharacter = ref(false);
 
 const newCharacterModal = ref<InstanceType<typeof BModal>>();
 const editCharacterModal = ref<InstanceType<typeof BModal>>();
+const mergeCharacterModal = ref<InstanceType<typeof BModal>>();
+
+const mergingCharacter = ref(false);
+const mergeSourceCharacter = ref<Character | null>(null);
+const mergeDestinationObject = ref<Character | null>(null);
 
 const characterFields = [
   'name',
@@ -193,6 +234,12 @@ const editRules = { editFormState: { name: { required } } };
 
 const newV$ = useVuelidate(newRules, { newFormState });
 const editV$ = useVuelidate(editRules, { editFormState });
+
+const mergeDestinationOptions = computed(() =>
+  showStore.characterList.filter(
+    (c) => mergeSourceCharacter.value === null || c.id !== mergeSourceCharacter.value.id,
+  ),
+);
 
 const castOptions = computed(() => [
   { value: null, text: 'Please select an option', disabled: true },
@@ -271,6 +318,39 @@ async function onSubmitEdit(event: Event): Promise<void> {
     event.preventDefault();
   } finally {
     submittingEditCharacter.value = false;
+  }
+}
+
+function openMergeForm(character: Character): void {
+  mergeSourceCharacter.value = character;
+  mergeDestinationObject.value = null;
+  mergeCharacterModal.value?.show();
+}
+
+function resetMergeForm(): void {
+  mergeSourceCharacter.value = null;
+  mergeDestinationObject.value = null;
+  mergingCharacter.value = false;
+}
+
+async function onSubmitMerge(event: Event): Promise<void> {
+  if (!mergeDestinationObject.value || mergingCharacter.value) {
+    event.preventDefault();
+    return;
+  }
+  mergingCharacter.value = true;
+  try {
+    await showStore.mergeCharacter(
+      mergeSourceCharacter.value!.id,
+      mergeDestinationObject.value.id,
+    );
+    mergeCharacterModal.value?.hide();
+    resetMergeForm();
+  } catch (error) {
+    log.error('Error merging character:', error);
+    event.preventDefault();
+  } finally {
+    mergingCharacter.value = false;
   }
 }
 

--- a/client/src/store/modules/show.ts
+++ b/client/src/store/modules/show.ts
@@ -212,6 +212,23 @@ const module: Module<ShowState, RootState> = {
         VueToast.$toast.error('Unable to delete character');
       }
     },
+    async MERGE_CHARACTER(
+      context,
+      { source_id, destination_id }: { source_id: number; destination_id: number },
+    ) {
+      const response = await fetch(makeURL('/api/v1/show/character/merge'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ source_id, destination_id }),
+      });
+      if (response.ok) {
+        context.dispatch('GET_CHARACTER_GROUP_LIST');
+        VueToast.$toast.success('Merged character!');
+      } else {
+        log.error('Unable to merge characters');
+        VueToast.$toast.error('Unable to merge characters');
+      }
+    },
     async UPDATE_CHARACTER(context, character: Partial<Character>) {
       const response = await fetch(`${makeURL('/api/v1/show/character')}`, {
         method: 'PATCH',

--- a/client/src/store/modules/show.ts
+++ b/client/src/store/modules/show.ts
@@ -214,7 +214,7 @@ const module: Module<ShowState, RootState> = {
     },
     async MERGE_CHARACTER(
       context,
-      { source_id, destination_id }: { source_id: number; destination_id: number },
+      { source_id, destination_id }: { source_id: number; destination_id: number }
     ) {
       const response = await fetch(makeURL('/api/v1/show/character/merge'), {
         method: 'POST',

--- a/client/src/views/show/config/ConfigCharacters.vue
+++ b/client/src/views/show/config/ConfigCharacters.vue
@@ -29,14 +29,21 @@
                 <b-button-group v-if="IS_SHOW_EDITOR">
                   <b-button
                     variant="warning"
-                    :disabled="submittingEditCharacter || deletingCharacter"
+                    :disabled="submittingEditCharacter || deletingCharacter || mergingCharacter"
                     @click="openEditForm(data)"
                   >
                     Edit
                   </b-button>
                   <b-button
+                    variant="info"
+                    :disabled="submittingEditCharacter || deletingCharacter || mergingCharacter"
+                    @click="openMergeForm(data)"
+                  >
+                    Merge
+                  </b-button>
+                  <b-button
                     variant="danger"
-                    :disabled="submittingEditCharacter || deletingCharacter"
+                    :disabled="submittingEditCharacter || deletingCharacter || mergingCharacter"
                     @click="deleteCharacter(data)"
                   >
                     Delete
@@ -62,6 +69,32 @@
         </b-tabs>
       </b-col>
     </b-row>
+    <b-modal
+      id="merge-character"
+      ref="merge-character"
+      :title="`Merge ${mergeSourceCharacter ? mergeSourceCharacter.name : 'Character'}`"
+      size="md"
+      :ok-disabled="!mergeDestinationCharacter || mergingCharacter"
+      @hidden="resetMergeForm"
+      @ok="onSubmitMerge"
+    >
+      <p>
+        Select a destination character. All script lines and group memberships from
+        <strong>{{ mergeSourceCharacter ? mergeSourceCharacter.name : '' }}</strong>
+        will be transferred to the selected character, and it will be deleted.
+      </p>
+      <b-form-group label="Merge into" label-for="merge-destination-input" label-cols="4">
+        <multi-select
+          id="merge-destination-input"
+          v-model="mergeDestinationCharacter"
+          :multiple="false"
+          :options="mergeDestinationOptions"
+          track-by="id"
+          label="name"
+          placeholder="Select destination character"
+        />
+      </b-form-group>
+    </b-modal>
     <b-modal
       id="new-character"
       ref="new-character"
@@ -200,6 +233,9 @@ export default defineComponent({
       submittingNewCharacter: false,
       submittingEditCharacter: false,
       deletingCharacter: false,
+      mergingCharacter: false,
+      mergeSourceCharacter: null as any,
+      mergeDestinationCharacter: null as any,
     };
   },
   validations: {
@@ -224,6 +260,11 @@ export default defineComponent({
           text: `${castMember.first_name} ${castMember.last_name}`,
         })),
       ];
+    },
+    mergeDestinationOptions(): any[] {
+      return (this as any).CHARACTER_LIST.filter(
+        (c: any) => !(this as any).mergeSourceCharacter || c.id !== (this as any).mergeSourceCharacter.id,
+      );
     },
   },
   async mounted(): Promise<void> {
@@ -308,12 +349,43 @@ export default defineComponent({
         }
       }
     },
+    openMergeForm(character: any): void {
+      this.mergeSourceCharacter = character.item;
+      this.mergeDestinationCharacter = null;
+      (this as any).$bvModal.show('merge-character');
+    },
+    resetMergeForm(): void {
+      this.mergeSourceCharacter = null;
+      this.mergeDestinationCharacter = null;
+      this.mergingCharacter = false;
+    },
+    async onSubmitMerge(event: Event): Promise<void> {
+      if (!this.mergeDestinationCharacter || this.mergingCharacter) {
+        event.preventDefault();
+        return;
+      }
+      this.mergingCharacter = true;
+      try {
+        await (this as any).MERGE_CHARACTER({
+          source_id: this.mergeSourceCharacter.id,
+          destination_id: this.mergeDestinationCharacter.id,
+        });
+        (this as any).$bvModal.hide('merge-character');
+        this.resetMergeForm();
+      } catch (error) {
+        log.error('Error merging character:', error);
+        event.preventDefault();
+      } finally {
+        this.mergingCharacter = false;
+      }
+    },
     ...mapActions([
       'GET_CHARACTER_LIST',
       'GET_CAST_LIST',
       'ADD_CHARACTER',
       'UPDATE_CHARACTER',
       'DELETE_CHARACTER',
+      'MERGE_CHARACTER',
     ]),
   },
 });

--- a/client/src/views/show/config/ConfigCharacters.vue
+++ b/client/src/views/show/config/ConfigCharacters.vue
@@ -263,7 +263,8 @@ export default defineComponent({
     },
     mergeDestinationOptions(): any[] {
       return (this as any).CHARACTER_LIST.filter(
-        (c: any) => !(this as any).mergeSourceCharacter || c.id !== (this as any).mergeSourceCharacter.id,
+        (c: any) =>
+          !(this as any).mergeSourceCharacter || c.id !== (this as any).mergeSourceCharacter.id
       );
     },
   },

--- a/server/controllers/api/constants.py
+++ b/server/controllers/api/constants.py
@@ -111,3 +111,4 @@ ERROR_CREW_ASSIGNMENT_EXISTS = "Crew assignment already exists"
 
 ERROR_NAME_ALREADY_TAKEN = "Name already taken"
 ERROR_TAG_NAME_EXISTS = "Tag name already exists (case-insensitive)"
+ERROR_CANNOT_MERGE_SAME_CHARACTER = "Source and destination characters must be different"

--- a/server/controllers/api/constants.py
+++ b/server/controllers/api/constants.py
@@ -111,4 +111,6 @@ ERROR_CREW_ASSIGNMENT_EXISTS = "Crew assignment already exists"
 
 ERROR_NAME_ALREADY_TAKEN = "Name already taken"
 ERROR_TAG_NAME_EXISTS = "Tag name already exists (case-insensitive)"
-ERROR_CANNOT_MERGE_SAME_CHARACTER = "Source and destination characters must be different"
+ERROR_CANNOT_MERGE_SAME_CHARACTER = (
+    "Source and destination characters must be different"
+)

--- a/server/controllers/api/show/characters.py
+++ b/server/controllers/api/show/characters.py
@@ -1,9 +1,10 @@
 from collections import defaultdict
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from tornado import escape
 
 from controllers.api.constants import (
+    ERROR_CANNOT_MERGE_SAME_CHARACTER,
     ERROR_CAST_MEMBER_NOT_FOUND,
     ERROR_CHARACTER_GROUP_NOT_FOUND,
     ERROR_CHARACTER_NOT_FOUND,
@@ -12,7 +13,13 @@ from controllers.api.constants import (
     ERROR_NAME_MISSING,
     ERROR_SHOW_NOT_FOUND,
 )
-from models.script import Script, ScriptLine, ScriptLineType, ScriptRevision
+from models.script import (
+    Script,
+    ScriptLine,
+    ScriptLinePart,
+    ScriptLineType,
+    ScriptRevision,
+)
 from models.show import Cast, Character, CharacterGroup, Show
 from rbac.role import Role
 from schemas.schemas import CharacterGroupSchema, CharacterSchema
@@ -184,6 +191,92 @@ class CharacterController(BaseAPIController):
             else:
                 self.set_status(404)
                 await self.finish({"message": ERROR_SHOW_NOT_FOUND})
+
+
+@ApiRoute("show/character/merge", ApiVersion.V1)
+class CharacterMergeController(BaseAPIController):
+    @requires_show
+    @no_live_session
+    async def post(self):
+        """Merge a source character into a destination character.
+
+        Reassigns all ScriptLinePart rows referencing the source character to
+        the destination character across all revisions, then adds the destination
+        to every CharacterGroup that contained the source (if not already a
+        member), and finally deletes the source character (which cascades away
+        mic allocations and secondary-table group memberships automatically).
+
+        :raises HTTPError 400: If source_id or destination_id are missing, or
+            if the source and destination are the same character.
+        :raises HTTPError 404: If either character cannot be found, or if
+            either character does not belong to the current show.
+        """
+        current_show = self.get_current_show()
+        show_id = current_show["id"]
+
+        with self.make_session() as session:
+            show: Show = session.get(Show, show_id)
+            if not show:
+                self.set_status(404)
+                await self.finish({"message": ERROR_SHOW_NOT_FOUND})
+                return
+
+            self.requires_role(show, Role.WRITE)
+            data = escape.json_decode(self.request.body)
+
+            source_id = data.get("source_id", None)
+            destination_id = data.get("destination_id", None)
+
+            if not source_id or not destination_id:
+                self.set_status(400)
+                await self.finish({"message": ERROR_ID_MISSING})
+                return
+
+            if source_id == destination_id:
+                self.set_status(400)
+                await self.finish({"message": ERROR_CANNOT_MERGE_SAME_CHARACTER})
+                return
+
+            source: Character = session.get(Character, source_id)
+            if not source or source.show_id != show_id:
+                self.set_status(404)
+                await self.finish({"message": ERROR_CHARACTER_NOT_FOUND})
+                return
+
+            destination: Character = session.get(Character, destination_id)
+            if not destination or destination.show_id != show_id:
+                self.set_status(404)
+                await self.finish({"message": ERROR_CHARACTER_NOT_FOUND})
+                return
+
+            # Step 1: Bulk-update all ScriptLinePart rows across all revisions.
+            # synchronize_session=False is safe: we do not re-read these objects
+            # after the update within this transaction.
+            session.execute(
+                update(ScriptLinePart)
+                .where(ScriptLinePart.character_id == source_id)
+                .values(character_id=destination_id)
+                .execution_options(synchronize_session=False)
+            )
+
+            # Step 2: Add destination to every group the source belongs to,
+            # skipping groups where destination is already a member to avoid
+            # a composite-PK collision on the association table.
+            for group in source.character_groups:
+                if destination not in group.characters:
+                    group.characters.append(destination)
+
+            # Step 3: Delete source. SQLAlchemy cascades:
+            # - mic_allocations: via cascade="all, delete-orphan"
+            # - character_group_association rows: via secondary= M2M management
+            session.delete(source)
+            session.commit()
+
+            self.set_status(200)
+            await self.finish({"message": "Successfully merged character"})
+
+            await self.application.ws_send_to_all("NOOP", "GET_CHARACTER_LIST", {})
+            await self.application.ws_send_to_all("NOOP", "GET_CHARACTER_GROUP_LIST", {})
 
 
 @ApiRoute("show/character/stats", ApiVersion.V1)

--- a/server/controllers/api/show/characters.py
+++ b/server/controllers/api/show/characters.py
@@ -276,7 +276,9 @@ class CharacterMergeController(BaseAPIController):
             await self.finish({"message": "Successfully merged character"})
 
             await self.application.ws_send_to_all("NOOP", "GET_CHARACTER_LIST", {})
-            await self.application.ws_send_to_all("NOOP", "GET_CHARACTER_GROUP_LIST", {})
+            await self.application.ws_send_to_all(
+                "NOOP", "GET_CHARACTER_GROUP_LIST", {}
+            )
 
 
 @ApiRoute("show/character/stats", ApiVersion.V1)

--- a/server/test/controllers/api/show/test_characters.py
+++ b/server/test/controllers/api/show/test_characters.py
@@ -1,7 +1,15 @@
 import tornado.escape
+from sqlalchemy import select
 
-from models.script import Script, ScriptRevision
-from models.show import Show, ShowScriptType
+from models.mics import Microphone, MicrophoneAllocation
+from models.script import (
+    Script,
+    ScriptLine,
+    ScriptLinePart,
+    ScriptLineType,
+    ScriptRevision,
+)
+from models.show import Act, Character, CharacterGroup, Scene, Show, ShowScriptType
 from test.conftest import DigiScriptTestCase
 
 
@@ -59,3 +67,212 @@ class TestCharacterStatsController(DigiScriptTestCase):
         response = self.fetch("/api/v1/show/character/stats")
         # Should get an error because there's no script
         self.assertNotEqual(200, response.code)
+
+
+class TestCharacterMergeController(DigiScriptTestCase):
+    """Test suite for POST /api/v1/show/character/merge endpoint."""
+
+    def setUp(self):
+        super().setUp()
+        self.token = self._create_and_login_admin()
+
+        with self._app.get_db().sessionmaker() as session:
+            show = Show(name="Test Show", script_mode=ShowScriptType.FULL)
+            session.add(show)
+            session.flush()
+            self.show_id = show.id
+
+            source = Character(show_id=show.id, name="Source")
+            destination = Character(show_id=show.id, name="Destination")
+            session.add(source)
+            session.add(destination)
+            session.flush()
+            self.source_id = source.id
+            self.destination_id = destination.id
+            session.commit()
+
+        self._app.digi_settings.settings["current_show"].set_value(self.show_id)
+
+    def _merge(self, body: dict) -> object:
+        return self.fetch(
+            "/api/v1/show/character/merge",
+            method="POST",
+            body=tornado.escape.json_encode(body),
+            headers={"Authorization": f"Bearer {self.token}"},
+        )
+
+    def test_merge_missing_source_id(self):
+        """POST with no source_id returns 400."""
+        response = self._merge({"destination_id": self.destination_id})
+        self.assertEqual(400, response.code)
+
+    def test_merge_missing_destination_id(self):
+        """POST with no destination_id returns 400."""
+        response = self._merge({"source_id": self.source_id})
+        self.assertEqual(400, response.code)
+
+    def test_merge_same_character(self):
+        """POST with identical source and destination returns 400."""
+        response = self._merge(
+            {"source_id": self.source_id, "destination_id": self.source_id}
+        )
+        self.assertEqual(400, response.code)
+
+    def test_merge_source_not_found(self):
+        """POST with a nonexistent source_id returns 404."""
+        response = self._merge(
+            {"source_id": 99999, "destination_id": self.destination_id}
+        )
+        self.assertEqual(404, response.code)
+
+    def test_merge_destination_not_found(self):
+        """POST with a nonexistent destination_id returns 404."""
+        response = self._merge({"source_id": self.source_id, "destination_id": 99999})
+        self.assertEqual(404, response.code)
+
+    def test_merge_cross_show_source(self):
+        """POST with a source character from a different show returns 404."""
+        with self._app.get_db().sessionmaker() as session:
+            other_show = Show(name="Other Show", script_mode=ShowScriptType.FULL)
+            session.add(other_show)
+            session.flush()
+            foreign_char = Character(show_id=other_show.id, name="Foreign")
+            session.add(foreign_char)
+            session.flush()
+            foreign_id = foreign_char.id
+            session.commit()
+
+        response = self._merge(
+            {"source_id": foreign_id, "destination_id": self.destination_id}
+        )
+        self.assertEqual(404, response.code)
+
+    def test_merge_deletes_source(self):
+        """Successful merge removes the source character."""
+        response = self._merge(
+            {"source_id": self.source_id, "destination_id": self.destination_id}
+        )
+        self.assertEqual(200, response.code)
+
+        with self._app.get_db().sessionmaker() as session:
+            remaining = session.scalars(
+                select(Character).where(Character.show_id == self.show_id)
+            ).all()
+            names = [c.name for c in remaining]
+        self.assertNotIn("Source", names)
+        self.assertIn("Destination", names)
+
+    def test_merge_transfers_script_line_parts(self):
+        """Merge updates all ScriptLinePart rows for the source to the destination."""
+        with self._app.get_db().sessionmaker() as session:
+            act = Act(show_id=self.show_id, name="Act 1")
+            session.add(act)
+            session.flush()
+            scene = Scene(show_id=self.show_id, act_id=act.id, name="Scene 1")
+            session.add(scene)
+            session.flush()
+            line = ScriptLine(
+                act_id=act.id,
+                scene_id=scene.id,
+                page=1,
+                line_type=ScriptLineType.DIALOGUE,
+            )
+            session.add(line)
+            session.flush()
+            part = ScriptLinePart(
+                line_id=line.id,
+                part_index=0,
+                character_id=self.source_id,
+            )
+            session.add(part)
+            session.flush()
+            part_id = part.id
+            session.commit()
+
+        response = self._merge(
+            {"source_id": self.source_id, "destination_id": self.destination_id}
+        )
+        self.assertEqual(200, response.code)
+
+        with self._app.get_db().sessionmaker() as session:
+            updated_part = session.get(ScriptLinePart, part_id)
+            self.assertEqual(self.destination_id, updated_part.character_id)
+
+    def test_merge_updates_character_groups(self):
+        """Merge adds destination to groups that contained the source."""
+        with self._app.get_db().sessionmaker() as session:
+            source = session.get(Character, self.source_id)
+            group = CharacterGroup(show_id=self.show_id, name="Ensemble")
+            group.characters.append(source)
+            session.add(group)
+            session.flush()
+            group_id = group.id
+            session.commit()
+
+        response = self._merge(
+            {"source_id": self.source_id, "destination_id": self.destination_id}
+        )
+        self.assertEqual(200, response.code)
+
+        with self._app.get_db().sessionmaker() as session:
+            group = session.get(CharacterGroup, group_id)
+            member_ids = [c.id for c in group.characters]
+        self.assertIn(self.destination_id, member_ids)
+        self.assertNotIn(self.source_id, member_ids)
+
+    def test_merge_group_deduplication(self):
+        """Merge does not create a duplicate when destination is already in the group."""
+        with self._app.get_db().sessionmaker() as session:
+            source = session.get(Character, self.source_id)
+            destination = session.get(Character, self.destination_id)
+            group = CharacterGroup(show_id=self.show_id, name="Royalty")
+            group.characters.append(source)
+            group.characters.append(destination)
+            session.add(group)
+            session.flush()
+            group_id = group.id
+            session.commit()
+
+        response = self._merge(
+            {"source_id": self.source_id, "destination_id": self.destination_id}
+        )
+        self.assertEqual(200, response.code)
+
+        with self._app.get_db().sessionmaker() as session:
+            group = session.get(CharacterGroup, group_id)
+            member_ids = [c.id for c in group.characters]
+        self.assertEqual(1, len(member_ids))
+        self.assertIn(self.destination_id, member_ids)
+
+    def test_merge_deletes_mic_allocations(self):
+        """Merge deletes all mic allocations belonging to the source character."""
+        with self._app.get_db().sessionmaker() as session:
+            mic = Microphone(show_id=self.show_id, name="Radio Mic 1")
+            session.add(mic)
+            session.flush()
+            act = Act(show_id=self.show_id, name="Act 1")
+            session.add(act)
+            session.flush()
+            scene = Scene(show_id=self.show_id, act_id=act.id, name="Scene 1")
+            session.add(scene)
+            session.flush()
+            alloc = MicrophoneAllocation(
+                mic_id=mic.id,
+                scene_id=scene.id,
+                character_id=self.source_id,
+            )
+            session.add(alloc)
+            session.commit()
+
+        response = self._merge(
+            {"source_id": self.source_id, "destination_id": self.destination_id}
+        )
+        self.assertEqual(200, response.code)
+
+        with self._app.get_db().sessionmaker() as session:
+            remaining = session.scalars(
+                select(MicrophoneAllocation).where(
+                    MicrophoneAllocation.character_id == self.source_id
+                )
+            ).all()
+        self.assertEqual(0, len(remaining))


### PR DESCRIPTION
## Summary

- Adds a **Merge** button alongside Edit/Delete on the Characters tab of show config
- Clicking Merge opens a modal with a searchable dropdown to select the destination character
- On confirm, the backend atomically: reassigns all `ScriptLinePart` rows to the destination across all revisions, adds the destination to any `CharacterGroup` the source belonged to (with deduplication), and deletes the source character (cascading its mic allocations)
- Implemented in both `client/` (Vue 2) and `client-v3/` (Vue 3)

## Changes

**Backend**
- `POST /api/v1/show/character/merge` — new endpoint with validation (missing IDs, same character, cross-show access)
- `server/controllers/api/constants.py` — `ERROR_CANNOT_MERGE_SAME_CHARACTER`
- 11 new backend tests covering error cases and all merge side-effects (line parts, group membership, deduplication, mic allocation deletion)

**Vue 3 (`client-v3/`)**
- `stores/show.ts` — `mergeCharacter()` action
- `views/show/config/ConfigCharacters.vue` — Merge button + modal with VueMultiselect searchable dropdown

**Vue 2 (`client/`)**
- `store/modules/show.ts` — `MERGE_CHARACTER` Vuex action
- `views/show/config/ConfigCharacters.vue` — Same merge button + modal

**E2E**
- 5 new Playwright tests in `06-show-config-characters.spec.ts`: button visibility, modal title, OK disabled without selection, successful merge

## Test plan

- [ ] Backend: `pytest test/controllers/api/show/test_characters.py` — 13 tests pass
- [ ] Vue 3 typecheck: `cd client-v3 && npm run typecheck`
- [ ] Vue 2 typecheck: `cd client && npm run typecheck`
- [ ] E2E: `cd client-v3 && npm run test:e2e` (full suite)
- [ ] Manual: navigate to show config → Characters, verify Merge button appears, merge one character into another, confirm source disappears and destination remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)