### PR TITLE
Fix INEFFECTIVE_DYNAMIC_IMPORT build warnings in client-v3

### DIFF
--- a/client-v3/src/composables/useWebSocket.ts
+++ b/client-v3/src/composables/useWebSocket.ts
@@ -5,6 +5,8 @@ import { toast } from '@/js/toast';
 import { useWebSocketStore } from '@/stores/websocket';
 import { useSystemStore } from '@/stores/system';
 import { useUserStore } from '@/stores/user';
+import { useShowStore } from '@/stores/show';
+import router from '@/router';
 import { getWebSocketURL } from '@/js/platform';
 import type { WsMessage } from '@/types/api/websocket';
 
@@ -36,8 +38,6 @@ async function handleMessage(msg: WsMessage): Promise<void> {
   const wsStore = useWebSocketStore();
   const systemStore = useSystemStore();
   const userStore = useUserStore();
-  const { default: router } = await import('@/router');
-
   switch (msg.OP) {
     case 'SET_UUID': {
       const newUUID = msg.DATA as unknown as string;
@@ -181,7 +181,6 @@ function connect(): void {
       }
       log.info('WebSocket connected');
       if (wasErrored) {
-        const { useShowStore } = await import('@/stores/show');
         const showStore = useShowStore();
         if (showStore.currentSession != null) {
           await showStore.getShowSessionData();

--- a/client-v3/src/router/index.ts
+++ b/client-v3/src/router/index.ts
@@ -1,5 +1,10 @@
 import { createRouter, createWebHistory, createWebHashHistory } from 'vue-router';
 import { isElectron } from '@/js/platform';
+import { useSystemStore } from '@/stores/system';
+import { useUserStore } from '@/stores/user';
+import { useShowStore } from '@/stores/show';
+import { useWebSocketStore } from '@/stores/websocket';
+import { toast } from '@/js/toast';
 import HomeView from '@/views/HomeView.vue';
 import NotFoundView from '@/views/NotFoundView.vue';
 
@@ -234,8 +239,6 @@ async function checkPermissionGuards(
 }
 
 async function checkLiveGuard(toast: ToastFn): Promise<string | undefined> {
-  const { useShowStore } = await import('@/stores/show');
-  const { useWebSocketStore } = await import('@/stores/websocket');
   const showStore = useShowStore();
   const wsStore = useWebSocketStore();
   await showStore.getShowSessionData();
@@ -247,9 +250,6 @@ async function checkLiveGuard(toast: ToastFn): Promise<string | undefined> {
 }
 
 router.beforeEach(async (to, from) => {
-  const { useSystemStore } = await import('@/stores/system');
-  const { useUserStore } = await import('@/stores/user');
-  const { toast } = await import('@/js/toast');
   const systemStore = useSystemStore();
   const userStore = useUserStore();
 

--- a/client-v3/src/stores/user.ts
+++ b/client-v3/src/stores/user.ts
@@ -3,6 +3,9 @@ import log from 'loglevel';
 import { isEmpty } from 'lodash';
 import { makeURL } from '@/js/utils';
 import { toast } from '@/js/toast';
+import { useWebSocketStore } from '@/stores/websocket';
+import { useSystemStore } from '@/stores/system';
+import router from '@/router';
 import type { User, UserSettings, CueColourOverride } from '@/types/api/user';
 import type { StageDirectionStyle } from '@/types/api/script';
 
@@ -36,7 +39,6 @@ export const useUserStore = defineStore('user', {
       this.authToken = null;
     },
     async login(username: string, password: string): Promise<boolean> {
-      const { useWebSocketStore } = await import('@/stores/websocket');
       const wsStore = useWebSocketStore();
 
       const response = await fetch(makeURL('/api/v1/auth/login'), {
@@ -54,7 +56,6 @@ export const useUserStore = defineStore('user', {
         if (data.access_token) this._setToken(data.access_token);
 
         try {
-          const { useSystemStore } = await import('@/stores/system');
           await useSystemStore().getRbacRoles();
           await this.getCurrentUser();
           await this.getCurrentRbac();
@@ -94,19 +95,17 @@ export const useUserStore = defineStore('user', {
       this.stageDirectionStyleOverrides = [];
       this.cueColourOverrides = [];
 
-      const { useWebSocketStore } = await import('@/stores/websocket');
       useWebSocketStore().$patch({ authenticated: false, authSucceeded: false });
 
       if (token) {
         try {
-          const { useWebSocketStore: getWsStore } = await import('@/stores/websocket');
           const response = await fetch(makeURL('/api/v1/auth/logout'), {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
               Authorization: `Bearer ${token}`, // use captured value since store is already cleared
             },
-            body: JSON.stringify({ session_id: getWsStore().internalUUID }),
+            body: JSON.stringify({ session_id: useWebSocketStore().internalUUID }),
           });
           if (!response.ok) {
             log.error('Logout response was not OK, but local state was cleared');
@@ -118,7 +117,6 @@ export const useUserStore = defineStore('user', {
 
       toast.success('Successfully logged out!');
 
-      const { default: router } = await import('@/router');
       if (router.currentRoute.value.path !== '/') {
         router.push('/');
       }
@@ -135,7 +133,6 @@ export const useUserStore = defineStore('user', {
         if (response.ok) {
           const data = await response.json();
           this._setToken(data.access_token);
-          const { useWebSocketStore } = await import('@/stores/websocket');
           useWebSocketStore().refreshWsToken();
           log.debug('Token refreshed successfully');
           return true;
@@ -152,7 +149,6 @@ export const useUserStore = defineStore('user', {
       log.info('Received token refresh from server');
       if (newToken) {
         this._setToken(newToken);
-        const { useWebSocketStore } = await import('@/stores/websocket');
         useWebSocketStore().refreshWsToken();
         log.info('Auth token updated from server');
       }


### PR DESCRIPTION
## Summary

- Converts dynamic `import()` calls for Pinia stores and the router to static imports at the top of each affected file
- Affected files: `src/composables/useWebSocket.ts`, `src/router/index.ts`, `src/stores/user.ts`
- Eliminates all three Rollup `INEFFECTIVE_DYNAMIC_IMPORT` warnings that appeared at build time
- No bundle size change — the modules were already included in the main chunk via other static importers, so the dynamic imports were never able to code-split them

## Test plan

- [ ] Log in and log out — confirm redirect to `/` and user data loads correctly
- [ ] Let the token refresh interval fire (or trigger via WS) — confirm token refresh works
- [ ] Navigate to a show-config route while logged out — should redirect to login
- [ ] Navigate to `/live` with no active session — should redirect with error toast
- [ ] Navigate to `/live` with an active session — should succeed
- [ ] Drop the network/restart the backend to force a WS reconnect — confirm reconnect toast and session data refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)