### PR TITLE
Fix revision graph nodes not spanning full width in client-v3

### DIFF
--- a/client-v3/src/components/show/config/script/RevisionGraph.vue
+++ b/client-v3/src/components/show/config/script/RevisionGraph.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="revision-graph-container">
+  <div ref="containerRef" class="revision-graph-container">
     <div v-if="!hasRevisions" class="text-center py-5 text-muted">No revisions to display</div>
     <div v-else class="graph-wrapper">
       <svg ref="svgRef" :width="width" :height="height" class="revision-graph">
@@ -74,6 +74,7 @@ const props = defineProps<{
 
 defineEmits<{ 'node-click': [revision: ScriptRevision] }>();
 
+const containerRef = ref<HTMLElement | null>(null);
 const svgRef = ref<SVGSVGElement | null>(null);
 const zoomGroupRef = ref<SVGGElement | null>(null);
 const width = ref(800);
@@ -83,6 +84,7 @@ const nodeRadius = 8;
 
 // D3 state — NOT in Vue reactive state (would cause infinite loops)
 let zoomBehavior: ReturnType<typeof d3zoom> | null = null;
+let resizeObserver: ResizeObserver | null = null;
 
 const hasRevisions = computed(() => props.revisions.length > 0);
 
@@ -136,7 +138,7 @@ function linkPath(link: any): string {
 }
 
 function updateWidth(): void {
-  const container = svgRef.value?.parentElement as HTMLElement | null;
+  const container = containerRef.value;
   if (container) width.value = container.clientWidth || 800;
 }
 
@@ -201,15 +203,24 @@ function resetZoom(): void {
 
 onMounted(() => {
   updateWidth();
-  window.addEventListener('resize', updateWidth);
   nextTick(() => {
     initZoom();
     fitToContent();
   });
+  if (containerRef.value) {
+    resizeObserver = new ResizeObserver(() => {
+      updateWidth();
+      nextTick(() => {
+        if (zoomBehavior) fitToContent();
+      });
+    });
+    resizeObserver.observe(containerRef.value);
+  }
 });
 
 onBeforeUnmount(() => {
-  window.removeEventListener('resize', updateWidth);
+  resizeObserver?.disconnect();
+  resizeObserver = null;
   if (zoomBehavior && svgRef.value) {
     select(svgRef.value as Element).on('.zoom', null);
   }
@@ -218,7 +229,10 @@ onBeforeUnmount(() => {
 watch(
   () => props.revisions,
   () => {
-    nextTick(() => fitToContent());
+    nextTick(() => {
+      initZoom();
+      fitToContent();
+    });
   },
   { deep: true }
 );


### PR DESCRIPTION
## Summary

- Revision graph in the new UI rendered nodes using only 800px of horizontal space regardless of the actual container width (~1500px), causing Rev 2 to appear in the middle instead of at the right edge
- Zooming in didn't use the available space either, for the same reason

**Root cause:** `RevisionGraph` mounts behind a `v-if="!loading"` gate in `ConfigScriptRevisions.vue` that waits for an async `getScriptRevisions()` fetch. When the component first mounts, `svgRef.value` is null (the `v-else` SVG branch hasn't rendered yet), so `updateWidth()` is a no-op and `width.value` stays at 800. The `revisions` watch that fires later only called `fitToContent()`, never re-measuring the container width.

**Secondary cause:** When `graphCollapsed = false` (first visit, no localStorage), the BCollapse hides the container — `wrapper.clientWidth = 0 → 0 || 800 = 800`. After opening the collapse, `window.resize` never fires, so the width was never corrected.

**Fix:** Replace `window.addEventListener('resize')` with a `ResizeObserver` on the component's root div (`containerRef`). The observer fires on: (a) initial attach with correct container width, (b) BCollapse open/close, (c) actual window resize. Also call `initZoom()` in the `revisions` watch so zoom is initialised when data arrives after mount.

## Test plan

- [x] Fresh page load: Rev 1 at far left, Rev 2 at far right (matching old UI)
- [x] Collapse/reopen "Revision Branch Graph" card: graph re-fits to full width
- [x] First visit (cleared localStorage, starts collapsed): expanding the card shows full-width graph
- [x] TypeScript typecheck passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)