### PR TITLE
Fix baseURL helper function

### DIFF
--- a/client-v3/src/components/user/settings/ApiToken.vue
+++ b/client-v3/src/components/user/settings/ApiToken.vue
@@ -127,6 +127,7 @@ const showRegenerateConfirm = ref(false);
 const showRevokeConfirm = ref(false);
 
 const apiBaseUrl = computed(() => baseURL());
+apiBaseUrl = apiBaseUrl.replace(/:\s*$/, "");
 
 onMounted(async () => {
   await checkTokenStatus();

--- a/client-v3/src/components/user/settings/ApiToken.vue
+++ b/client-v3/src/components/user/settings/ApiToken.vue
@@ -127,7 +127,6 @@ const showRegenerateConfirm = ref(false);
 const showRevokeConfirm = ref(false);
 
 const apiBaseUrl = computed(() => baseURL());
-apiBaseUrl = apiBaseUrl.replace(/:\s*$/, "");
 
 onMounted(async () => {
   await checkTokenStatus();

--- a/client-v3/src/js/platform/browser.ts
+++ b/client-v3/src/js/platform/browser.ts
@@ -10,7 +10,7 @@
  * @returns {string} Base URL (e.g., "http://localhost:8080")
  */
 export function baseURL(): string {
-  return `${window.location.protocol}//${window.location.hostname}:${window.location.port}`;
+  return `${window.location.protocol}//${window.location.hostname}${window.location.port ? ':' + window.location.port : '' }`;
 }
 
 export function makeURL(path: string): string {

--- a/client-v3/src/js/platform/browser.ts
+++ b/client-v3/src/js/platform/browser.ts
@@ -10,7 +10,7 @@
  * @returns {string} Base URL (e.g., "http://localhost:8080")
  */
 export function baseURL(): string {
-  return `${window.location.protocol}//${window.location.hostname}${window.location.port ? ':' + window.location.port : '' }`;
+  return `${window.location.protocol}//${window.location.hostname}${window.location.port ? ':' + window.location.port : ''}`;
 }
 
 export function makeURL(path: string): string {

--- a/client/src/js/platform/browser.test.ts
+++ b/client/src/js/platform/browser.test.ts
@@ -39,7 +39,7 @@ describe('browser.js', () => {
       window.location.port = '';
 
       const result = baseURL();
-      expect(result).toBe('http://localhost:');
+      expect(result).toBe('http://localhost');
     });
   });
 

--- a/client/src/js/platform/browser.ts
+++ b/client/src/js/platform/browser.ts
@@ -10,7 +10,7 @@
  * @returns {string} Base URL (e.g., "http://localhost:8080")
  */
 export function baseURL(): string {
-  return `${window.location.protocol}//${window.location.hostname}:${window.location.port}`;
+  return `${window.location.protocol}//${window.location.hostname}${window.location.port ? ':' + window.location.port : '' }`;
 }
 
 export function makeURL(path: string): string {

--- a/client/src/js/platform/browser.ts
+++ b/client/src/js/platform/browser.ts
@@ -10,7 +10,7 @@
  * @returns {string} Base URL (e.g., "http://localhost:8080")
  */
 export function baseURL(): string {
-  return `${window.location.protocol}//${window.location.hostname}${window.location.port ? ':' + window.location.port : '' }`;
+  return `${window.location.protocol}//${window.location.hostname}${window.location.port ? ':' + window.location.port : ''}`;
 }
 
 export function makeURL(path: string): string {


### PR DESCRIPTION
baseURL helper function was concantenating the application URL with the port, separated by a comma. If the application was being served on a default web port (80 or 443) the port value was empty and a comman was shown at the end of the FQDN before the URL path, invalidating the full URL.