### PR TITLE
Fix script page changes not propagating to other connected clients

### DIFF
--- a/client-v3/src/stores/script.ts
+++ b/client-v3/src/stores/script.ts
@@ -50,10 +50,10 @@ export const useScriptStore = defineStore('script', {
 
     async scriptPageChanged(data: { page: number }): Promise<void> {
       const pageStr = String(data.page);
-      if (Object.prototype.hasOwnProperty.call(this.script, pageStr)) {
+      if (Object.hasOwn(this.script, pageStr)) {
         await this.loadScriptPage(data.page);
         const scriptConfigStore = useScriptConfigStore();
-        if (Object.prototype.hasOwnProperty.call(scriptConfigStore.tmpScript, pageStr)) {
+        if (Object.hasOwn(scriptConfigStore.tmpScript, pageStr)) {
           scriptConfigStore.addPage(data.page, this.getScriptPage(data.page));
         }
       }

--- a/client-v3/src/stores/script.ts
+++ b/client-v3/src/stores/script.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import log from 'loglevel';
 import { makeURL } from '@/js/utils';
 import { toast } from '@/js/toast';
+import { useScriptConfigStore } from '@/stores/scriptConfig';
 import type {
   ScriptLine,
   StageDirectionStyle,
@@ -44,6 +45,17 @@ export const useScriptStore = defineStore('script', {
         this.script[String(data.page)] = data.lines;
       } else {
         log.error('Unable to load script page');
+      }
+    },
+
+    async scriptPageChanged(data: { page: number }): Promise<void> {
+      const pageStr = String(data.page);
+      if (Object.prototype.hasOwnProperty.call(this.script, pageStr)) {
+        await this.loadScriptPage(data.page);
+        const scriptConfigStore = useScriptConfigStore();
+        if (Object.prototype.hasOwnProperty.call(scriptConfigStore.tmpScript, pageStr)) {
+          scriptConfigStore.addPage(data.page, this.getScriptPage(data.page));
+        }
       }
     },
 

--- a/client/src/store/modules/script.ts
+++ b/client/src/store/modules/script.ts
@@ -145,6 +145,13 @@ const module: Module<ScriptState, RootState> = {
       await context.dispatch('LOAD_CUES');
       await context.dispatch('GET_CUTS');
     },
+    async SCRIPT_PAGE_CHANGED(context, msg: { DATA: { page: number } }) {
+      const page = String(msg.DATA.page);
+      if (Object.prototype.hasOwnProperty.call(context.state.script, page)) {
+        await context.dispatch('LOAD_SCRIPT_PAGE', page);
+        await context.dispatch('ADD_BLANK_PAGE', page);
+      }
+    },
     async LOAD_SCRIPT_PAGE(context, page: string | number) {
       const searchParams = new URLSearchParams({ page: String(page) });
       const response = await fetch(`${makeURL('/api/v1/show/script')}?${searchParams}`, {

--- a/client/src/store/modules/script.ts
+++ b/client/src/store/modules/script.ts
@@ -147,7 +147,7 @@ const module: Module<ScriptState, RootState> = {
     },
     async SCRIPT_PAGE_CHANGED(context, msg: { DATA: { page: number } }) {
       const page = String(msg.DATA.page);
-      if (Object.prototype.hasOwnProperty.call(context.state.script, page)) {
+      if (Object.hasOwn(context.state.script, page)) {
         await context.dispatch('LOAD_SCRIPT_PAGE', page);
         await context.dispatch('ADD_BLANK_PAGE', page);
       }

--- a/server/controllers/api/show/script/script.py
+++ b/server/controllers/api/show/script/script.py
@@ -269,6 +269,9 @@ class ScriptController(BaseAPIController):
                         CompiledScript.compile_script, self.application, revision.id
                     )
                 )
+                await self.application.ws_send_to_all(
+                    "NOOP", "SCRIPT_PAGE_CHANGED", {"page": page}
+                )
             else:
                 self.set_status(404)
                 await self.finish({"message": ERROR_SHOW_NOT_FOUND})
@@ -663,10 +666,14 @@ class ScriptController(BaseAPIController):
                             (revision.id, line["id"]),
                         )
                 # Spawn a callback to create a compiled version of the script
+                session.commit()
                 IOLoop.current().add_callback(
                     partial(
                         CompiledScript.compile_script, self.application, revision.id
                     )
+                )
+                await self.application.ws_send_to_all(
+                    "NOOP", "SCRIPT_PAGE_CHANGED", {"page": page}
                 )
             else:
                 self.set_status(404)


### PR DESCRIPTION
## Summary

- After saving script changes, the backend now broadcasts a `SCRIPT_PAGE_CHANGED` WebSocket message to all connected clients
- Vue 2 client handles this with a new `SCRIPT_PAGE_CHANGED` Vuex action that reloads both the script store and `tmpScript` for the changed page
- Vue 3 client handles this with a new `scriptPageChanged` Pinia action (auto-routed by the WS convention-based dispatcher) that does the same

## Root Cause

The `post()` and `patch()` handlers in `server/controllers/api/show/script/script.py` committed changes to the DB but sent no WebSocket notification to other clients. The only post-save broadcast was `GET_COMPILED_SCRIPTS` (fired asynchronously after script compilation), which neither client had a handler for that refreshes editable page state.

## Test plan

- [ ] Start the backend and Vue 3 dev server
- [ ] Open two browser windows on Show Config → Script Editor
- [ ] Window A enters edit mode, makes a change to a line, and saves
- [ ] Window B should display the updated content without a manual page refresh
- [ ] Repeat on the Vue 2 client at `/ui/`
- [ ] Backend tests pass: `cd server && pytest`
- [ ] Vue 3 unit tests pass: `cd client-v3 && npm run test:run`
- [ ] Vue 2 unit tests pass: `cd client && npm run test:run`

Fixes #1149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)