### PR TITLE
Auto-grant full RBAC access to cue type creator

### DIFF
--- a/server/controllers/api/show/cues.py
+++ b/server/controllers/api/show/cues.py
@@ -21,6 +21,7 @@ from controllers.api.constants import (
 from models.cue import Cue, CueAssociation, CueType
 from models.script import Script, ScriptLine, ScriptLineType, ScriptRevision
 from models.show import Show
+from models.user import User
 from rbac.role import Role
 from schemas.schemas import CueSchema, CueTypeSchema
 from utils.web.base_controller import BaseAPIController
@@ -80,6 +81,15 @@ class CueTypesController(BaseAPIController):
                 )
                 session.add(new_cuetype)
                 session.commit()
+
+                user = session.get(User, self.current_user["id"])
+                self.application.rbac.give_role(
+                    user, new_cuetype, Role.READ | Role.WRITE | Role.EXECUTE
+                )
+                for socket in self.application.get_all_ws(user.id):
+                    await socket.write_message(
+                        {"OP": "NOOP", "DATA": {}, "ACTION": "GET_CURRENT_RBAC"}
+                    )
 
                 self.set_status(200)
                 await self.finish(

--- a/server/test/controllers/api/show/test_cues.py
+++ b/server/test/controllers/api/show/test_cues.py
@@ -11,6 +11,7 @@ from models.script import (
 )
 from models.show import Act, Scene, Show, ShowScriptType
 from models.user import User
+from rbac.role import Role
 from test.conftest import DigiScriptTestCase
 
 
@@ -936,3 +937,76 @@ class TestCueTypeImportController(DigiScriptTestCase):
             self.assertIn("name", group)
             self.assertIn("cue_types", group)
             self.assertIsInstance(group["cue_types"], list)
+
+
+class TestCueTypesController(DigiScriptTestCase):
+    """Test suite for POST /api/v1/show/cues/types endpoint."""
+
+    def setUp(self):
+        super().setUp()
+        with self._app.get_db().sessionmaker() as session:
+            show = Show(name="Test Show", script_mode=ShowScriptType.FULL)
+            session.add(show)
+            session.flush()
+            self.show_id = show.id
+            session.commit()
+
+        self._app.digi_settings.settings["current_show"].set_value(self.show_id)
+        self.admin_token = self._create_and_login_admin()
+        self.user_token = self._create_and_login_user(self.admin_token)
+
+        with self._app.get_db().sessionmaker() as session:
+            admin = session.scalars(
+                select(User).where(User.username == "admin")
+            ).first()
+            self.admin_id = admin.id
+            user = session.scalars(
+                select(User).where(User.username == "user")
+            ).first()
+            self.user_id = user.id
+            show = session.get(Show, self.show_id)
+            self._app.rbac.give_role(user, show, Role.WRITE)
+
+    def test_post_cue_type_grants_all_roles_to_creator(self):
+        """Creating a cue type grants READ|WRITE|EXECUTE to the creating user."""
+        response = self.fetch(
+            "/api/v1/show/cues/types",
+            method="POST",
+            body=tornado.escape.json_encode(
+                {"prefix": "LX", "description": "Lighting", "colour": "#ff0000"}
+            ),
+            headers={"Authorization": f"Bearer {self.user_token}"},
+        )
+        self.assertEqual(200, response.code)
+        cue_type_id = tornado.escape.json_decode(response.body)["id"]
+
+        with self._app.get_db().sessionmaker() as session:
+            user = session.get(User, self.user_id)
+            cue_type = session.get(CueType, cue_type_id)
+            self.assertTrue(
+                self._app.rbac.has_role(
+                    user, cue_type, Role.READ | Role.WRITE | Role.EXECUTE
+                )
+            )
+
+    def test_post_cue_type_admin_also_gets_grant(self):
+        """Creating a cue type as an admin still writes the RBAC grant."""
+        response = self.fetch(
+            "/api/v1/show/cues/types",
+            method="POST",
+            body=tornado.escape.json_encode(
+                {"prefix": "SQ", "description": "Sound", "colour": "#00ff00"}
+            ),
+            headers={"Authorization": f"Bearer {self.admin_token}"},
+        )
+        self.assertEqual(200, response.code)
+        cue_type_id = tornado.escape.json_decode(response.body)["id"]
+
+        with self._app.get_db().sessionmaker() as session:
+            admin = session.get(User, self.admin_id)
+            cue_type = session.get(CueType, cue_type_id)
+            self.assertTrue(
+                self._app.rbac.has_role(
+                    admin, cue_type, Role.READ | Role.WRITE | Role.EXECUTE
+                )
+            )

--- a/server/test/controllers/api/show/test_cues.py
+++ b/server/test/controllers/api/show/test_cues.py
@@ -960,9 +960,7 @@ class TestCueTypesController(DigiScriptTestCase):
                 select(User).where(User.username == "admin")
             ).first()
             self.admin_id = admin.id
-            user = session.scalars(
-                select(User).where(User.username == "user")
-            ).first()
+            user = session.scalars(select(User).where(User.username == "user")).first()
             self.user_id = user.id
             show = session.get(Show, self.show_id)
             self._app.rbac.give_role(user, show, Role.WRITE)


### PR DESCRIPTION
## Summary

- When a user creates a new cue type via `POST /api/v1/show/cues/types`, they are immediately granted `READ | WRITE | EXECUTE` on that `CueType` instance in the `rbac_user_cuetypes` table
- A `GET_CURRENT_RBAC` WebSocket message is sent to the creator's active connections so both frontends refresh their RBAC state without a page reload
- Grant happens before the HTTP response is sent and before the `GET_CUE_TYPES` broadcast, ensuring permissions are in the DB before any downstream refetch

## Test plan

- [ ] `pytest server/test/controllers/api/show/test_cues.py::TestCueTypesController` — two new tests: non-admin creator gets all roles, admin creator also gets grant written
- [ ] `pytest server/` — full suite, no regressions (633 tests passing locally)
- [ ] Manually: create a cue type as a non-admin user; verify they appear with READ+WRITE+EXECUTE in the RBAC admin panel without any manual grant

## Notes

The `CueTypesController.delete()` handler does not call `rbac.delete_resource()`, so RBAC rows in `rbac_user_cuetypes` will become orphaned when a cue type is deleted. This is a pre-existing issue but is now more prominent since every creation produces a row. A follow-up ticket is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)