### PR TITLE
Highlight script row on Edit/dropdown button hover

### DIFF
--- a/client-v3/src/components/show/config/script/ScriptLineViewer.vue
+++ b/client-v3/src/components/show/config/script/ScriptLineViewer.vue
@@ -1,5 +1,6 @@
 <template>
   <BRow
+    class="script-line-row"
     :class="{
       'stage-direction': line.line_type === LINE_TYPES.STAGE_DIRECTION,
       'heading-padding': line.line_type === LINE_TYPES.DIALOGUE && needsHeadingsAll,
@@ -121,7 +122,7 @@
           End
         </BButton>
       </BButtonGroup>
-      <BButtonGroup v-else-if="canEdit && !isCutMode">
+      <BButtonGroup v-else-if="canEdit && !isCutMode" class="script-edit-controls">
         <BButton variant="link" style="padding: 0" @click.prevent.stop="$emit('editLine')"
           >Edit</BButton
         >
@@ -304,5 +305,10 @@ function cutLinePart(partIndex: number): void {
 }
 .cut-line-part {
   text-decoration: line-through;
+}
+.script-line-row:has(.script-edit-controls:hover) {
+  background-color: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
 }
 </style>

--- a/client/src/vue_components/show/config/script/ScriptLineViewer.vue
+++ b/client/src/vue_components/show/config/script/ScriptLineViewer.vue
@@ -1,5 +1,6 @@
 <template>
   <b-row
+    class="script-line-row"
     :class="{
       'stage-direction': line.line_type === LINE_TYPES.STAGE_DIRECTION,
       'heading-padding': line.line_type === LINE_TYPES.DIALOGUE && needsHeadingsAll,
@@ -142,6 +143,7 @@
       </b-button-group>
       <b-dropdown
         v-else-if="canEdit && !IS_CUT_MODE"
+        class="script-edit-controls"
         split
         text="Edit"
         right
@@ -385,5 +387,10 @@ export default defineComponent({
 }
 .cut-line-part {
   text-decoration: line-through;
+}
+.script-line-row:has(.script-edit-controls:hover) {
+  background-color: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
 }
 </style>


### PR DESCRIPTION
## Summary

- Replicates the cue editor's existing row hover highlight behaviour in the script editor
- When hovering the **Edit** button or the **dropdown caret** on any script line, the full row highlights with a subtle semi-transparent background
- Implemented in both `client/` (Vue 2) and `client-v3/` (Vue 3) for feature parity

## Implementation

Uses the same pure-CSS `:has()` pattern already in place in `ScriptLineCueEditor.vue` — no JavaScript or reactive state needed:

```css
.script-line-row:has(.script-edit-controls:hover) {
  background-color: rgba(255, 255, 255, 0.06);
  border-radius: 4px;
  transition: background-color 0.15s ease;
}
```

Two classes added per file: `script-line-row` on the root row, `script-edit-controls` on the Edit/dropdown button group.

## Test plan

- [ ] Navigate to the script editor and hover over the Edit button on any line — row highlights
- [ ] Hover over the dropdown caret — row highlights
- [ ] Move mouse away — highlight disappears
- [ ] Confirm behaviour matches the cue editor's add-cue button highlight
- [ ] Check both `/ui/` (Vue 2) and `/ui-new/` (Vue 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)