### PR TITLE
Fix cut mode in V3 script editor

### DIFF
--- a/client-v3/e2e/tests/10-show-config-script.spec.ts
+++ b/client-v3/e2e/tests/10-show-config-script.spec.ts
@@ -120,6 +120,73 @@ test('saves a dialogue line to the script', async () => {
   ).toBeVisible({ timeout: 10_000 });
 });
 
+// ── Cut mode ──────────────────────────────────────────────────────────────
+
+test('enters cut mode', async () => {
+  await page.goto(`${UI_BASE}/show-config/script`);
+  await waitForAppReady(page);
+  await page.click('button:has-text("Cuts")');
+  await expect(page.locator('button:has-text("Stop Editing")')).toBeVisible({ timeout: 10_000 });
+});
+
+test('dialogue line becomes clickable in cut mode', async () => {
+  await expect(
+    page.locator('a.viewable-line-cut').filter({ hasText: 'To be or not to be' })
+  ).toBeVisible({ timeout: 5_000 });
+});
+
+test('clicking a line toggles cut styling', async () => {
+  await page.locator('a.viewable-line-cut').filter({ hasText: 'To be or not to be' }).click();
+  await expect(
+    page.locator('.cut-line-part').filter({ hasText: 'To be or not to be' })
+  ).toBeVisible({ timeout: 3_000 });
+});
+
+test('saves cuts', async () => {
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(page.locator('.v-toast__text').filter({ hasText: /saved/i })).toBeVisible({
+    timeout: 5_000,
+  });
+});
+
+test('stops cut mode without blank-page flash', async () => {
+  // In cut mode the line is an anchor (.viewable-line-cut); verify it exists before stopping
+  await expect(
+    page.locator('.viewable-line-cut').filter({ hasText: 'To be or not to be' })
+  ).toBeVisible();
+
+  await page.click('button:has-text("Stop Editing")');
+
+  // Edit button reappears
+  await expect(page.getByRole('button', { name: 'Edit', exact: true })).toBeVisible({
+    timeout: 10_000,
+  });
+  // The saved line is still visible (no reload / blank flash)
+  await expect(
+    page.locator('.viewable-line').filter({ hasText: 'To be or not to be' })
+  ).toBeVisible();
+  // No edit controls are shown after stopping
+  await expect(page.locator('.script-edit-controls')).not.toBeVisible();
+});
+
+test('cut styling persists after re-entering cut mode', async () => {
+  await page.click('button:has-text("Cuts")');
+  await expect(page.locator('button:has-text("Stop Editing")')).toBeVisible({ timeout: 10_000 });
+  await expect(
+    page.locator('.cut-line-part').filter({ hasText: 'To be or not to be' })
+  ).toBeVisible({ timeout: 5_000 });
+  // Clean up: un-cut the line so later tests start from a known state
+  await page.locator('a.viewable-line-cut').filter({ hasText: 'To be or not to be' }).click();
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(page.locator('.v-toast__text').filter({ hasText: /saved/i })).toBeVisible({
+    timeout: 5_000,
+  });
+  await page.click('button:has-text("Stop Editing")');
+  await expect(page.getByRole('button', { name: 'Edit', exact: true })).toBeVisible({
+    timeout: 10_000,
+  });
+});
+
 // ── Stage Direction Styles ────────────────────────────────────────────────
 
 test('switches to Stage Direction Styles sub-tab', async () => {

--- a/client-v3/src/components/show/config/script/ScriptEditor.vue
+++ b/client-v3/src/components/show/config/script/ScriptEditor.vue
@@ -257,7 +257,7 @@ const isEditor = computed(
     wsStore.internalUUID !== null &&
     wsStore.internalUUID === scriptConfigStore.editStatus.currentEditor
 );
-const canEdit = computed(() => isEditor.value && !scriptConfigStore.cutMode);
+const canEdit = computed(() => isEditor.value);
 
 const saveProgressVariant = computed(() => {
   if (savingInProgress.value) return 'primary';
@@ -336,13 +336,17 @@ async function stopEditing(): Promise<void> {
     );
     if (!ok) return;
   }
+  const wasCutMode = scriptConfigStore.cutMode;
   editingLines.value.clear();
   exitBulkEditMode();
-  scriptConfigStore.emptyScript();
   linePartCuts.value = [...scriptStore.cuts];
-  sendObj({ OP: 'STOP_SCRIPT_EDIT', DATA: {} });
   scriptConfigStore.setCutMode(false);
-  await loadPage(currentPage.value);
+  scriptConfigStore.setEditStatus({ canRequestEdit: scriptConfigStore.editStatus.canRequestEdit, currentEditor: null });
+  sendObj({ OP: 'STOP_SCRIPT_EDIT', DATA: {} });
+  if (!wasCutMode) {
+    scriptConfigStore.emptyScript();
+    await loadPage(currentPage.value);
+  }
 }
 
 async function loadPage(page: number): Promise<void> {

--- a/client-v3/src/components/show/config/script/ScriptEditor.vue
+++ b/client-v3/src/components/show/config/script/ScriptEditor.vue
@@ -341,7 +341,10 @@ async function stopEditing(): Promise<void> {
   exitBulkEditMode();
   linePartCuts.value = [...scriptStore.cuts];
   scriptConfigStore.setCutMode(false);
-  scriptConfigStore.setEditStatus({ canRequestEdit: scriptConfigStore.editStatus.canRequestEdit, currentEditor: null });
+  scriptConfigStore.setEditStatus({
+    canRequestEdit: scriptConfigStore.editStatus.canRequestEdit,
+    currentEditor: null,
+  });
   sendObj({ OP: 'STOP_SCRIPT_EDIT', DATA: {} });
   if (!wasCutMode) {
     scriptConfigStore.emptyScript();


### PR DESCRIPTION
## Summary

- **Bug 1 (cut links never appeared):** `canEdit` was computed as `isEditor && !cutMode`, making the condition `canEdit && isCutMode` in `ScriptLineViewer` permanently false. Fixed by computing `canEdit = isEditor` only — matching V2 behaviour. All edit-only UI surfaces already have their own independent `!isCutMode` guards.

- **Bug 2 (blank-page flash + edit-button flicker on exit):** `stopEditing()` always called `emptyScript()` + `loadPage()` even in cut mode where `tmpScript` was never modified. This caused a blank page between the clear and reload. Additionally, `cutMode` was set to false before `currentEditor` was cleared, causing edit buttons to briefly appear. Fixed by:
  - Skipping `emptyScript()`/`loadPage()` when exiting cut mode (V2 uses a synchronous in-memory reset, not a re-fetch)
  - Clearing `currentEditor` synchronously before sending `STOP_SCRIPT_EDIT`, so `isEditor` goes false in the same tick as `cutMode`

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Full Playwright E2E suite passes (170/170 tests)
- [x] 6 new E2E tests added covering the full cut mode workflow: enter cut mode, lines become clickable, toggle cut styling, save cuts, exit without blank flash, cut styling persists on re-entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)