### PR TITLE
Add hover highlighting to live view cue add buttons

### DIFF
--- a/client-v3/src/components/show/live/ScriptLineViewer.vue
+++ b/client-v3/src/components/show/live/ScriptLineViewer.vue
@@ -64,6 +64,7 @@
         </template>
       </BRow>
       <BRow
+        class="line-row"
         :class="{
           'stage-direction': line.line_type === LINE_TYPES.STAGE_DIRECTION,
           'heading-padding': line.line_type === LINE_TYPES.DIALOGUE && needsHeadingsAll,
@@ -144,7 +145,7 @@
             <BButton
               v-if="cueAddMode"
               variant="success"
-              class="cue-button ms-1"
+              class="cue-button add-cue-btn ms-1"
               :disabled="isLineCut"
               @click.stop="addNewCue"
             >
@@ -170,7 +171,7 @@
             <BButton
               v-if="cueAddMode"
               variant="success"
-              class="cue-button ms-1"
+              class="cue-button add-cue-btn ms-1"
               :disabled="isLineCut"
               @click.stop="addNewCue"
             >
@@ -437,6 +438,12 @@ onUnmounted(() => {
 
 .cue-button {
   padding: 0.2rem;
+}
+
+.line-row:has(.add-cue-btn:hover) {
+  background-color: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
 }
 
 .stage-direction {

--- a/client-v3/src/components/show/live/ScriptLineViewerCompact.vue
+++ b/client-v3/src/components/show/live/ScriptLineViewerCompact.vue
@@ -56,7 +56,7 @@
         </BCol>
         <BCol v-if="cueAddMode" cols="1" class="cue-add-column" />
       </BRow>
-      <BRow>
+      <BRow class="line-row">
         <template v-if="line.line_type === LINE_TYPES.DIALOGUE">
           <template v-for="(part, index) in line.line_parts" :key="`part_${lineIndex}_${index}`">
             <BCol
@@ -88,7 +88,9 @@
             cols="1"
             class="cue-add-column d-flex align-items-center justify-content-center"
           >
-            <BButton variant="success" size="sm" @click.stop="addNewCue"><IMdiPlusBox /></BButton>
+            <BButton variant="success" size="sm" class="add-cue-btn" @click.stop="addNewCue"
+              ><IMdiPlusBox
+            /></BButton>
           </BCol>
         </template>
         <template v-else-if="line.line_type === LINE_TYPES.STAGE_DIRECTION">
@@ -113,7 +115,9 @@
             cols="1"
             class="cue-add-column d-flex align-items-center justify-content-center"
           >
-            <BButton variant="success" size="sm" @click.stop="addNewCue"><IMdiPlusBox /></BButton>
+            <BButton variant="success" size="sm" class="add-cue-btn" @click.stop="addNewCue"
+              ><IMdiPlusBox
+            /></BButton>
           </BCol>
         </template>
         <template v-else-if="line.line_type === LINE_TYPES.CUE_LINE">
@@ -124,7 +128,9 @@
             cols="1"
             class="cue-add-column d-flex align-items-center justify-content-center"
           >
-            <BButton variant="success" size="sm" @click.stop="addNewCue"><IMdiPlusBox /></BButton>
+            <BButton variant="success" size="sm" class="add-cue-btn" @click.stop="addNewCue"
+              ><IMdiPlusBox
+            /></BButton>
           </BCol>
         </template>
       </BRow>
@@ -336,5 +342,11 @@ onUnmounted(() => {
 
 .cue-add-column {
   border-left: 0.1rem solid #3498db;
+}
+
+.line-row:has(.add-cue-btn:hover) {
+  background-color: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
 }
 </style>

--- a/client/src/vue_components/show/live/ScriptLineViewer.vue
+++ b/client/src/vue_components/show/live/ScriptLineViewer.vue
@@ -66,6 +66,7 @@
       </template>
     </b-row>
     <b-row
+      class="line-row"
       :class="{
         'stage-direction': line.line_type === LINE_TYPES.STAGE_DIRECTION,
         'heading-padding': line.line_type === LINE_TYPES.DIALOGUE && needsHeadingsAll,
@@ -150,7 +151,7 @@
             </b-button>
             <b-button
               v-if="cueAddMode"
-              class="cue-button"
+              class="cue-button add-cue-btn"
               :disabled="isWholeLineCut(line)"
               @click.stop="addNewCue"
             >
@@ -175,7 +176,7 @@
             </b-button>
             <b-button
               v-if="cueAddMode"
-              class="cue-button"
+              class="cue-button add-cue-btn"
               :disabled="isWholeLineCut(line)"
               @click.stop="addNewCue"
             >
@@ -391,6 +392,12 @@ export default defineComponent({
 
 .cue-button {
   padding: 0.2rem;
+}
+
+.line-row:has(.add-cue-btn:hover) {
+  background-color: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
 }
 
 .stage-direction {

--- a/client/src/vue_components/show/live/ScriptLineViewerCompact.vue
+++ b/client/src/vue_components/show/live/ScriptLineViewerCompact.vue
@@ -70,7 +70,7 @@
         <b-col v-if="cueAddMode" cols="1" class="cue-add-column" />
       </b-row>
     </template>
-    <b-row>
+    <b-row class="line-row">
       <template v-if="line.line_type === LINE_TYPES.DIALOGUE">
         <template v-for="(part, index) in line.line_parts">
           <b-col
@@ -106,7 +106,7 @@
           cols="1"
           class="cue-add-column d-flex align-items-center justify-content-center"
         >
-          <b-button variant="success" size="sm" @click.stop="addNewCue">
+          <b-button variant="success" size="sm" class="add-cue-btn" @click.stop="addNewCue">
             <b-icon-plus-square-fill />
           </b-button>
         </b-col>
@@ -141,7 +141,7 @@
           cols="1"
           class="cue-add-column d-flex align-items-center justify-content-center"
         >
-          <b-button variant="success" size="sm" @click.stop="addNewCue">
+          <b-button variant="success" size="sm" class="add-cue-btn" @click.stop="addNewCue">
             <b-icon-plus-square-fill />
           </b-button>
         </b-col>
@@ -158,7 +158,7 @@
           cols="1"
           class="cue-add-column d-flex align-items-center justify-content-center"
         >
-          <b-button variant="success" size="sm" @click.stop="addNewCue">
+          <b-button variant="success" size="sm" class="add-cue-btn" @click.stop="addNewCue">
             <b-icon-plus-square-fill />
           </b-button>
         </b-col>
@@ -326,5 +326,11 @@ export default defineComponent({
 
 .cue-add-column {
   border-left: 0.1rem solid #3498db;
+}
+
+.line-row:has(.add-cue-btn:hover) {
+  background-color: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  transition: background-color 0.15s ease;
 }
 </style>


### PR DESCRIPTION
## Summary

- Replicates the CSS `:has()` hover highlighting pattern (introduced in the config cue editor and script editor) to the live show view
- When cue edit mode is active, hovering the add-cue button applies a faint white overlay (`rgba(255, 255, 255, 0.06)`) to the script row
- Applied to the inner content row (not the root container) to avoid conflicting with the existing `.current-line` blue highlight
- Updated all four components: standard and compact viewers in both the Vue 2 (`client/`) and Vue 3 (`client-v3/`) clients

## Test plan

- [ ] Open a show in the live view and press `C` to enter cue edit mode
- [ ] Hover over an add-cue button — the row should highlight with a subtle white overlay
- [ ] Navigate with arrow keys to confirm the current-line blue highlight is unaffected
- [ ] Test both standard and compact layout modes (toggle in user settings)
- [ ] Test with cues on the left and cues on the right (toggle in user settings)
- [ ] Repeat smoke-test in the Vue 2 client at `/ui-old/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)