### PR TITLE
Fix race condition in Add New Cue modal when submitting via Enter key

### DIFF
--- a/client-v3/src/components/show/config/cues/ScriptLineCueEditor.vue
+++ b/client-v3/src/components/show/config/cues/ScriptLineCueEditor.vue
@@ -401,13 +401,12 @@ async function onSubmitNew(event: Event): Promise<void> {
     return;
   }
   submittingNewCue.value = true;
+  newCueModal.value?.hide();
   await scriptStore.addNewCue({
     cueType: newFormState.value.cueType!,
     ident: newFormState.value.ident!,
     lineId: newFormState.value.lineId!,
   });
-  newCueModal.value?.hide();
-  resetNewForm();
 }
 
 // Edit cue modal


### PR DESCRIPTION
## Summary

- Fixes a race condition where pressing **Enter** to submit the Add New Cue modal left it open during the API call, causing a spurious "A cue with this identifier already exists" warning to flash before the modal closed.
- Moves `newCueModal.hide()` to before `await scriptStore.addNewCue(...)` so Enter key and OK button now both close the modal immediately on valid submission.
- Removes the now-redundant `resetNewForm()` call at the end of `onSubmitNew` — the modal's `@hidden` event already calls it as a cleanup handler.

**Root cause:** BVN auto-closes the modal at the first `await` in a `@ok` handler, but a DOM `@submit` event (Enter key) has no such behaviour — the modal stayed open until `hide()` was called explicitly (post-`await`). By then, `addNewCue` had already run `loadCues()`, updating the store and briefly making `isDuplicateNewCue` true.

## Test plan

- [ ] Open the Cue Configuration tab in a show with an existing cue type and script line
- [ ] Open the Add New Cue modal on a line, fill in type and identifier, press **Enter**
- [ ] Confirm: modal closes immediately without flashing the duplicate warning
- [ ] Confirm: the new cue appears on the line
- [ ] Repeat using the **OK button** — behaviour should be unchanged
- [ ] All 180 Playwright E2E tests pass (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)