### PR TITLE
Fix misaligned navbar items in hamburger menu (client-v3)

### DIFF
--- a/client-v3/src/App.vue
+++ b/client-v3/src/App.vue
@@ -424,6 +424,17 @@ async function goToLivePage(): Promise<void> {
   text-align: center;
 }
 
+@media (max-width: 991.98px) {
+  .navbar-nav .nav-item {
+    display: flex;
+    justify-content: center;
+  }
+
+  .navbar-nav .nav-link {
+    text-align: center;
+  }
+}
+
 div.center-spinner {
   position: fixed;
   top: 50%;


### PR DESCRIPTION
## Summary

- Navbar items in the collapsed (hamburger) menu were inconsistently aligned — plain `BNavItem` links appeared centred while `BNavItemDropdown` toggles were left-aligned
- Root cause: `<button>` elements with `display: block` don't stretch to fill their containing block like `<a>` elements do, so `text-align: center` alone was insufficient for dropdown toggles
- Fix: make `.navbar-nav .nav-item` a flex container with `justify-content: center` in a `@media (max-width: 991.98px)` block (the Bootstrap `lg` breakpoint), so both link and button children are centred regardless of display type; `text-align: center` on `.nav-link` handles text alignment within the element

## Test plan

- [ ] Open app at a viewport narrower than 992px
- [ ] Click the hamburger toggle — all items (plain links and dropdowns) should be consistently centred
- [ ] Expand viewport above 992px — desktop horizontal navbar should look unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)