### PR TITLE
Add bulk character/group assignment to script bulk edit mode

### DIFF
--- a/client-v3/e2e/tests/10-show-config-script.spec.ts
+++ b/client-v3/e2e/tests/10-show-config-script.spec.ts
@@ -97,11 +97,31 @@ test('saves a dialogue line to the script', async () => {
   await lineEditor.locator('select').nth(0).selectOption({ label: 'Act 1' });
   await lineEditor.locator('select').nth(1).selectOption({ label: 'Scene 1' });
 
-  await page.locator('select').filter({ hasText: 'Hamlet' }).selectOption({ label: 'Hamlet' });
+  await lineEditor
+    .locator('select')
+    .filter({ hasText: 'Hamlet' })
+    .selectOption({ label: 'Hamlet' });
   await page.locator('input[type="text"]:visible').last().fill('To be or not to be');
 
   await page.locator('button:has-text("Done")').first().click();
-  // ScriptEditor auto-adds a blank dialogue line after Done — delete it before asserting
+  // ScriptEditor auto-adds a blank dialogue editor after Done — fill it in as a second line so
+  // the bulk edit tests below can use a two-line range without needing the split dropdown.
+  await expect(page.locator('button:has-text("Done")').first()).toBeVisible({ timeout: 5_000 });
+
+  const lineEditor2 = page
+    .locator('div.row')
+    .filter({ has: page.locator('button:has-text("Done")') })
+    .first();
+  await lineEditor2.locator('select').nth(0).selectOption({ label: 'Act 1' });
+  await lineEditor2.locator('select').nth(1).selectOption({ label: 'Scene 1' });
+  await lineEditor2
+    .locator('select')
+    .filter({ hasText: 'Hamlet' })
+    .selectOption({ label: 'Hamlet' });
+  await page.locator('input[type="text"]:visible').last().fill('That is the question');
+
+  await page.locator('button:has-text("Done")').first().click();
+  // Delete the third auto-added blank editor
   await page.locator('button.btn-danger:has-text("Delete")').first().click();
   await expect(page.locator('button:has-text("Done")')).not.toBeVisible({ timeout: 5_000 });
 
@@ -118,6 +138,59 @@ test('saves a dialogue line to the script', async () => {
   await expect(
     page.locator('.viewable-line').filter({ hasText: 'To be or not to be' })
   ).toBeVisible({ timeout: 10_000 });
+  await expect(
+    page.locator('.viewable-line').filter({ hasText: 'That is the question' })
+  ).toBeVisible({ timeout: 10_000 });
+});
+
+// ── Bulk edit ─────────────────────────────────────────────────────────────
+
+test('bulk edit mode is accessible and shows Start/End buttons', async () => {
+  // Still in edit mode from the save test, which saved two viewable dialogue lines.
+  await page.click('button:has-text("Bulk Edit")');
+  // Two ScriptLineViewer rows → two Start/End button pairs
+  await expect(page.getByRole('button', { name: 'Start', exact: true }).first()).toBeVisible({
+    timeout: 5_000,
+  });
+  await expect(page.getByRole('button', { name: 'End', exact: true }).first()).toBeVisible({
+    timeout: 5_000,
+  });
+});
+
+test('bulk edit opens the Bulk Edit modal when start and end span two different lines', async () => {
+  // Start on the first line, End on the last line (different indices → valid range)
+  await page.getByRole('button', { name: 'Start', exact: true }).first().click();
+  await page.getByRole('button', { name: 'End', exact: true }).last().click();
+  await waitForModal(page, 'Bulk Edit');
+});
+
+test('bulk edit can assign a character to part 1', async () => {
+  await page.locator('.modal.show #bulk-part-input').selectOption({ label: 'Part 1' });
+  // Select Alice — a different character from Hamlet (who is already assigned) so the apply
+  // produces a real change that scriptChanges can detect via deep equality.
+  await page.locator('.modal.show #bulk-char-input').selectOption({ label: 'Alice' });
+  await confirmModal(page);
+  await waitForModalClosed(page);
+  // After apply, bulk edit mode exits automatically
+  await expect(page.getByRole('button', { name: 'Bulk Edit', exact: true })).toBeVisible({
+    timeout: 5_000,
+  });
+});
+
+test('bulk edit stops when Exit Bulk Edit is clicked', async () => {
+  await page.click('button:has-text("Bulk Edit")');
+  await expect(page.getByRole('button', { name: 'Start', exact: true }).first()).toBeVisible({
+    timeout: 5_000,
+  });
+  await page.click('button:has-text("Exit Bulk Edit")');
+  await expect(page.getByRole('button', { name: 'Start', exact: true })).not.toBeVisible({
+    timeout: 3_000,
+  });
+  await page.click('button:has-text("Stop Editing")');
+  await confirmDialog(page);
+  await expect(page.getByRole('button', { name: 'Edit', exact: true })).toBeVisible({
+    timeout: 10_000,
+  });
 });
 
 // ── Cut mode ──────────────────────────────────────────────────────────────
@@ -232,7 +305,7 @@ test('adds a cue to the script line', async () => {
   // Scope to the visible modal's select to avoid matching the hidden "Add Cue Type" modal
   // dialog which BVN assigns id="new-cue-type" via its auto-ID scheme.
   await page.locator('.modal.show select#new-cue-type').selectOption({ index: 1 });
-  await page.fill('#new-cue-ident', '001');
+  await page.locator('.modal.show #new-cue-ident').fill('001');
   await confirmModal(page);
   await waitForModalClosed(page);
   // Wait for the actual cue button (not the add-cue-btn which shares the cue-button class)
@@ -246,7 +319,7 @@ test('edits the cue identifier', async () => {
   // Use :not(.add-cue-btn) to target the real cue button, not the add button
   await page.locator('.cue-button:not(.add-cue-btn)').first().click();
   await waitForModal(page, 'Edit Cue');
-  await page.fill('#edit-cue-ident', '002');
+  await page.locator('.modal.show #edit-cue-ident').fill('002');
   await confirmModal(page);
   await waitForModalClosed(page);
   await expect(page.locator('.cue-button:not(.add-cue-btn)').first()).toBeVisible({
@@ -258,9 +331,11 @@ test('can add a cue using Enter key in Add New Cue modal', async () => {
   await page.locator('.add-cue-btn').first().click();
   await waitForModal(page, 'Add New Cue');
   await page.locator('.modal.show select#new-cue-type').selectOption({ index: 1 });
-  await page.fill('#new-cue-ident', '003');
+  await page.locator('.modal.show #new-cue-ident').fill('003');
   // Enter key submits the form (fix: BForm @submit bound to onSubmitNew)
-  await page.locator('#new-cue-ident').press('Enter');
+  // Scope to .modal.show to avoid strict-mode violation from other Add New Cue modal instances
+  // in the DOM (one per viewable script line — BVN v-show keeps them all present).
+  await page.locator('.modal.show #new-cue-ident').press('Enter');
   await waitForModalClosed(page);
   await expect(page.locator('.cue-button:not(.add-cue-btn)')).toHaveCount(2, { timeout: 5_000 });
 });
@@ -269,9 +344,9 @@ test('can edit a cue identifier using Enter key in Edit Cue modal', async () => 
   // Click the second cue button (003)
   await page.locator('.cue-button:not(.add-cue-btn)').last().click();
   await waitForModal(page, 'Edit Cue');
-  await page.fill('#edit-cue-ident', '004');
+  await page.locator('.modal.show #edit-cue-ident').fill('004');
   // Enter key submits the form (fix: BForm @submit bound to onSubmitEdit)
-  await page.locator('#edit-cue-ident').press('Enter');
+  await page.locator('.modal.show #edit-cue-ident').press('Enter');
   await waitForModalClosed(page);
   await expect(page.locator('.cue-button:not(.add-cue-btn)')).toHaveCount(2, { timeout: 5_000 });
 });

--- a/client-v3/src/components/show/config/script/BulkEditModal.vue
+++ b/client-v3/src/components/show/config/script/BulkEditModal.vue
@@ -1,0 +1,247 @@
+<template>
+  <BModal
+    ref="modal"
+    title="Bulk Edit"
+    size="md"
+    ok-title="Apply"
+    :ok-disabled="!canApply"
+    @ok.prevent="handleOk"
+    @hidden="reset"
+  >
+    <p class="text-muted small mb-3">
+      Applies the selected changes to all lines from the chosen start line to end line (inclusive).
+      Fill in a section to apply those changes; leave it empty to skip it.
+    </p>
+
+    <h6 class="mb-2">Act / Scene</h6>
+    <BFormGroup label="Act" label-for="bulk-act-input">
+      <BFormSelect
+        id="bulk-act-input"
+        v-model="selectedActId"
+        :options="actOptions"
+        @update:model-value="selectedSceneId = null"
+      />
+    </BFormGroup>
+    <BFormGroup label="Scene" label-for="bulk-scene-input">
+      <BFormSelect
+        id="bulk-scene-input"
+        v-model="selectedSceneId"
+        :options="sceneOptions"
+        :disabled="selectedActId == null"
+      />
+    </BFormGroup>
+
+    <hr />
+
+    <h6 class="mb-2">Character Assignment</h6>
+    <p class="text-muted small mb-2">Lines without the selected part will be skipped.</p>
+    <BFormGroup label="Part" label-for="bulk-part-input">
+      <BFormSelect id="bulk-part-input" v-model="selectedPartIndex" :options="partOptions" />
+    </BFormGroup>
+    <template v-if="combinedDropdown">
+      <BFormGroup label="Character / Character Group" label-for="bulk-char-combined-input">
+        <BFormSelect
+          id="bulk-char-combined-input"
+          v-model="combinedValue"
+          :options="combinedOptions"
+          :disabled="selectedPartIndex == null"
+        />
+      </BFormGroup>
+    </template>
+    <template v-else>
+      <BFormGroup
+        v-show="selectedCharacterGroupId == null"
+        label="Character"
+        label-for="bulk-char-input"
+      >
+        <BFormSelect
+          id="bulk-char-input"
+          v-model="selectedCharacterId"
+          :options="characterOptions"
+          :disabled="selectedPartIndex == null"
+        />
+      </BFormGroup>
+      <BFormGroup
+        v-show="selectedCharacterId == null"
+        label="Character Group"
+        label-for="bulk-char-group-input"
+      >
+        <BFormSelect
+          id="bulk-char-group-input"
+          v-model="selectedCharacterGroupId"
+          :options="characterGroupOptions"
+          :disabled="selectedPartIndex == null"
+        />
+      </BFormGroup>
+    </template>
+  </BModal>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import type { BModal } from 'bootstrap-vue-next';
+import type { ScriptLine } from '@/types/api/script';
+import type { Act, Scene, Character, CharacterGroup } from '@/types/api/show';
+import { useUserStore } from '@/stores/user';
+
+const props = defineProps<{
+  previousLineOfStart: ScriptLine | null;
+  nextLineOfEnd: ScriptLine | null;
+  acts: Act[];
+  scenes: Scene[];
+  characters: Character[];
+  characterGroups: CharacterGroup[];
+}>();
+
+const emit = defineEmits<{
+  apply: [
+    payload: {
+      actId: number | null;
+      sceneId: number | null;
+      partIndex: number | null;
+      characterId: number | null;
+      characterGroupId: number | null;
+    },
+  ];
+}>();
+
+const userStore = useUserStore();
+const modal = ref<InstanceType<typeof BModal>>();
+
+const selectedActId = ref<number | null>(null);
+const selectedSceneId = ref<number | null>(null);
+const selectedPartIndex = ref<number | null>(null);
+const selectedCharacterId = ref<number | null>(null);
+const selectedCharacterGroupId = ref<number | null>(null);
+
+const combinedDropdown = computed(
+  () =>
+    !!(userStore.userSettings as { character_combined_dropdown?: boolean })
+      .character_combined_dropdown
+);
+
+const validActs = computed<Act[]>(() => {
+  let startAct = props.acts.find((a) => a.previous_act == null) ?? null;
+  if (props.previousLineOfStart?.act_id != null) {
+    startAct = props.acts.find((a) => a.id === props.previousLineOfStart!.act_id) ?? startAct;
+  }
+  const result: Act[] = [];
+  let cur = startAct;
+  while (cur) {
+    result.push(cur);
+    if (props.nextLineOfEnd && props.nextLineOfEnd.act_id === cur.id) break;
+    cur = cur.next_act == null ? null : (props.acts.find((a) => a.id === cur!.next_act) ?? null);
+  }
+  return result;
+});
+
+const validScenes = computed<Scene[]>(() => {
+  if (selectedActId.value == null) return [];
+  const actScenes = props.scenes.filter((s) => s.act === selectedActId.value);
+  let startScene = actScenes.find((s) => s.previous_scene == null) ?? null;
+  if (
+    props.previousLineOfStart?.act_id === selectedActId.value &&
+    props.previousLineOfStart?.scene_id != null
+  ) {
+    startScene = actScenes.find((s) => s.id === props.previousLineOfStart!.scene_id) ?? startScene;
+  }
+  const result: Scene[] = [];
+  let cur = startScene;
+  while (cur) {
+    result.push(cur);
+    if (props.nextLineOfEnd && props.nextLineOfEnd.scene_id === cur.id) break;
+    cur = cur.next_scene == null ? null : (actScenes.find((s) => s.id === cur!.next_scene) ?? null);
+  }
+  return result;
+});
+
+const actOptions = computed(() => [
+  { value: null, text: 'Select an act', disabled: true },
+  ...validActs.value.map((a) => ({ value: a.id, text: a.name })),
+]);
+
+const sceneOptions = computed(() => [
+  { value: null, text: 'Select a scene', disabled: true },
+  ...validScenes.value.map((s) => ({ value: s.id, text: s.name })),
+]);
+
+const partOptions = computed(() => [
+  { value: null, text: 'Select a part', disabled: true },
+  { value: 1, text: 'Part 1' },
+  { value: 2, text: 'Part 2' },
+  { value: 3, text: 'Part 3' },
+  { value: 4, text: 'Part 4' },
+]);
+
+const characterOptions = computed(() => [
+  { value: null, text: 'N/A' },
+  ...props.characters.map((c) => ({ value: c.id, text: c.name })),
+]);
+
+const characterGroupOptions = computed(() => [
+  { value: null, text: 'N/A' },
+  ...props.characterGroups.map((g) => ({ value: g.id, text: g.name })),
+]);
+
+const combinedOptions = computed<{ value: string | null; text: string; disabled?: boolean }[]>(
+  () => [
+    { value: null, text: 'Select character / group', disabled: true },
+    ...props.characters.map((c) => ({ value: `c:${c.id}`, text: c.name ?? '' })),
+    ...props.characterGroups.map((g) => ({ value: `g:${g.id}`, text: g.name ?? '' })),
+  ]
+);
+
+const combinedValue = computed<string | null>({
+  get() {
+    if (selectedCharacterId.value != null) return `c:${selectedCharacterId.value}`;
+    if (selectedCharacterGroupId.value != null) return `g:${selectedCharacterGroupId.value}`;
+    return null;
+  },
+  set(val: string | null) {
+    if (val == null) {
+      selectedCharacterId.value = null;
+      selectedCharacterGroupId.value = null;
+    } else if (val.startsWith('c:')) {
+      selectedCharacterId.value = Number.parseInt(val.slice(2), 10);
+      selectedCharacterGroupId.value = null;
+    } else if (val.startsWith('g:')) {
+      selectedCharacterId.value = null;
+      selectedCharacterGroupId.value = Number.parseInt(val.slice(2), 10);
+    }
+  },
+});
+
+const actSceneComplete = computed(
+  () => selectedActId.value != null && selectedSceneId.value != null
+);
+
+const characterComplete = computed(
+  () =>
+    selectedPartIndex.value != null &&
+    (selectedCharacterId.value != null || selectedCharacterGroupId.value != null)
+);
+
+const canApply = computed(() => actSceneComplete.value || characterComplete.value);
+
+function handleOk(): void {
+  if (canApply.value) {
+    emit('apply', {
+      actId: actSceneComplete.value ? selectedActId.value : null,
+      sceneId: actSceneComplete.value ? selectedSceneId.value : null,
+      partIndex: characterComplete.value ? selectedPartIndex.value : null,
+      characterId: characterComplete.value ? selectedCharacterId.value : null,
+      characterGroupId: characterComplete.value ? selectedCharacterGroupId.value : null,
+    });
+  }
+}
+
+function reset(): void {
+  selectedActId.value = null;
+  selectedSceneId.value = null;
+  selectedPartIndex.value = null;
+  selectedCharacterId.value = null;
+  selectedCharacterGroupId.value = null;
+}
+
+defineExpose({ show: () => modal.value?.show(), hide: () => modal.value?.hide() });
+</script>

--- a/client-v3/src/components/show/config/script/ScriptEditor.vue
+++ b/client-v3/src/components/show/config/script/ScriptEditor.vue
@@ -161,12 +161,14 @@
       />
     </BModal>
 
-    <BulkActSceneModal
+    <BulkEditModal
       ref="bulkModal"
       :previous-line-of-start="previousLineOfStart"
       :next-line-of-end="nextLineOfEnd"
       :acts="showStore.actList"
       :scenes="showStore.sceneList"
+      :characters="showStore.characterList"
+      :character-groups="showStore.characterGroupList"
       @apply="onBulkApply"
     />
 
@@ -211,7 +213,7 @@ import { useConfirm } from '@/composables/useConfirm';
 import { toast } from '@/js/toast';
 import ScriptLineEditor from './ScriptLineEditor.vue';
 import ScriptLineViewer from './ScriptLineViewer.vue';
-import BulkActSceneModal from './BulkActSceneModal.vue';
+import BulkEditModal from './BulkEditModal.vue';
 import type { ScriptLine } from '@/types/api/script';
 
 const MRU_LOOK_BACK = 4;
@@ -247,7 +249,7 @@ const pageInputNo = ref(1);
 
 const saveModal = ref<InstanceType<typeof BModal>>();
 const goToPageModal = ref<InstanceType<typeof BModal>>();
-const bulkModal = ref<InstanceType<typeof BulkActSceneModal>>();
+const bulkModal = ref<InstanceType<typeof BulkEditModal>>();
 
 const currentPageLines = computed(() => scriptConfigStore.getTmpPage(currentPage.value));
 const deletedLines = computed(() => scriptConfigStore.getDeletedLines(currentPage.value));
@@ -712,10 +714,21 @@ function endLines_isLast(lines: ScriptLine[], index: number): boolean {
   return index === lines.length - 1;
 }
 
-async function onBulkApply({ actId, sceneId }: { actId: number; sceneId: number }): Promise<void> {
+async function onBulkApply(payload: {
+  actId: number | null;
+  sceneId: number | null;
+  partIndex: number | null;
+  characterId: number | null;
+  characterGroupId: number | null;
+}): Promise<void> {
   if (!bulkEditStart.value || !bulkEditEnd.value) return;
   const { page: startPage, lineIndex: startIndex } = bulkEditStart.value;
   const { page: endPage, lineIndex: endIndex } = bulkEditEnd.value;
+
+  const applyActScene = payload.actId != null && payload.sceneId != null;
+  const applyCharacter =
+    payload.partIndex != null && (payload.characterId != null || payload.characterGroupId != null);
+  const targetPartIdx = (payload.partIndex ?? 1) - 1;
 
   for (let p = startPage; p <= endPage; p++) {
     await loadPage(p);
@@ -725,7 +738,28 @@ async function onBulkApply({ actId, sceneId }: { actId: number; sceneId: number 
     const deletedOnPage = scriptConfigStore.getDeletedLines(p);
     for (let i = fromIdx; i <= toIdx; i++) {
       if (deletedOnPage.includes(i)) continue;
-      scriptConfigStore.setLine(p, i, { ...pageLines[i], act_id: actId, scene_id: sceneId });
+      const updatedLine = { ...pageLines[i] };
+      if (applyActScene) {
+        updatedLine.act_id = payload.actId!;
+        updatedLine.scene_id = payload.sceneId!;
+      }
+      if (applyCharacter) {
+        const sortedParts = [...updatedLine.line_parts].sort(
+          (a, b) => (a.part_index ?? 0) - (b.part_index ?? 0)
+        );
+        if (sortedParts.length > targetPartIdx) {
+          updatedLine.line_parts = sortedParts.map((part, idx) =>
+            idx === targetPartIdx
+              ? {
+                  ...part,
+                  character_id: payload.characterId,
+                  character_group_id: payload.characterGroupId,
+                }
+              : part
+          );
+        }
+      }
+      scriptConfigStore.setLine(p, i, updatedLine);
     }
   }
 

--- a/client/src/vue_components/show/config/script/BulkEditModal.vue
+++ b/client/src/vue_components/show/config/script/BulkEditModal.vue
@@ -1,0 +1,262 @@
+<template>
+  <b-modal
+    id="bulk-edit-modal"
+    title="Bulk Edit"
+    size="md"
+    ok-title="Apply"
+    :ok-disabled="!canApply"
+    @ok="handleOk"
+    @hidden="reset"
+  >
+    <p class="text-muted small mb-3">
+      Applies the selected changes to all lines from the chosen start line to end line (inclusive).
+      Fill in a section to apply those changes; leave it empty to skip it.
+    </p>
+
+    <h6 class="mb-2">Act / Scene</h6>
+    <b-form-group label="Act" label-for="bulk-act-input">
+      <b-form-select
+        id="bulk-act-input"
+        v-model="selectedActId"
+        :options="actOptions"
+        @change="selectedSceneId = null"
+      />
+    </b-form-group>
+    <b-form-group label="Scene" label-for="bulk-scene-input">
+      <b-form-select
+        id="bulk-scene-input"
+        v-model="selectedSceneId"
+        :options="sceneOptions"
+        :disabled="selectedActId == null"
+      />
+    </b-form-group>
+
+    <hr />
+
+    <h6 class="mb-2">Character Assignment</h6>
+    <p class="text-muted small mb-2">Lines without the selected part will be skipped.</p>
+    <b-form-group label="Part" label-for="bulk-part-input">
+      <b-form-select id="bulk-part-input" v-model="selectedPartIndex" :options="partOptions" />
+    </b-form-group>
+    <template v-if="combinedDropdown">
+      <b-form-group label="Character / Character Group" label-for="bulk-char-combined-input">
+        <b-form-select
+          id="bulk-char-combined-input"
+          v-model="combinedValue"
+          :options="combinedOptions"
+          :disabled="selectedPartIndex == null"
+        />
+      </b-form-group>
+    </template>
+    <template v-else>
+      <b-form-group
+        v-show="selectedCharacterGroupId == null"
+        label="Character"
+        label-for="bulk-char-input"
+      >
+        <b-form-select
+          id="bulk-char-input"
+          v-model="selectedCharacterId"
+          :options="characterOptions"
+          :disabled="selectedPartIndex == null"
+        />
+      </b-form-group>
+      <b-form-group
+        v-show="selectedCharacterId == null"
+        label="Character Group"
+        label-for="bulk-char-group-input"
+      >
+        <b-form-select
+          id="bulk-char-group-input"
+          v-model="selectedCharacterGroupId"
+          :options="characterGroupOptions"
+          :disabled="selectedPartIndex == null"
+        />
+      </b-form-group>
+    </template>
+  </b-modal>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { mapGetters } from 'vuex';
+
+export default defineComponent({
+  name: 'BulkEditModal',
+  events: ['apply'],
+  props: {
+    previousLineOfStart: {
+      type: Object,
+      default: null,
+    },
+    nextLineOfEnd: {
+      type: Object,
+      default: null,
+    },
+    acts: {
+      required: true,
+      type: Array,
+    },
+    scenes: {
+      required: true,
+      type: Array,
+    },
+    characters: {
+      required: true,
+      type: Array,
+    },
+    characterGroups: {
+      required: true,
+      type: Array,
+    },
+  },
+  data() {
+    return {
+      selectedActId: null as number | null,
+      selectedSceneId: null as number | null,
+      selectedPartIndex: null as number | null,
+      selectedCharacterId: null as number | null,
+      selectedCharacterGroupId: null as number | null,
+    };
+  },
+  computed: {
+    ...mapGetters(['USER_SETTINGS']),
+    combinedDropdown(): boolean {
+      return !!(this.USER_SETTINGS as { character_combined_dropdown?: boolean })
+        ?.character_combined_dropdown;
+    },
+    validActs(): any[] {
+      let startAct = (this.acts as any[]).find((act) => act.previous_act == null);
+      if (this.previousLineOfStart != null && this.previousLineOfStart.act_id != null) {
+        startAct = (this.acts as any[]).find((act) => act.id === this.previousLineOfStart.act_id);
+      }
+      const validActs: any[] = [];
+      let nextAct = startAct;
+      while (nextAct != null) {
+        validActs.push(nextAct);
+        if (this.nextLineOfEnd != null && this.nextLineOfEnd.act_id === nextAct.id) {
+          break;
+        }
+        nextAct = (this.acts as any[]).find((act) => act.id === nextAct.next_act) || null;
+      }
+      return validActs;
+    },
+    validScenes(): any[] {
+      if (this.selectedActId == null) {
+        return [];
+      }
+      const actScenes = (this.scenes as any[]).filter((scene) => scene.act === this.selectedActId);
+      let startScene = actScenes.find((scene) => scene.previous_scene == null);
+      if (
+        this.previousLineOfStart != null &&
+        this.previousLineOfStart.act_id === this.selectedActId &&
+        this.previousLineOfStart.scene_id != null
+      ) {
+        startScene = actScenes.find((scene) => scene.id === this.previousLineOfStart.scene_id);
+      }
+      const validScenes: any[] = [];
+      let nextScene = startScene;
+      while (nextScene != null) {
+        validScenes.push(nextScene);
+        if (this.nextLineOfEnd != null && this.nextLineOfEnd.scene_id === nextScene.id) {
+          break;
+        }
+        nextScene = actScenes.find((scene) => scene.id === nextScene.next_scene) || null;
+      }
+      return validScenes;
+    },
+    actOptions(): any[] {
+      return [
+        { value: null, text: 'Select an act', disabled: true },
+        ...this.validActs.map((act) => ({ value: act.id, text: act.name })),
+      ];
+    },
+    sceneOptions(): any[] {
+      return [
+        { value: null, text: 'Select a scene', disabled: true },
+        ...this.validScenes.map((scene) => ({ value: scene.id, text: scene.name })),
+      ];
+    },
+    partOptions(): any[] {
+      return [
+        { value: null, text: 'Select a part', disabled: true },
+        { value: 1, text: 'Part 1' },
+        { value: 2, text: 'Part 2' },
+        { value: 3, text: 'Part 3' },
+        { value: 4, text: 'Part 4' },
+      ];
+    },
+    characterOptions(): any[] {
+      return [
+        { value: null, text: 'N/A' },
+        ...(this.characters as any[]).map((c) => ({ value: c.id, text: c.name })),
+      ];
+    },
+    characterGroupOptions(): any[] {
+      return [
+        { value: null, text: 'N/A' },
+        ...(this.characterGroups as any[]).map((g) => ({ value: g.id, text: g.name })),
+      ];
+    },
+    combinedOptions(): any[] {
+      return [
+        { value: null, text: 'Select character / group', disabled: true },
+        ...(this.characters as any[]).map((c) => ({ value: `c:${c.id}`, text: c.name })),
+        ...(this.characterGroups as any[]).map((g) => ({ value: `g:${g.id}`, text: g.name })),
+      ];
+    },
+    combinedValue: {
+      get(): string | null {
+        if (this.selectedCharacterId != null) return `c:${this.selectedCharacterId}`;
+        if (this.selectedCharacterGroupId != null) return `g:${this.selectedCharacterGroupId}`;
+        return null;
+      },
+      set(val: string | null) {
+        if (val == null) {
+          this.selectedCharacterId = null;
+          this.selectedCharacterGroupId = null;
+        } else if (val.startsWith('c:')) {
+          this.selectedCharacterId = Number.parseInt(val.slice(2), 10);
+          this.selectedCharacterGroupId = null;
+        } else if (val.startsWith('g:')) {
+          this.selectedCharacterId = null;
+          this.selectedCharacterGroupId = Number.parseInt(val.slice(2), 10);
+        }
+      },
+    },
+    actSceneComplete(): boolean {
+      return this.selectedActId != null && this.selectedSceneId != null;
+    },
+    characterComplete(): boolean {
+      return (
+        this.selectedPartIndex != null &&
+        (this.selectedCharacterId != null || this.selectedCharacterGroupId != null)
+      );
+    },
+    canApply(): boolean {
+      return this.actSceneComplete || this.characterComplete;
+    },
+  },
+  methods: {
+    handleOk(bvModalEvt: any): void {
+      bvModalEvt.preventDefault();
+      if (this.canApply) {
+        this.$emit('apply', {
+          actId: this.actSceneComplete ? this.selectedActId : null,
+          sceneId: this.actSceneComplete ? this.selectedSceneId : null,
+          partIndex: this.characterComplete ? this.selectedPartIndex : null,
+          characterId: this.characterComplete ? this.selectedCharacterId : null,
+          characterGroupId: this.characterComplete ? this.selectedCharacterGroupId : null,
+        });
+      }
+    },
+    reset(): void {
+      this.selectedActId = null;
+      this.selectedSceneId = null;
+      this.selectedPartIndex = null;
+      this.selectedCharacterId = null;
+      this.selectedCharacterGroupId = null;
+    },
+  },
+});
+</script>

--- a/client/src/vue_components/show/config/script/ScriptEditor.vue
+++ b/client/src/vue_components/show/config/script/ScriptEditor.vue
@@ -167,11 +167,13 @@
         />
       </div>
     </b-modal>
-    <bulk-act-scene-modal
+    <bulk-edit-modal
       :previous-line-of-start="previousLineOfStart"
       :next-line-of-end="nextLineOfEnd"
       :acts="ACT_LIST"
       :scenes="SCENE_LIST"
+      :characters="CHARACTER_LIST"
+      :character-groups="CHARACTER_GROUP_LIST"
       @apply="onBulkApply"
     />
     <b-modal
@@ -221,7 +223,7 @@ import { diff } from 'deep-object-diff';
 import log from 'loglevel';
 import { sample } from 'lodash';
 
-import BulkActSceneModal from '@/vue_components/show/config/script/BulkActSceneModal.vue';
+import BulkEditModal from '@/vue_components/show/config/script/BulkEditModal.vue';
 import ScriptLineEditor from '@/vue_components/show/config/script/ScriptLineEditor.vue';
 import ScriptLineViewer from '@/vue_components/show/config/script/ScriptLineViewer.vue';
 import { makeURL, randInt } from '@/js/utils';
@@ -232,7 +234,7 @@ const MRU_LOOK_BACK = 4;
 
 export default defineComponent({
   name: 'ScriptConfig',
-  components: { BulkActSceneModal, ScriptLineViewer, ScriptLineEditor },
+  components: { BulkEditModal, ScriptLineViewer, ScriptLineEditor },
   data() {
     return {
       currentEditPage: 1,
@@ -351,7 +353,7 @@ export default defineComponent({
     async bulkEditEnd(val: { page: number; lineIndex: number } | null): Promise<void> {
       if (val != null) {
         await this.loadBoundaryLines();
-        (this as any).$bvModal.show('bulk-act-scene-modal');
+        (this as any).$bvModal.show('bulk-edit-modal');
       }
     },
     USER_SETTINGS(): void {
@@ -1045,9 +1047,21 @@ export default defineComponent({
         this.nextLineOfEnd = nextPage ? nextPage[0] : null;
       }
     },
-    async onBulkApply({ actId, sceneId }: { actId: number; sceneId: number }): Promise<void> {
+    async onBulkApply(payload: {
+      actId: number | null;
+      sceneId: number | null;
+      partIndex: number | null;
+      characterId: number | null;
+      characterGroupId: number | null;
+    }): Promise<void> {
       const { page: startPage, lineIndex: startIndex } = this.bulkEditStart!;
       const { page: endPage, lineIndex: endIndex } = this.bulkEditEnd!;
+
+      const applyActScene = payload.actId != null && payload.sceneId != null;
+      const applyCharacter =
+        payload.partIndex != null &&
+        (payload.characterId != null || payload.characterGroupId != null);
+      const targetPartIdx = (payload.partIndex ?? 1) - 1;
 
       for (let p = startPage; p <= endPage; p++) {
         await (this as any).LOAD_SCRIPT_PAGE(p);
@@ -1060,15 +1074,33 @@ export default defineComponent({
         const toIndex = p === endPage ? endIndex : pageLines.length - 1;
         for (let i = fromIndex; i <= toIndex; i++) {
           if ((this as any).DELETED_LINES(p).includes(i)) continue;
-          (this as any).SET_LINE({
-            pageNo: p,
-            lineIndex: i,
-            lineObj: { ...pageLines[i], act_id: actId, scene_id: sceneId },
-          });
+          const line = pageLines[i];
+          const updatedLine: any = { ...line };
+          if (applyActScene) {
+            updatedLine.act_id = payload.actId;
+            updatedLine.scene_id = payload.sceneId;
+          }
+          if (applyCharacter) {
+            const sortedParts = [...(line.line_parts ?? [])].sort(
+              (a: any, b: any) => (a.part_index ?? 0) - (b.part_index ?? 0)
+            );
+            if (sortedParts.length > targetPartIdx) {
+              updatedLine.line_parts = sortedParts.map((part: any, idx: number) =>
+                idx === targetPartIdx
+                  ? {
+                      ...part,
+                      character_id: payload.characterId,
+                      character_group_id: payload.characterGroupId,
+                    }
+                  : part
+              );
+            }
+          }
+          (this as any).SET_LINE({ pageNo: p, lineIndex: i, lineObj: updatedLine });
         }
       }
 
-      (this as any).$bvModal.hide('bulk-act-scene-modal');
+      (this as any).$bvModal.hide('bulk-edit-modal');
       this.exitBulkEditMode();
     },
     ...mapMutations([


### PR DESCRIPTION
## Summary

- Extends `BulkActSceneModal` into a new `BulkEditModal` with two always-visible sections: **Act / Scene** and **Character Assignment**
- Users can select a target part index (1–4) and assign a character or character group to that part across the entire bulk line range
- Applied changes are derived from filled values — no checkboxes needed; each section is independently applied if its values are non-null
- Lines with fewer parts than the selected part index are silently skipped
- Setting a character clears the character group on that part and vice versa
- Implemented with feature parity in both `client-v3/` (Vue 3) and `client/` (Vue 2 legacy)

## Test plan

- [x] `client-v3` TypeScript typecheck passes (`npm run typecheck`)
- [x] `client-v3` lint passes (`npm run ci-lint`)
- [x] `client-v3` unit tests pass (`npm run test:run`)
- [x] `client` TypeScript typecheck passes
- [x] `client` lint passes
- [x] `client` unit tests pass
- [x] Backend ruff lint passes
- [x] Full Playwright E2E suite passes (184/184 tests) — 4 new bulk edit tests added to `10-show-config-script.spec.ts`
- [ ] Manual test in dev browser: enter bulk edit mode → verify modal shows both sections → test act/scene only, character only, and both together

🤖 Generated with [Claude Code](https://claude.com/claude-code)