### PR TITLE
Add ability to delete individual line parts from the script editor

### DIFF
--- a/client-v3/e2e/tests/10-show-config-script.spec.ts
+++ b/client-v3/e2e/tests/10-show-config-script.spec.ts
@@ -393,3 +393,79 @@ test('deletes the cue', async () => {
   // After deletion only the add-cue-btn remains; no actual cue buttons should exist
   await expect(page.locator('.cue-button:not(.add-cue-btn)')).not.toBeVisible({ timeout: 5_000 });
 });
+
+// ── Line part removal ──────────────────────────────────────────────────────
+
+test('remove button is absent on a single-part dialogue line', async () => {
+  await page.goto(`${UI_BASE}/show-config/script`);
+  await waitForAppReady(page);
+  await page.getByRole('button', { name: 'Edit', exact: true }).click();
+  await expect(page.locator('button:has-text("Stop Editing")')).toBeVisible({ timeout: 10_000 });
+
+  await page.click('button:has-text("Add Dialogue")');
+  const lineEditor = page
+    .locator('div.row')
+    .filter({ has: page.locator('button:has-text("Done")') })
+    .first();
+  await expect(lineEditor.locator('button:has-text("Done")')).toBeVisible({ timeout: 5_000 });
+
+  // With only 1 part no remove button should be present
+  await expect(lineEditor.locator('button.btn-outline-danger')).not.toBeVisible();
+});
+
+test('remove button appears when a second part is added', async () => {
+  const lineEditor = page
+    .locator('div.row')
+    .filter({ has: page.locator('button:has-text("Done")') })
+    .first();
+
+  // btn-secondary is the add-line-part (+) button — only btn-secondary in the editor row
+  await lineEditor.locator('button.btn-secondary').click();
+
+  // One remove button per part
+  await expect(lineEditor.locator('button.btn-outline-danger')).toHaveCount(2, { timeout: 3_000 });
+});
+
+test('clicking remove reduces to single part and hides the remove button', async () => {
+  const lineEditor = page
+    .locator('div.row')
+    .filter({ has: page.locator('button:has-text("Done")') })
+    .first();
+
+  await lineEditor.locator('button.btn-outline-danger').first().click();
+
+  // Back to 1 part — remove button gone
+  await expect(lineEditor.locator('button.btn-outline-danger')).not.toBeVisible({ timeout: 3_000 });
+});
+
+test('dialogue line with removed part saves correctly', async () => {
+  const lineEditor = page
+    .locator('div.row')
+    .filter({ has: page.locator('button:has-text("Done")') })
+    .first();
+
+  await lineEditor.locator('select').nth(0).selectOption({ label: 'Act 1' });
+  await lineEditor.locator('select').nth(1).selectOption({ label: 'Scene 1' });
+  await lineEditor
+    .locator('select')
+    .filter({ hasText: 'Hamlet' })
+    .selectOption({ label: 'Hamlet' });
+  await lineEditor.locator('input[type="text"]').last().fill('Surviving part text');
+
+  await lineEditor.locator('button:has-text("Done")').click();
+  // Delete the auto-added blank editor that appears after Done
+  await page.locator('button.btn-danger:has-text("Delete")').first().click();
+  await expect(page.locator('button:has-text("Done")')).not.toBeVisible({ timeout: 5_000 });
+
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await waitForModal(page, 'Saving Script');
+  await expect(page.locator('.modal.show').getByText('Finished saving script.')).toBeVisible({
+    timeout: 15_000,
+  });
+  await confirmModal(page);
+  await waitForModalClosed(page);
+
+  await expect(
+    page.locator('.viewable-line').filter({ hasText: 'Surviving part text' })
+  ).toBeVisible({ timeout: 10_000 });
+});

--- a/client-v3/src/components/show/config/script/ScriptLineEditor.vue
+++ b/client-v3/src/components/show/config/script/ScriptLineEditor.vue
@@ -50,6 +50,7 @@
             scriptMode === 1
           "
           :enable-add-button="state.line_parts.length < 4 && lineType === LINE_TYPES.DIALOGUE"
+          :show-remove-button="state.line_parts.length > 1 && lineType === LINE_TYPES.DIALOGUE"
           :line-type="lineType"
           :line-parts="state.line_parts"
           :stage-direction-styles="
@@ -58,6 +59,7 @@
           :stage-direction-style-id="state.stage_direction_style_id"
           @update:model-value="onPartUpdate(index, $event)"
           @add-line-part="addLinePart"
+          @remove-line-part="removeLinePart(index)"
           @try-finish-line="tryFinishLine"
           @stage-direction-style-change="onStageDirectionStyleChange"
         />
@@ -207,6 +209,13 @@ function onStateChange(): void {
 
 function onPartUpdate(index: number, part: ScriptLinePartType): void {
   state.value.line_parts[index] = part;
+  onStateChange();
+}
+
+function removeLinePart(index: number): void {
+  state.value.line_parts = state.value.line_parts
+    .filter((_, i) => i !== index)
+    .map((part, i) => ({ ...part, part_index: i }));
   onStateChange();
 }
 

--- a/client-v3/src/components/show/config/script/ScriptLinePart.vue
+++ b/client-v3/src/components/show/config/script/ScriptLinePart.vue
@@ -47,17 +47,15 @@
           />
         </BFormGroup>
       </BCol>
-      <BCol v-if="showRemoveButton" cols="auto">
-        <BFormGroup label-size="sm" label=" ">
-          <BButton
-            v-b-tooltip.hover.top="'Remove line part'"
-            variant="outline-danger"
-            size="sm"
-            @click="$emit('remove-line-part')"
-          >
-            <IMdiMinusBox />
-          </BButton>
-        </BFormGroup>
+      <BCol v-if="showRemoveButton" cols="auto" class="align-self-end mb-3">
+        <BButton
+          v-b-tooltip.hover.top="'Remove line part'"
+          variant="outline-danger"
+          size="sm"
+          @click="$emit('remove-line-part')"
+        >
+          <IMdiMinusBox />
+        </BButton>
       </BCol>
     </BRow>
     <BRow>

--- a/client-v3/src/components/show/config/script/ScriptLinePart.vue
+++ b/client-v3/src/components/show/config/script/ScriptLinePart.vue
@@ -47,6 +47,18 @@
           />
         </BFormGroup>
       </BCol>
+      <BCol v-if="showRemoveButton" cols="auto">
+        <BFormGroup label-size="sm" label=" ">
+          <BButton
+            v-b-tooltip.hover.top="'Remove line part'"
+            variant="outline-danger"
+            size="sm"
+            @click="$emit('remove-line-part')"
+          >
+            <IMdiMinusBox />
+          </BButton>
+        </BFormGroup>
+      </BCol>
     </BRow>
     <BRow>
       <BCol style="display: inline-flex">
@@ -94,6 +106,7 @@ const props = defineProps<{
   characterGroups: CharacterGroup[];
   showAddButton: boolean;
   enableAddButton: boolean;
+  showRemoveButton: boolean;
   lineType: number;
   lineParts: ScriptLinePart[];
   stageDirectionStyles?: StageDirectionStyle[];
@@ -104,6 +117,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   'update:modelValue': [part: ScriptLinePart];
   'add-line-part': [];
+  'remove-line-part': [];
   'try-finish-line': [];
   'stage-direction-style-change': [id: number | null];
 }>();

--- a/client/src/vue_components/show/config/script/ScriptLineEditor.vue
+++ b/client/src/vue_components/show/config/script/ScriptLineEditor.vue
@@ -53,6 +53,7 @@
             CURRENT_SHOW.script_mode === 1
           "
           :enable-add-button="state.line_parts.length < 4 && lineType === LINE_TYPES.DIALOGUE"
+          :show-remove-button="state.line_parts.length > 1 && lineType === LINE_TYPES.DIALOGUE"
           :line-type="lineType"
           :line-parts="state.line_parts"
           :stage-direction-styles="
@@ -61,6 +62,7 @@
           :stage-direction-style-id="state.stage_direction_style_id"
           @input="stateChange"
           @addLinePart="addLinePart"
+          @removeLinePart="removeLinePart(index)"
           @tryFinishLine="tryFinishLine"
           @stage-direction-style-change="onStageDirectionStyleChange"
         />
@@ -373,6 +375,13 @@ export default defineComponent({
     stateChange(): void {
       (this as any).$v.state.$touch();
       this.$emit('input', (this as any).state);
+    },
+    removeLinePart(index: number): void {
+      const state = (this as any).state;
+      state.line_parts = state.line_parts
+        .filter((_: any, i: number) => i !== index)
+        .map((part: any, i: number) => ({ ...part, part_index: i }));
+      this.stateChange();
     },
     addLinePart(): void {
       const state = (this as any).state;

--- a/client/src/vue_components/show/config/script/ScriptLinePart.vue
+++ b/client/src/vue_components/show/config/script/ScriptLinePart.vue
@@ -69,17 +69,15 @@
           />
         </b-form-group>
       </b-col>
-      <b-col v-if="showRemoveButton" cols="auto">
-        <b-form-group label-size="sm" label=" ">
-          <b-button
-            v-b-popover.hover.top="'Remove line part'"
-            variant="outline-danger"
-            size="sm"
-            @click="removeLinePart"
-          >
-            <b-icon-dash-square-fill variant="danger" />
-          </b-button>
-        </b-form-group>
+      <b-col v-if="showRemoveButton" cols="auto" class="align-self-end mb-3">
+        <b-button
+          v-b-popover.hover.top="'Remove line part'"
+          variant="outline-danger"
+          size="sm"
+          @click="removeLinePart"
+        >
+          <b-icon-dash-square-fill variant="danger" />
+        </b-button>
       </b-col>
     </b-form-row>
     <b-form-row>

--- a/client/src/vue_components/show/config/script/ScriptLinePart.vue
+++ b/client/src/vue_components/show/config/script/ScriptLinePart.vue
@@ -69,6 +69,18 @@
           />
         </b-form-group>
       </b-col>
+      <b-col v-if="showRemoveButton" cols="auto">
+        <b-form-group label-size="sm" label=" ">
+          <b-button
+            v-b-popover.hover.top="'Remove line part'"
+            variant="outline-danger"
+            size="sm"
+            @click="removeLinePart"
+          >
+            <b-icon-dash-square-fill variant="danger" />
+          </b-button>
+        </b-form-group>
+      </b-col>
     </b-form-row>
     <b-form-row>
       <b-col style="display: inline-flex">
@@ -126,6 +138,10 @@ export default defineComponent({
       type: Boolean,
     },
     enableAddButton: {
+      required: true,
+      type: Boolean,
+    },
+    showRemoveButton: {
       required: true,
       type: Boolean,
     },
@@ -270,6 +286,9 @@ export default defineComponent({
     },
     addLinePart(): void {
       this.$emit('addLinePart');
+    },
+    removeLinePart(): void {
+      this.$emit('removeLinePart');
     },
     stateChange(): void {
       (this as any).$v.state.$touch();


### PR DESCRIPTION
## Summary

- Adds a small outline-danger remove button in the character/character group row of each `ScriptLinePart`, visible only when the line has more than one part
- Button disappears automatically when a single part remains, preventing accidental full-line deletion
- On removal, remaining parts are re-sequenced (`part_index`) so the existing PATCH endpoint correctly migrates cuts and cue associations — no backend changes required
- Implemented in both `client-v3/` (Vue 3, using `IMdiMinusBox`) and `client/` (Vue 2, using `b-icon-dash-square-fill`)

## Test plan

- [ ] Open show config → Script tab, enter edit mode, add a DIALOGUE line with 1 part — confirm no remove button is visible
- [ ] Click `+` to add a second part — confirm remove buttons appear on both parts
- [ ] Click a remove button — confirm it reduces to 1 part and the remove buttons disappear
- [ ] Fill in the remaining part, save — confirm the saved line appears correctly in the viewer
- [ ] Repeat the above in the legacy UI (`/ui-old/`)
- [ ] 4 new Playwright E2E tests added to `10-show-config-script.spec.ts` — all 188 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)