### PR TITLE
Fix Act/Scene heading spuriously repeating mid-scene in live show view

### DIFF
--- a/client-v3/src/components/show/live/ScriptLineViewer.vue
+++ b/client-v3/src/components/show/live/ScriptLineViewer.vue
@@ -271,7 +271,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue';
-import { useScriptNavigation } from '@/composables/useScriptNavigation';
+import { useScriptNavigation, getPreviousLineAcrossPages } from '@/composables/useScriptNavigation';
 import { useScriptDisplay } from '@/composables/useScriptDisplay';
 import { useCueDisplay } from '@/composables/useCueDisplay';
 import { useUserStore } from '@/stores/user';
@@ -341,9 +341,7 @@ const needsActSceneLabel = computed(() =>
 const needsIntervalBanner = computed(() => {
   let prev: ScriptLine | null = props.previousLine;
   while (prev != null && isWholeLineCut(prev, props.cuts)) {
-    const prevPage = scriptStore.getScriptPage(prev.page ?? 0);
-    const idx = prevPage.indexOf(prev);
-    prev = idx > 0 ? prevPage[idx - 1] : null;
+    prev = getPreviousLineAcrossPages(prev, scriptStore.getScriptPage);
   }
   if (prev == null) return false;
   return prev.act_id !== props.line.act_id;

--- a/client-v3/src/components/show/live/ScriptLineViewerCompact.vue
+++ b/client-v3/src/components/show/live/ScriptLineViewerCompact.vue
@@ -168,7 +168,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue';
-import { useScriptNavigation } from '@/composables/useScriptNavigation';
+import { useScriptNavigation, getPreviousLineAcrossPages } from '@/composables/useScriptNavigation';
 import { useScriptDisplay } from '@/composables/useScriptDisplay';
 import { useCueDisplay } from '@/composables/useCueDisplay';
 import { useScriptStore } from '@/stores/script';
@@ -232,9 +232,7 @@ const needsActSceneLabel = computed(() =>
 const needsIntervalBanner = computed(() => {
   let prev: ScriptLine | null = props.previousLine;
   while (prev != null && isWholeLineCut(prev, props.cuts)) {
-    const prevPage = scriptStore.getScriptPage(prev.page ?? 0);
-    const idx = prevPage.indexOf(prev);
-    prev = idx > 0 ? prevPage[idx - 1] : null;
+    prev = getPreviousLineAcrossPages(prev, scriptStore.getScriptPage);
   }
   if (prev == null || prev.act_id === props.line.act_id) return false;
   const prevAct = props.acts.find((a) => a.id === prev!.act_id);

--- a/client-v3/src/composables/useScriptNavigation.test.ts
+++ b/client-v3/src/composables/useScriptNavigation.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import type { ScriptLine } from '@/types/api/script';
+import { LINE_TYPES } from '@/constants/lineTypes';
+import { useScriptNavigation, getPreviousLineAcrossPages } from './useScriptNavigation';
+
+function makeLine(overrides: Partial<ScriptLine> & { id: number; page: number }): ScriptLine {
+  return {
+    act_id: 1,
+    scene_id: 1,
+    line_type: LINE_TYPES.DIALOGUE,
+    stage_direction_style_id: null,
+    line_parts: [
+      {
+        id: overrides.id * 10,
+        line_id: overrides.id,
+        part_index: 0,
+        character_id: 1,
+        character_group_id: null,
+        line_text: 'Some line text',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeSpacingLine(id: number, page: number): ScriptLine {
+  return {
+    id,
+    act_id: 1,
+    scene_id: 1,
+    page,
+    line_type: LINE_TYPES.SPACING,
+    stage_direction_style_id: null,
+    line_parts: [],
+  };
+}
+
+describe('getPreviousLineAcrossPages', () => {
+  it('returns the previous line on the same page', () => {
+    const lineA = makeLine({ id: 1, page: 1 });
+    const lineB = makeLine({ id: 2, page: 1 });
+    const pages: Record<number, ScriptLine[]> = { 1: [lineA, lineB] };
+    const getPage = (page: number) => pages[page] ?? [];
+
+    expect(getPreviousLineAcrossPages(lineB, getPage)).toBe(lineA);
+  });
+
+  it('crosses into the previous page when at the start of the current page', () => {
+    const lineA = makeLine({ id: 1, page: 1 });
+    const lineB = makeLine({ id: 2, page: 2 });
+    const pages: Record<number, ScriptLine[]> = { 1: [lineA], 2: [lineB] };
+    const getPage = (page: number) => pages[page] ?? [];
+
+    expect(getPreviousLineAcrossPages(lineB, getPage)).toBe(lineA);
+  });
+
+  it('walks back through multiple empty pages to find content', () => {
+    const lineA = makeLine({ id: 1, page: 1 });
+    const lineB = makeLine({ id: 2, page: 4 });
+    const pages: Record<number, ScriptLine[]> = { 1: [lineA], 2: [], 3: [], 4: [lineB] };
+    const getPage = (page: number) => pages[page] ?? [];
+
+    expect(getPreviousLineAcrossPages(lineB, getPage)).toBe(lineA);
+  });
+
+  it('returns null when there is no earlier page', () => {
+    const lineA = makeLine({ id: 1, page: 1 });
+    const pages: Record<number, ScriptLine[]> = { 1: [lineA] };
+    const getPage = (page: number) => pages[page] ?? [];
+
+    expect(getPreviousLineAcrossPages(lineA, getPage)).toBeNull();
+  });
+});
+
+describe('needsActSceneLabel', () => {
+  const { needsActSceneLabel } = useScriptNavigation();
+
+  it('does not need a label when the previous line on the same page is the same act/scene', () => {
+    const lineA = makeLine({ id: 1, page: 1 });
+    const lineB = makeLine({ id: 2, page: 1 });
+    const pages: Record<number, ScriptLine[]> = { 1: [lineA, lineB] };
+    const getPage = (page: number) => pages[page] ?? [];
+
+    expect(needsActSceneLabel(lineB, lineA, [], getPage)).toBe(false);
+  });
+
+  it('does not need a label when the scene continues across a page boundary', () => {
+    const lineA = makeLine({ id: 1, page: 1 });
+    const lineB = makeLine({ id: 2, page: 2 });
+    const pages: Record<number, ScriptLine[]> = { 1: [lineA], 2: [lineB] };
+    const getPage = (page: number) => pages[page] ?? [];
+
+    expect(needsActSceneLabel(lineB, lineA, [], getPage)).toBe(false);
+  });
+
+  it('does not need a label when a spacing line sits exactly at the page boundary (regression case)', () => {
+    const lineA = makeLine({ id: 1, page: 1 });
+    const spacing = makeSpacingLine(2, 2);
+    const lineC = makeLine({ id: 3, page: 2 });
+    const pages: Record<number, ScriptLine[]> = { 1: [lineA], 2: [spacing, lineC] };
+    const getPage = (page: number) => pages[page] ?? [];
+
+    // previousLine as seen by lineC is the spacing line, which must be walked past,
+    // crossing back to page 1 to find the true same-scene previous line.
+    expect(needsActSceneLabel(lineC, spacing, [], getPage)).toBe(false);
+  });
+
+  it('needs a label when crossing pages lands on a genuinely different scene', () => {
+    const lineA = makeLine({ id: 1, page: 1, scene_id: 1 });
+    const lineB = makeLine({ id: 2, page: 2, scene_id: 2 });
+    const pages: Record<number, ScriptLine[]> = { 1: [lineA], 2: [lineB] };
+    const getPage = (page: number) => pages[page] ?? [];
+
+    expect(needsActSceneLabel(lineB, lineA, [], getPage)).toBe(true);
+  });
+
+  it('needs a label when there is no previous line at all', () => {
+    const lineA = makeLine({ id: 1, page: 1 });
+    const getPage = () => [];
+
+    expect(needsActSceneLabel(lineA, null, [], getPage)).toBe(true);
+  });
+});
+
+describe('needsHeadings', () => {
+  const { needsHeadings } = useScriptNavigation();
+
+  it('does not need a character heading when the same character continues across a page boundary', () => {
+    const lineA = makeLine({ id: 1, page: 1 });
+    const lineB = makeLine({ id: 2, page: 2 });
+    const pages: Record<number, ScriptLine[]> = { 1: [lineA], 2: [lineB] };
+    const getPage = (page: number) => pages[page] ?? [];
+
+    expect(needsHeadings(lineB, lineA, [], getPage)).toEqual([false]);
+  });
+
+  it('does not need a character heading when the same character continues past a spacing line at the page boundary (regression case)', () => {
+    const lineA = makeLine({ id: 1, page: 1 });
+    const spacing = makeSpacingLine(2, 2);
+    const lineC = makeLine({ id: 3, page: 2 });
+    const pages: Record<number, ScriptLine[]> = { 1: [lineA], 2: [spacing, lineC] };
+    const getPage = (page: number) => pages[page] ?? [];
+
+    expect(needsHeadings(lineC, spacing, [], getPage)).toEqual([false]);
+  });
+
+  it('needs a character heading when a spacing line at the page boundary hides a genuine character change', () => {
+    const lineA = makeLine({ id: 1, page: 1 });
+    const spacing = makeSpacingLine(2, 2);
+    const lineC = makeLine({ id: 3, page: 2 });
+    lineC.line_parts[0].character_id = 2;
+    const pages: Record<number, ScriptLine[]> = { 1: [lineA], 2: [spacing, lineC] };
+    const getPage = (page: number) => pages[page] ?? [];
+
+    expect(needsHeadings(lineC, spacing, [], getPage)).toEqual([true]);
+  });
+});

--- a/client-v3/src/composables/useScriptNavigation.ts
+++ b/client-v3/src/composables/useScriptNavigation.ts
@@ -10,6 +10,22 @@ function checkIsUntaggedStageDirection(line: ScriptLine): boolean {
   );
 }
 
+export function getPreviousLineAcrossPages(
+  current: ScriptLine,
+  getPage: (page: number) => ScriptLine[]
+): ScriptLine | null {
+  const page = getPage(current.page ?? 0);
+  const idx = page.indexOf(current);
+  if (idx > 0) return page[idx - 1];
+  let loopPageNo = (current.page ?? 0) - 1;
+  while (loopPageNo >= 1) {
+    const loopPage = getPage(loopPageNo);
+    if (loopPage.length > 0) return loopPage[loopPage.length - 1];
+    loopPageNo -= 1;
+  }
+  return null;
+}
+
 function needsActSceneLabel(
   line: ScriptLine,
   previousLine: ScriptLine | null,
@@ -18,9 +34,7 @@ function needsActSceneLabel(
 ): boolean {
   let prev: ScriptLine | null = previousLine;
   while (prev != null && isWholeLineCut(prev, cuts)) {
-    const prevPage = getPage(prev.page ?? 0);
-    const idx = prevPage.indexOf(prev);
-    prev = idx > 0 ? prevPage[idx - 1] : null;
+    prev = getPreviousLineAcrossPages(prev, getPage);
   }
   if (prev == null) return true;
   return !(prev.act_id === line.act_id && prev.scene_id === line.scene_id);
@@ -35,9 +49,7 @@ export function useScriptNavigation() {
   ): boolean[] {
     let prev: ScriptLine | null = previousLine;
     while (prev != null && (checkIsUntaggedStageDirection(prev) || isWholeLineCut(prev, cuts))) {
-      const prevPage = getPage(prev.page ?? 0);
-      const idx = prevPage.indexOf(prev);
-      prev = idx > 0 ? prevPage[idx - 1] : null;
+      prev = getPreviousLineAcrossPages(prev, getPage);
     }
 
     return line.line_parts.map((part) => {


### PR DESCRIPTION
## Summary
- The Act/Scene heading in the live show view (client-v3) could spuriously re-appear partway through a scene, whenever a cut/spacing line landed exactly at a page boundary
- Root cause: `useScriptNavigation.ts`'s walk-back-past-cut-lines logic was reimplemented during the Vue 3 migration using a single-page `Array.indexOf` lookup with no cross-page fallback, unlike the legacy Vue 2 mixins (`scriptNavigationMixin.ts`/`scriptDisplayMixin.ts`) which correctly cross page boundaries. When the walk-back reached the first line of a page it gave up instead of continuing into the previous page, so the act/scene continuity check spuriously failed
- Same bug was independently duplicated in the `needsIntervalBanner` computed in both `ScriptLineViewer.vue` and `ScriptLineViewerCompact.vue`
- Fix: added a shared `getPreviousLineAcrossPages` helper (mirroring V2's `getPreviousLineForIndex`) and used it at all 4 affected call sites

## Test plan
- [x] Added 12 unit tests in `client-v3/src/composables/useScriptNavigation.test.ts` covering the exact regression scenario (cut/spacing line at a page boundary, same-scene continuity, genuine scene changes, character heading changes)
- [x] `npm run test:run`, `npm run typecheck`, `npm run ci-lint` all pass in `client-v3`
- [x] Confirmed fixed against the live show that originally reproduced the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)