### PR TITLE
Add current cue footer to live show view

### DIFF
--- a/client-v3/e2e/tests/13-live-show.spec.ts
+++ b/client-v3/e2e/tests/13-live-show.spec.ts
@@ -79,6 +79,12 @@ test('leader is NOT in following mode', async () => {
   await expect(container).not.toHaveAttribute('data-following', 'true');
 });
 
+test('current cue footer is visible by default', async () => {
+  // toBeVisible() alone would pass even if the footer were pushed below the fold by
+  // the script pane's computed height — toBeInViewport() catches that layout regression.
+  await expect(leaderPage.locator('.current-cue-footer')).toBeInViewport();
+});
+
 // ── Follower connects ─────────────────────────────────────────────────────
 
 test('follower navigates to /live after leader', async () => {
@@ -146,6 +152,13 @@ test('can add an individual cue from the live view', async () => {
   });
 });
 
+test('current cue footer shows the last cue seen for its type', async () => {
+  await expect(leaderPage.locator('.current-cue-footer .cue-button')).toHaveCount(1, {
+    timeout: 5_000,
+  });
+  await expect(leaderPage.locator('.current-cue-footer .cue-button').first()).toContainText('101');
+});
+
 test('can add a cue group from the live view', async () => {
   await leaderPage.locator('.add-cue-btn').first().click();
   await waitForModal(leaderPage, 'Add Cue');
@@ -165,6 +178,14 @@ test('can add a cue group from the live view', async () => {
   await waitForModalClosed(leaderPage);
   await expect(leaderPage.locator('.cue-group-btn').first()).toBeVisible({ timeout: 5_000 });
   await expect(leaderPage.locator('.cue-group-btn').first()).toContainText('LX 200 - LX 202');
+});
+
+test('current cue footer still shows exactly one badge for the cue type after grouped cues are added', async () => {
+  // Grouped cues are tracked individually — the footer collapses to the single most
+  // recently passed cue of that type, whichever one that ends up being.
+  await expect(leaderPage.locator('.current-cue-footer .cue-button')).toHaveCount(1, {
+    timeout: 5_000,
+  });
 });
 
 test('cue group buttons in live view are non-interactive display-only buttons', async () => {

--- a/client-v3/e2e/tests/14-user-settings.spec.ts
+++ b/client-v3/e2e/tests/14-user-settings.spec.ts
@@ -63,6 +63,28 @@ test('changing a toggle enables the Submit button', async () => {
   }
 });
 
+test('current cue footer setting defaults on and persists after being toggled off', async () => {
+  const checkbox = page.locator('#show-current-cue-footer-input');
+  await expect(checkbox).toBeChecked();
+
+  await checkbox.click();
+  await expect(checkbox).not.toBeChecked();
+  await page.click('button:has-text("Submit")');
+  await expect(page.locator('button:has-text("Submit")')).toBeDisabled({ timeout: 5_000 });
+
+  await page.reload();
+  await waitForAppReady(page);
+  await page.click('.nav-link:has-text("Settings"), button[role="tab"]:has-text("Settings")');
+  await expect(page.locator('#show-current-cue-footer-input')).not.toBeChecked({
+    timeout: 5_000,
+  });
+
+  // Restore default state so it doesn't affect any later tests
+  await page.locator('#show-current-cue-footer-input').click();
+  await page.click('button:has-text("Submit")');
+  await expect(page.locator('#show-current-cue-footer-input')).toBeChecked({ timeout: 5_000 });
+});
+
 // ── Stage Direction Styles ────────────────────────────────────────────────
 
 test('creates a stage direction style for override testing', async () => {

--- a/client-v3/src/components/show/live/CurrentCueFooter.vue
+++ b/client-v3/src/components/show/live/CurrentCueFooter.vue
@@ -1,0 +1,58 @@
+<template>
+  <BRow id="current-cue-footer" class="current-cue-footer">
+    <BCol class="d-flex flex-wrap align-items-center gap-2">
+      <b>Current Cues:</b>
+      <BButtonGroup v-if="currentCues.length > 0" class="flex-wrap">
+        <BButton
+          v-for="cue in currentCues"
+          :key="cue.id"
+          class="cue-button"
+          :style="{
+            backgroundColor: cueBackgroundColour(cue),
+            color: contrastColor(cueBackgroundColour(cue)),
+          }"
+        >
+          {{ cueLabel(cue) }}
+        </BButton>
+      </BButtonGroup>
+      <span v-else class="text-muted">No cues called yet</span>
+    </BCol>
+  </BRow>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useCueDisplay } from '@/composables/useCueDisplay';
+import { useScriptStore } from '@/stores/script';
+import { useShowStore } from '@/stores/show';
+import type { Cue } from '@/types/api/cues';
+
+const props = defineProps<{
+  currentPage: number;
+  currentLineOnPage: number;
+}>();
+
+const scriptStore = useScriptStore();
+const showStore = useShowStore();
+const { cueLabel, cueBackgroundColour, contrastColor } = useCueDisplay();
+
+const currentCues = computed<Cue[]>(() => {
+  const lastPerType = scriptStore.lastCuePerTypeAt(props.currentPage, props.currentLineOnPage);
+  return showStore.cueTypes
+    .map((cueType) => lastPerType[cueType.id])
+    .filter((cue): cue is Cue => cue != null);
+});
+</script>
+
+<style scoped>
+.current-cue-footer {
+  border-top: 0.1rem solid #3498db;
+  padding-top: 0.3rem;
+  padding-bottom: 0.3rem;
+  margin: 0;
+}
+
+.cue-button {
+  padding: 0.2rem;
+}
+</style>

--- a/client-v3/src/components/show/live/ScriptViewPane.vue
+++ b/client-v3/src/components/show/live/ScriptViewPane.vue
@@ -263,10 +263,12 @@ const props = defineProps<{
   intervalActive: boolean;
   scriptMode: number;
   stageManagerMode: boolean;
+  showCurrentCueFooter: boolean;
 }>();
 
 const emit = defineEmits<{
   'page-change': [page: number];
+  'current-line-change': [lineOnPage: number];
   'script-loaded': [];
 }>();
 
@@ -479,6 +481,7 @@ function navigateTo(targetPage: number, targetLineOnPage: number, preventScroll 
   currentPage.value = targetPage;
   currentLineOnPage.value = targetLineOnPage;
   emit('page-change', targetPage);
+  emit('current-line-change', targetLineOnPage);
 
   const targetElementId = `page_${targetPage}_line_${targetLineOnPage}`;
   const targetElement = document.getElementById(targetElementId);
@@ -660,7 +663,9 @@ function handleFollowDataChange(): void {
       scrollToElement(contextElement ?? currentLineElement);
 
       currentPage.value = page;
+      currentLineOnPage.value = line;
       emit('page-change', page);
+      emit('current-line-change', line);
       computeScriptBoundaries();
     }
   }
@@ -713,10 +718,24 @@ function computeScriptBoundaries(): void {
 function computeContentSize(): void {
   const scriptContainer = document.getElementById('script-container');
   if (!scriptContainer) return;
+  const footer = document.getElementById('current-cue-footer');
+  const footerHeight = footer ? footer.getBoundingClientRect().height : 0;
   const startPos = scriptContainer.getBoundingClientRect().top;
-  const boxHeight = document.documentElement.clientHeight - startPos;
+  const boxHeight = document.documentElement.clientHeight - startPos - footerHeight;
   scriptContainer.style.height = `${boxHeight - 10}px`;
   computeScriptBoundaries();
+}
+
+let footerResizeObserver: ResizeObserver | null = null;
+
+function observeFooterResize(): void {
+  footerResizeObserver?.disconnect();
+  footerResizeObserver = null;
+  const footer = document.getElementById('current-cue-footer');
+  if (footer) {
+    footerResizeObserver = new ResizeObserver(() => debounceContentSize());
+    footerResizeObserver.observe(footer);
+  }
 }
 
 // --- Script loading ---
@@ -909,6 +928,7 @@ onMounted(async () => {
   ]);
 
   computeContentSize();
+  observeFooterResize();
 
   const loadedCompiledScript = await loadCompiledScript();
 
@@ -945,7 +965,17 @@ onMounted(async () => {
   emit('script-loaded');
 });
 
+watch(
+  () => props.showCurrentCueFooter,
+  async () => {
+    await nextTick();
+    computeContentSize();
+    observeFooterResize();
+  }
+);
+
 onUnmounted(() => {
+  footerResizeObserver?.disconnect();
   window.removeEventListener('keydown', handleKeyPress);
   const scriptContainer = document.getElementById('script-container');
   if (scriptContainer) {

--- a/client-v3/src/components/user/settings/UserSettingsConfig.vue
+++ b/client-v3/src/components/user/settings/UserSettingsConfig.vue
@@ -107,6 +107,19 @@
               />
             </BFormGroup>
 
+            <BFormGroup
+              label-cols="4"
+              label="Show current cue footer in Live view"
+              label-for="show-current-cue-footer-input"
+            >
+              <BFormCheckbox
+                id="show-current-cue-footer-input"
+                v-model="state.show_current_cue_footer"
+                name="show-current-cue-footer-input"
+                switch
+              />
+            </BFormGroup>
+
             <BFormGroup label-cols="4" label="Preferred UI Version" label-for="preferred-ui-input">
               <BFormSelect
                 id="preferred-ui-input"
@@ -160,6 +173,7 @@ const defaultState = (): UserSettings => ({
   character_mru_sort: false,
   character_combined_dropdown: false,
   preferred_ui: null,
+  show_current_cue_footer: true,
 });
 
 const state = ref<UserSettings>(defaultState());
@@ -200,6 +214,7 @@ const rules = computed(() => ({
   character_mru_sort: {},
   character_combined_dropdown: {},
   preferred_ui: {},
+  show_current_cue_footer: {},
 }));
 
 const v$ = useVuelidate(rules, state);

--- a/client-v3/src/stores/script.test.ts
+++ b/client-v3/src/stores/script.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import type { ScriptLine } from '@/types/api/script';
+import type { Cue } from '@/types/api/cues';
+import { useScriptStore } from './script';
+
+function makeLine(id: number): ScriptLine {
+  return {
+    id,
+    act_id: 1,
+    scene_id: 1,
+    page: 1,
+    line_type: 1,
+    stage_direction_style_id: null,
+    line_parts: [],
+  };
+}
+
+function makeCue(id: number, cueTypeId: number, linePosition: number | null = 0): Cue {
+  return {
+    id,
+    cue_type_id: cueTypeId,
+    ident: String(id),
+    group_id: null,
+    sort_order: null,
+    line_position: linePosition,
+  };
+}
+
+describe('script store cue tracking getters', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('builds a line order index across pages', () => {
+    const store = useScriptStore();
+    store.script = {
+      '1': [makeLine(10), makeLine(11)],
+      '2': [makeLine(20)],
+    };
+
+    const index = store.lineOrderIndex;
+
+    expect(index.get(10)).toEqual({ page: 1, index: 0 });
+    expect(index.get(11)).toEqual({ page: 1, index: 1 });
+    expect(index.get(20)).toEqual({ page: 2, index: 0 });
+  });
+
+  it('returns the last cue per cue type at or before the given position', () => {
+    const store = useScriptStore();
+    store.script = {
+      '1': [makeLine(10), makeLine(11)],
+      '2': [makeLine(20), makeLine(21)],
+    };
+    store.cues = {
+      '10': [makeCue(1, 100), makeCue(2, 200)],
+      '11': [makeCue(3, 100)],
+      '20': [makeCue(4, 200)],
+      '21': [makeCue(5, 100)],
+    };
+
+    // Position at page 1, line index 1 (line 11): cue type 100 -> cue 3, type 200 -> cue 2
+    const atLine11 = store.lastCuePerTypeAt(1, 1);
+    expect(atLine11[100].id).toBe(3);
+    expect(atLine11[200].id).toBe(2);
+
+    // Position at page 2, line index 0 (line 20): type 100 still cue 3 (last passed), type 200 -> cue 4
+    const atLine20 = store.lastCuePerTypeAt(2, 0);
+    expect(atLine20[100].id).toBe(3);
+    expect(atLine20[200].id).toBe(4);
+
+    // Position at page 2, line index 1 (line 21): type 100 -> cue 5 (overtakes cue 3)
+    const atLine21 = store.lastCuePerTypeAt(2, 1);
+    expect(atLine21[100].id).toBe(5);
+    expect(atLine21[200].id).toBe(4);
+  });
+
+  it('ignores cues on lines not yet in the line order index', () => {
+    const store = useScriptStore();
+    store.script = { '1': [makeLine(10)] };
+    store.cues = { '999': [makeCue(1, 100)] };
+
+    const result = store.lastCuePerTypeAt(1, 0);
+
+    expect(result).toEqual({});
+  });
+
+  it('breaks ties on the same line using line_position', () => {
+    const store = useScriptStore();
+    store.script = { '1': [makeLine(10)] };
+    store.cues = {
+      '10': [makeCue(1, 100, 0), makeCue(2, 100, 5)],
+    };
+
+    const result = store.lastCuePerTypeAt(1, 0);
+
+    expect(result[100].id).toBe(2);
+  });
+});

--- a/client-v3/src/stores/script.ts
+++ b/client-v3/src/stores/script.ts
@@ -93,6 +93,46 @@ export const useScriptStore = defineStore('script', {
         });
         return { individual, groups, merged };
       },
+    lineOrderIndex(state): Map<number, { page: number; index: number }> {
+      const index = new Map<number, { page: number; index: number }>();
+      for (const [pageStr, lines] of Object.entries(state.script)) {
+        const page = Number(pageStr);
+        lines.forEach((line, lineIndex) => {
+          if (line.id != null) index.set(line.id, { page, index: lineIndex });
+        });
+      }
+      return index;
+    },
+    orderedCueEntries(state): { cue: Cue; page: number; index: number }[] {
+      const order = this.lineOrderIndex;
+      const entries: { cue: Cue; page: number; index: number }[] = [];
+      for (const [lineIdStr, cuesForLine] of Object.entries(state.cues)) {
+        const position = order.get(Number(lineIdStr));
+        if (!position) continue;
+        for (const cue of cuesForLine) {
+          entries.push({ cue, page: position.page, index: position.index });
+        }
+      }
+      entries.sort((a, b) => {
+        if (a.page !== b.page) return a.page - b.page;
+        if (a.index !== b.index) return a.index - b.index;
+        return (a.cue.line_position ?? 0) - (b.cue.line_position ?? 0);
+      });
+      return entries;
+    },
+    lastCuePerTypeAt(): (page: number, lineIndex: number) => Record<number, Cue> {
+      const entries = this.orderedCueEntries;
+      return (page: number, lineIndex: number): Record<number, Cue> => {
+        const result: Record<number, Cue> = {};
+        for (const entry of entries) {
+          if (entry.page > page || (entry.page === page && entry.index > lineIndex)) break;
+          if (entry.cue.cue_type_id != null) {
+            result[entry.cue.cue_type_id] = entry.cue;
+          }
+        }
+        return result;
+      };
+    },
   },
 
   actions: {

--- a/client-v3/src/types/api/user.ts
+++ b/client-v3/src/types/api/user.ts
@@ -27,4 +27,5 @@ export interface UserSettings {
   table_page_sizes: Record<string, number> | null;
   default_sd_text_colour: string | null;
   default_sd_background_colour: string | null;
+  show_current_cue_footer: boolean;
 }

--- a/client-v3/src/views/show/ShowLiveView.vue
+++ b/client-v3/src/views/show/ShowLiveView.vue
@@ -59,7 +59,9 @@
             :interval-active="showStore.currentInterval != null"
             :script-mode="systemStore.currentShow?.script_mode ?? 1"
             :stage-manager-mode="showStore.stageManagerMode"
+            :show-current-cue-footer="userStore.userSettings?.show_current_cue_footer ?? false"
             @page-change="currentPage = $event"
+            @current-line-change="currentLineOnPage = $event"
           />
         </Pane>
         <Pane v-if="showStore.stageManagerMode" :size="20">
@@ -67,6 +69,11 @@
         </Pane>
       </Splitpanes>
     </BOverlay>
+    <CurrentCueFooter
+      v-if="userStore.userSettings?.show_current_cue_footer"
+      :current-page="currentPage"
+      :current-line-on-page="currentLineOnPage"
+    />
   </BContainer>
 </template>
 
@@ -78,20 +85,24 @@ import 'splitpanes/dist/splitpanes.css';
 import { formatTimerParts, msToTimerParts, msToTimerString } from '@/js/utils';
 import { useShowStore } from '@/stores/show';
 import { useSystemStore } from '@/stores/system';
+import { useUserStore } from '@/stores/user';
 import { useWebSocketStore } from '@/stores/websocket';
 import { useWebSocket } from '@/composables/useWebSocket';
 import { toast } from '@/js/toast';
 import ScriptViewPane from '@/components/show/live/ScriptViewPane.vue';
 import StageManagerPane from '@/components/show/live/StageManagerPane.vue';
+import CurrentCueFooter from '@/components/show/live/CurrentCueFooter.vue';
 
 const showStore = useShowStore();
 const systemStore = useSystemStore();
+const userStore = useUserStore();
 const wsStore = useWebSocketStore();
 const { sendObj } = useWebSocket();
 
 // Session header state
 const loadedSessionData = ref(false);
 const currentPage = ref(1);
+const currentLineOnPage = ref(0);
 
 // Elapsed time
 const elapsedTime = ref(0);

--- a/client/src/store/modules/script.test.ts
+++ b/client/src/store/modules/script.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import Vue from 'vue';
+import Vuex from 'vuex';
+import type { ScriptLine } from '@/types/api/script';
+import type { Cue } from '@/types/api/cues';
+import scriptModule from './script';
+
+Vue.use(Vuex);
+
+function makeLine(id: number): ScriptLine {
+  return {
+    id,
+    act_id: 1,
+    scene_id: 1,
+    page: 1,
+    line_type: 1,
+    stage_direction_style_id: null,
+    line_parts: [],
+  };
+}
+
+function makeCue(id: number, cueTypeId: number, linePosition: number | null = 0): Cue {
+  return {
+    id,
+    cue_type_id: cueTypeId,
+    ident: String(id),
+    group_id: null,
+    sort_order: null,
+    line_position: linePosition,
+  };
+}
+
+function makeStore() {
+  return new Vuex.Store({
+    modules: {
+      script: { ...scriptModule, namespaced: true },
+    },
+  });
+}
+
+describe('script module cue tracking getters', () => {
+  it('builds a line order index across pages', () => {
+    const store = makeStore();
+    store.replaceState({
+      script: { script: { '1': [makeLine(10), makeLine(11)], '2': [makeLine(20)] } },
+    } as any);
+
+    const index = store.getters['script/LINE_ORDER_INDEX'];
+
+    expect(index.get(10)).toEqual({ page: 1, index: 0 });
+    expect(index.get(11)).toEqual({ page: 1, index: 1 });
+    expect(index.get(20)).toEqual({ page: 2, index: 0 });
+  });
+
+  it('returns the last cue per cue type at or before the given position', () => {
+    const store = makeStore();
+    store.replaceState({
+      script: {
+        script: { '1': [makeLine(10), makeLine(11)], '2': [makeLine(20), makeLine(21)] },
+        cues: {
+          '10': [makeCue(1, 100), makeCue(2, 200)],
+          '11': [makeCue(3, 100)],
+          '20': [makeCue(4, 200)],
+          '21': [makeCue(5, 100)],
+        },
+      },
+    } as any);
+
+    const atLine11 = store.getters['script/LAST_CUE_PER_TYPE_AT'](1, 1);
+    expect(atLine11[100].id).toBe(3);
+    expect(atLine11[200].id).toBe(2);
+
+    const atLine20 = store.getters['script/LAST_CUE_PER_TYPE_AT'](2, 0);
+    expect(atLine20[100].id).toBe(3);
+    expect(atLine20[200].id).toBe(4);
+
+    const atLine21 = store.getters['script/LAST_CUE_PER_TYPE_AT'](2, 1);
+    expect(atLine21[100].id).toBe(5);
+    expect(atLine21[200].id).toBe(4);
+  });
+
+  it('ignores cues on lines not yet in the line order index', () => {
+    const store = makeStore();
+    store.replaceState({
+      script: {
+        script: { '1': [makeLine(10)] },
+        cues: { '999': [makeCue(1, 100)] },
+      },
+    } as any);
+
+    expect(store.getters['script/LAST_CUE_PER_TYPE_AT'](1, 0)).toEqual({});
+  });
+
+  it('breaks ties on the same line using line_position', () => {
+    const store = makeStore();
+    store.replaceState({
+      script: {
+        script: { '1': [makeLine(10)] },
+        cues: { '10': [makeCue(1, 100, 0), makeCue(2, 100, 5)] },
+      },
+    } as any);
+
+    expect(store.getters['script/LAST_CUE_PER_TYPE_AT'](1, 0)[100].id).toBe(2);
+  });
+});

--- a/client/src/store/modules/script.ts
+++ b/client/src/store/modules/script.ts
@@ -486,6 +486,53 @@ const module: Module<ScriptState, RootState> = {
         });
         return { individual, groups, merged };
       },
+    LINE_ORDER_INDEX(state: ScriptState): Map<number, { page: number; index: number }> {
+      const index = new Map<number, { page: number; index: number }>();
+      for (const [pageStr, lines] of Object.entries(state.script)) {
+        const page = Number(pageStr);
+        lines.forEach((line, lineIndex) => {
+          if (line.id != null) index.set(line.id, { page, index: lineIndex });
+        });
+      }
+      return index;
+    },
+    ORDERED_CUE_ENTRIES(
+      state: ScriptState,
+      getters: any
+    ): { cue: Cue; page: number; index: number }[] {
+      const order = getters.LINE_ORDER_INDEX as Map<number, { page: number; index: number }>;
+      const entries: { cue: Cue; page: number; index: number }[] = [];
+      for (const [lineIdStr, cuesForLine] of Object.entries(state.cues)) {
+        const position = order.get(Number(lineIdStr));
+        if (!position) continue;
+        for (const cue of cuesForLine) {
+          entries.push({ cue, page: position.page, index: position.index });
+        }
+      }
+      entries.sort((a, b) => {
+        if (a.page !== b.page) return a.page - b.page;
+        if (a.index !== b.index) return a.index - b.index;
+        return (a.cue.line_position ?? 0) - (b.cue.line_position ?? 0);
+      });
+      return entries;
+    },
+    LAST_CUE_PER_TYPE_AT:
+      (_state: ScriptState, getters: any) =>
+      (page: number, lineIndex: number): Record<number, Cue> => {
+        const entries = getters.ORDERED_CUE_ENTRIES as {
+          cue: Cue;
+          page: number;
+          index: number;
+        }[];
+        const result: Record<number, Cue> = {};
+        for (const entry of entries) {
+          if (entry.page > page || (entry.page === page && entry.index > lineIndex)) break;
+          if (entry.cue.cue_type_id != null) {
+            result[entry.cue.cue_type_id] = entry.cue;
+          }
+        }
+        return result;
+      },
     SCRIPT_CUTS(state: ScriptState) {
       return state.cuts;
     },

--- a/client/src/types/api/user.ts
+++ b/client/src/types/api/user.ts
@@ -26,4 +26,5 @@ export interface UserSettings {
   table_page_sizes: Record<string, number> | null;
   default_sd_text_colour: string | null;
   default_sd_background_colour: string | null;
+  show_current_cue_footer: boolean;
 }

--- a/client/src/views/show/ShowLiveView.vue
+++ b/client/src/views/show/ShowLiveView.vue
@@ -66,7 +66,9 @@
             :interval-active="CURRENT_SHOW_INTERVAL != null"
             :script-mode="CURRENT_SHOW?.script_mode || 1"
             :stage-manager-mode="stageManagerMode"
+            :show-current-cue-footer="!!USER_SETTINGS.show_current_cue_footer"
             @page-change="currentPage = $event"
+            @current-line-change="currentLineOnPage = $event"
           />
         </split-pane>
         <split-pane v-if="stageManagerMode" :size="20">
@@ -74,6 +76,12 @@
         </split-pane>
       </split-panes>
     </b-overlay>
+    <current-cue-footer
+      v-if="USER_SETTINGS.show_current_cue_footer"
+      :current-page="currentPage"
+      :current-line-on-page="currentLineOnPage"
+      :cue-types="CUE_TYPES"
+    />
   </b-container>
 </template>
 
@@ -84,12 +92,14 @@ import { mapGetters, mapActions } from 'vuex';
 import { formatTimerParts, msToTimerParts, msToTimerString } from '@/js/utils';
 import ScriptViewPane from '@/vue_components/show/live/ScriptViewPane.vue';
 import StageManagerPane from '@/vue_components/show/live/StageManagerPane.vue';
+import CurrentCueFooter from '@/vue_components/show/live/CurrentCueFooter.vue';
 
 export default defineComponent({
   name: 'ShowLiveView',
   components: {
     ScriptViewPane,
     StageManagerPane,
+    CurrentCueFooter,
   },
   data() {
     return {
@@ -98,6 +108,7 @@ export default defineComponent({
       startTime: null as Date | null,
       loadedSessionData: false,
       currentPage: 1,
+      currentLineOnPage: 0,
       intervalTimer: null as ReturnType<typeof setInterval> | null,
       intervalStartDate: null as Date | null,
       isIntervalLong: false,
@@ -158,6 +169,8 @@ export default defineComponent({
       'INTERNAL_UUID',
       'SESSION_FOLLOW_DATA',
       'CURRENT_SHOW_INTERVAL',
+      'USER_SETTINGS',
+      'CUE_TYPES',
     ]),
     ...mapGetters({
       stageManagerMode: 'STAGE_MANAGER_MODE',

--- a/client/src/vue_components/show/live/CurrentCueFooter.vue
+++ b/client/src/vue_components/show/live/CurrentCueFooter.vue
@@ -1,0 +1,72 @@
+<template>
+  <b-row id="current-cue-footer" class="current-cue-footer">
+    <b-col class="d-flex flex-wrap align-items-center" style="gap: 0.5rem">
+      <b>Current Cues:</b>
+      <b-button-group v-if="currentCues.length > 0" class="flex-wrap">
+        <b-button
+          v-for="cue in currentCues"
+          :key="cue.id"
+          class="cue-button"
+          :style="{
+            backgroundColor: cueBackgroundColour(cue),
+            color: contrastColor({ bgColor: cueBackgroundColour(cue) }),
+          }"
+        >
+          {{ cueLabel(cue) }}
+        </b-button>
+      </b-button-group>
+      <span v-else class="text-muted">No cues called yet</span>
+    </b-col>
+  </b-row>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { mapGetters } from 'vuex';
+import cueDisplayMixin from '@/mixins/cueDisplayMixin';
+import type { Cue } from '@/types/api/cues';
+
+export default defineComponent({
+  name: 'CurrentCueFooter',
+  mixins: [cueDisplayMixin],
+  props: {
+    currentPage: {
+      required: true,
+      type: Number,
+    },
+    currentLineOnPage: {
+      required: true,
+      type: Number,
+    },
+    cueTypes: {
+      required: true,
+      type: Array,
+    },
+  },
+  computed: {
+    ...mapGetters(['LAST_CUE_PER_TYPE_AT']),
+    currentCues(): Cue[] {
+      const lastPerType = (this as any).LAST_CUE_PER_TYPE_AT(
+        this.currentPage,
+        this.currentLineOnPage
+      );
+      return (this.cueTypes as any[])
+        .map((cueType) => lastPerType[cueType.id])
+        .filter((cue): cue is Cue => cue != null);
+    },
+  },
+});
+</script>
+
+<style scoped>
+.current-cue-footer {
+  border-top: 0.1rem solid #3498db;
+  padding-top: 0.3rem;
+  padding-bottom: 0.3rem;
+  margin: 0;
+}
+
+.cue-button {
+  padding: 0.2rem;
+}
+</style>

--- a/client/src/vue_components/show/live/ScriptViewPane.vue
+++ b/client/src/vue_components/show/live/ScriptViewPane.vue
@@ -250,6 +250,10 @@ export default defineComponent({
       type: Boolean,
       required: true,
     },
+    showCurrentCueFooter: {
+      type: Boolean,
+      required: true,
+    },
   },
   data() {
     return {
@@ -398,7 +402,9 @@ export default defineComponent({
             this.scrollToElement(currentLineElement);
           }
           this.currentPage = page;
+          this.currentLineOnPage = line;
           this.$emit('page-change', page);
+          this.$emit('current-line-change', line);
           this.computeScriptBoundaries();
         }
       }
@@ -408,6 +414,12 @@ export default defineComponent({
         if (this.initialLoad) {
           this.resumeNavigation();
         }
+      });
+    },
+    showCurrentCueFooter(): void {
+      this.$nextTick(() => {
+        this.computeContentSize();
+        this.observeFooterResize();
       });
     },
   },
@@ -437,6 +449,7 @@ export default defineComponent({
     ]);
 
     this.computeContentSize();
+    this.observeFooterResize();
 
     const loadedCompiledScript = await this.loadCompiledScript();
 
@@ -495,6 +508,7 @@ export default defineComponent({
     this.$emit('script-loaded');
   },
   destroyed(): void {
+    (this as any).footerResizeObserver?.disconnect();
     this.removeNavigation();
     window.removeEventListener('resize', this.debounceContentSize);
   },
@@ -529,6 +543,7 @@ export default defineComponent({
       this.currentPage = targetPage;
       this.currentLineOnPage = targetLineOnPage;
       this.$emit('page-change', targetPage);
+      this.$emit('current-line-change', targetLineOnPage);
 
       const targetElementId = `page_${targetPage}_line_${targetLineOnPage}`;
       const targetElement = document.getElementById(targetElementId);
@@ -902,10 +917,21 @@ export default defineComponent({
     },
     computeContentSize() {
       const scriptContainer = $('#script-container');
+      const footer = $('#current-cue-footer');
+      const footerHeight = footer.length > 0 ? (footer.outerHeight() ?? 0) : 0;
       const startPos = scriptContainer.offset().top;
-      const boxHeight = document.documentElement.clientHeight - startPos;
+      const boxHeight = document.documentElement.clientHeight - startPos - footerHeight;
       scriptContainer.height(boxHeight - 10);
       this.computeScriptBoundaries();
+    },
+    observeFooterResize() {
+      (this as any).footerResizeObserver?.disconnect();
+      (this as any).footerResizeObserver = null;
+      const footer = document.getElementById('current-cue-footer');
+      if (footer) {
+        (this as any).footerResizeObserver = new ResizeObserver(() => this.debounceContentSize());
+        (this as any).footerResizeObserver.observe(footer);
+      }
     },
 
     // Line/cue helpers

--- a/client/src/vue_components/user/settings/Settings.vue
+++ b/client/src/vue_components/user/settings/Settings.vue
@@ -104,6 +104,18 @@
               </b-form-group>
               <b-form-group
                 :label-cols="true"
+                label="Show current cue footer in Live view"
+                label-for="show-current-cue-footer-input"
+              >
+                <b-form-checkbox
+                  id="show-current-cue-footer-input"
+                  v-model="$v.editSettings.show_current_cue_footer.$model"
+                  name="show-current-cue-footer-input"
+                  :switch="true"
+                />
+              </b-form-group>
+              <b-form-group
+                :label-cols="true"
                 label="Preferred UI Version"
                 label-for="preferred-ui-input"
               >
@@ -155,6 +167,7 @@ export default defineComponent({
         character_mru_sort: false,
         character_combined_dropdown: false,
         preferred_ui: null as string | null,
+        show_current_cue_footer: true,
       },
       textAlignmentOptions: [
         { value: TEXT_ALIGNMENT.LEFT, text: 'Left' },
@@ -207,6 +220,7 @@ export default defineComponent({
       character_mru_sort: {},
       character_combined_dropdown: {},
       preferred_ui: { isValidUi: (val: unknown) => val === null || val === 'old' || val === 'new' },
+      show_current_cue_footer: {},
     },
   },
   mounted(): void {

--- a/docs/pages/live_show.md
+++ b/docs/pages/live_show.md
@@ -51,6 +51,12 @@ All other connected clients (whether logged in or not) will automatically follow
 #### Manual Mode
 If the leader's client becomes disconnected, all other clients become "orphaned" and switch to manual mode, where they can control their own script position independently. When a client logged in as the leader user reconnects, it automatically resumes leadership, and all orphaned clients return to follower mode.
 
+### Current Cue Footer
+
+A "Current Cues" footer bar at the bottom of the script area shows the last cue that has been passed for every cue type, updating automatically as the script scrolls. This gives a quick "where are we" reference without needing to keep the script's cue column in view. Cues are displayed using the same colours and labels as they appear in the script itself.
+
+The footer is shown by default, but it can be turned off independently by each user from the **Settings** tab of the User Settings page (**Show current cue footer in Live view**). The preference is saved to your account and persists across sessions and devices.
+
 ### Act Intervals
 
 If your show has intervals configured between acts, an interval screen will automatically appear between the acts during the live show. The interval will only display if there is script content in both acts surrounding the interval.

--- a/server/alembic_config/versions/e96bdd11ca42_add_show_current_cue_footer_user_setting.py
+++ b/server/alembic_config/versions/e96bdd11ca42_add_show_current_cue_footer_user_setting.py
@@ -1,0 +1,44 @@
+"""Add show_current_cue_footer user setting
+
+Revision ID: e96bdd11ca42
+Revises: f1974e4e57d0
+Create Date: 2026-07-09 12:28:26.922816
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e96bdd11ca42"
+down_revision: Union[str, None] = "f1974e4e57d0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add column as nullable first so existing rows can be backfilled
+    with op.batch_alter_table("user_settings", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("show_current_cue_footer", sa.Boolean(), nullable=True)
+        )
+
+    # Backfill existing rows to True (feature defaults to on)
+    op.execute(
+        "UPDATE user_settings SET show_current_cue_footer = 1 "
+        "WHERE show_current_cue_footer IS NULL"
+    )
+
+    # Make column non-nullable
+    with op.batch_alter_table("user_settings", schema=None) as batch_op:
+        batch_op.alter_column(
+            "show_current_cue_footer", existing_type=sa.Boolean(), nullable=False
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("user_settings", schema=None) as batch_op:
+        batch_op.drop_column("show_current_cue_footer")

--- a/server/models/user.py
+++ b/server/models/user.py
@@ -102,6 +102,7 @@ class UserSettings(db.Model):
     table_page_sizes: Mapped[dict | None] = mapped_column(JSON, default=None)
     default_sd_text_colour: Mapped[str | None] = mapped_column(default=None)
     default_sd_background_colour: Mapped[str | None] = mapped_column(default=None)
+    show_current_cue_footer: Mapped[bool] = mapped_column(default=True)
 
     __table_args__ = (
         CheckConstraint(


### PR DESCRIPTION
## Summary
- Adds a "Current Cues" footer below the script pane in the live show view, showing the last cue passed for every cue type (using the same badge styling as the script's cue column), updating as the script scrolls for both leader and follower clients.
- Toggleable per user via a new **Show current cue footer in Live view** setting on the User Settings page (Settings tab), defaulting to on, synced via the existing PATCH + WS `GET_USER_SETTINGS` round-trip.
- Fixes `ScriptViewPane.vue`'s JS-computed pane height to account for the new footer (previously it claimed the entire viewport, which would have pushed the footer off-screen); wired a `ResizeObserver` + prop watcher so sizing stays correct as the footer grows or is toggled.

## Test plan
- [x] `pytest` (server) — 704 passed
- [x] `npm run typecheck` / `npm run lint` (client-v3) — clean
- [x] `npm run test:run` (client-v3) — 39 passed, incl. new coverage for the cue-ordering store getters
- [x] `npm run test:e2e` (client-v3, full suite) — 221 passed, incl. new coverage for footer visibility (`toBeInViewport`), cue tracking, and settings persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)