### PR TITLE
[npm] Bump @types/node to ^26.1.1 across client, client-v3, electron

### DIFF
--- a/client-v3/package-lock.json
+++ b/client-v3/package-lock.json
@@ -39,7 +39,7 @@
         "@iconify-json/mdi": "^1.2.3",
         "@playwright/test": "^1.61.1",
         "@types/lodash": "~4.17.24",
-        "@types/node": ">=22.12.0",
+        "@types/node": "^26.1.1",
         "@typescript-eslint/eslint-plugin": "^8.63.0",
         "@typescript-eslint/parser": "^8.63.0",
         "@vitejs/plugin-vue": "^6.0.7",

--- a/client-v3/package.json
+++ b/client-v3/package.json
@@ -61,7 +61,7 @@
     "@eslint/js": "^10.0.1",
     "@iconify-json/mdi": "^1.2.3",
     "@types/lodash": "~4.17.24",
-    "@types/node": ">=22.12.0",
+    "@types/node": "^26.1.1",
     "@typescript-eslint/eslint-plugin": "^8.63.0",
     "@typescript-eslint/parser": "^8.63.0",
     "@vitejs/plugin-vue": "^6.0.7",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -36,7 +36,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.2",
         "@types/lodash": "~4.17.24",
-        "@types/node": "~20.14.0",
+        "@types/node": "^26.1.1",
         "@types/vuelidate": "^0.7.22",
         "@typescript-eslint/eslint-plugin": "^8.63.0",
         "@typescript-eslint/parser": "^8.63.0",
@@ -1820,13 +1820,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.14.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.15.tgz",
-      "integrity": "sha512-Fz1xDMCF/B00/tYSVMlmK7hVeLh7jE5f3B7X1/hmV0MJBwE27KlS7EvD/Yp+z1lm8mVhwV5w+n8jOZG8AfTlKw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -4985,9 +4985,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/client/package.json
+++ b/client/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@types/lodash": "~4.17.24",
-    "@types/node": "~20.14.0",
+    "@types/node": "^26.1.1",
     "@types/vuelidate": "^0.7.22",
     "@typescript-eslint/eslint-plugin": "^8.63.0",
     "@typescript-eslint/parser": "^8.63.0",

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -19,7 +19,7 @@
         "@electron-forge/maker-squirrel": "^7.11.2",
         "@electron-forge/maker-zip": "^7.11.2",
         "@eslint/js": "^9.39.2",
-        "@types/node": "^22.0.0",
+        "@types/node": "^26.1.1",
         "@typescript-eslint/eslint-plugin": "^8.63.0",
         "@typescript-eslint/parser": "^8.63.0",
         "electron": "^40.6.1",
@@ -1090,6 +1090,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/@inquirer/core/node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@inquirer/editor": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-3.0.1.tgz",
@@ -1547,13 +1564,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.20.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
-      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/responselike": {
@@ -3691,32 +3708,6 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -7816,9 +7807,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -2337,9 +2337,9 @@
       "license": "MIT"
     },
     "node_modules/bonjour-service": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.2.tgz",
-      "integrity": "sha512-lMskhnsW70yWHr4PhPeh2rvaIkLSaDpp+nmtbXBZaNKTXwxL73QOkW6HhbzqTImXjevn9TreGT4GACGBCGP9nQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.3.tgz",
+      "integrity": "sha512-2Kd5UYlFUVgAKMTyuBLl6w49wqfOnbxHqmuH0oCl/n7TfAikR0zoowNOP5BU4dfXmm+Vr9JyEN370auSMx+CNg==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3708,6 +3708,32 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -6506,9 +6532,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
-      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/electron/package.json
+++ b/electron/package.json
@@ -39,7 +39,7 @@
     "@eslint/js": "^9.39.2",
     "@typescript-eslint/eslint-plugin": "^8.63.0",
     "@typescript-eslint/parser": "^8.63.0",
-    "@types/node": "^22.0.0",
+    "@types/node": "^26.1.1",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",


### PR DESCRIPTION
## Summary
- Bumps `@types/node` from `~20.14.0`/`>=22.12.0`/`^22.0.0` to `^26.1.1` in `client/`, `client-v3/`, and `electron/` respectively, keeping all three packages on a consistent floor.
- Leaves `typescript` at `^6.0.3` in all three — TypeScript 7.0 ships without a compiler API (only `tsc` got the native Go port; the API is promised for 7.1), and `typescript-eslint@8.63.0` (already latest, already in use) hard-pins its peer range to `typescript: >=4.8.4 <6.1.0`. The [upstream tracking issue](https://github.com/typescript-eslint/typescript-eslint/issues/12518) for TS7 support was closed "not planned," so bumping `typescript` now would break ESLint's type-aware linting and both `nodelint.yml` CI jobs. Revisit once `typescript-eslint` adds support.
- No functional/behavioral changes — types-only dependency bump.

## Test plan
- [x] `npm install` clean (no peer dependency warnings) in `client/`, `client-v3/`, `electron/`
- [x] `npm run typecheck` passes in all three
- [x] `npm run ci-lint` passes in all three (confirms type-aware ESLint rules still work, since `typescript` is unchanged)
- [x] `npm run build` passes in `client/` and `client-v3/`
- [x] `npm run test:run` passes in `client/` (132 tests) and `client-v3/` (39 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)