### PR TITLE
Upgrade bootstrap-vue-next to 1.0.1 in client-v3

### DIFF
--- a/client-v3/package-lock.json
+++ b/client-v3/package-lock.json
@@ -11,7 +11,7 @@
         "@vuelidate/core": "^2.0.3",
         "@vuelidate/validators": "^2.0.4",
         "bootstrap": "^5.3.8",
-        "bootstrap-vue-next": "^0.45.7",
+        "bootstrap-vue-next": "^1.0.1",
         "bootswatch": "^5.3.8",
         "contrast-color": "1.0.1",
         "core-js": "^3.50.0",
@@ -2378,15 +2378,15 @@
       }
     },
     "node_modules/bootstrap-vue-next": {
-      "version": "0.45.10",
-      "resolved": "https://registry.npmjs.org/bootstrap-vue-next/-/bootstrap-vue-next-0.45.10.tgz",
-      "integrity": "sha512-9HkNYQ0pS6E48qFsSifR/S04qdTNBy+E5+Qxe+R0ORUAVe3z/R9dhq2fnjGjKV3yOPJzLxC1y/fqvkzVV3dZbQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue-next/-/bootstrap-vue-next-1.0.1.tgz",
+      "integrity": "sha512-3qIPlwy1T4nWwWTk1a9jHC7k60N94N1ZvF8sLqH6oIGWKsWa5wrDNxUiHRgApoF/aUjhXu3bjZqo/W7Fn0xi4w==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/vue": "^1.1.11",
-        "@vueuse/core": "^14.2.1",
-        "reka-ui": "^2.9.2"
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/vue": "^2.0.1",
+        "@vueuse/core": "~14.2.1",
+        "reka-ui": "^2.10.3"
       },
       "funding": {
         "type": "opencollective",
@@ -2425,6 +2425,57 @@
         "vue-router": {
           "optional": true
         }
+      }
+    },
+    "node_modules/bootstrap-vue-next/node_modules/@floating-ui/vue": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-2.0.1.tgz",
+      "integrity": "sha512-043dyEKD9TDSfz080YH2vobubgg+NIo/9Fw4RAl7sEMpD8Am1DNrrSTl/GpMBjyGHoD/FbJY2QLawY+HSQsEIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      },
+      "peerDependencies": {
+        "vue": ">=3.3.0"
+      }
+    },
+    "node_modules/bootstrap-vue-next/node_modules/@vueuse/core": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.2.1.tgz",
+      "integrity": "sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "14.2.1",
+        "@vueuse/shared": "14.2.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/bootstrap-vue-next/node_modules/@vueuse/metadata": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.2.1.tgz",
+      "integrity": "sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/bootstrap-vue-next/node_modules/@vueuse/shared": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.2.1.tgz",
+      "integrity": "sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
       }
     },
     "node_modules/bootswatch": {

--- a/client-v3/package.json
+++ b/client-v3/package.json
@@ -34,7 +34,7 @@
     "@vuelidate/core": "^2.0.3",
     "@vuelidate/validators": "^2.0.4",
     "bootstrap": "^5.3.8",
-    "bootstrap-vue-next": "^0.45.7",
+    "bootstrap-vue-next": "^1.0.1",
     "bootswatch": "^5.3.8",
     "contrast-color": "1.0.1",
     "core-js": "^3.50.0",

--- a/client-v3/src/components/config/ConfigLogs.vue
+++ b/client-v3/src/components/config/ConfigLogs.vue
@@ -48,7 +48,7 @@
       </BFormGroup>
 
       <BFormGroup label="Live:" label-cols="auto" class="mb-0">
-        <BFormCheckbox v-model="liveRefresh" switch />
+        <BFormCheckbox v-model="liveRefresh" :unchecked-value="false" switch />
       </BFormGroup>
 
       <BButton :disabled="loading || liveRefresh" size="sm" variant="secondary" @click="fetchLogs">

--- a/client-v3/src/components/config/ConfigSettings.vue
+++ b/client-v3/src/components/config/ConfigSettings.vue
@@ -75,6 +75,7 @@
                       v-model="editSettings[String(key)]"
                       :name="`${key}-input`"
                       :disabled="!setting.can_edit"
+                      :unchecked-value="false"
                       switch
                     />
                   </BFormGroup>

--- a/client-v3/src/components/config/ConfigUsers.vue
+++ b/client-v3/src/components/config/ConfigUsers.vue
@@ -87,7 +87,7 @@
     >
       <BForm v-if="editFormState">
         <BFormGroup label="User Type">
-          <BFormCheckbox v-model="editFormState.is_admin" switch>
+          <BFormCheckbox v-model="editFormState.is_admin" :unchecked-value="false" switch>
             {{ editFormState.is_admin ? 'Admin' : 'Standard User' }}
           </BFormCheckbox>
         </BFormGroup>

--- a/client-v3/src/components/show/config/acts_and_scenes/ConfigActs.vue
+++ b/client-v3/src/components/show/config/acts_and_scenes/ConfigActs.vue
@@ -73,7 +73,11 @@
           <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
         </BFormGroup>
         <BFormGroup label="Interval After" label-for="new-interval-input" label-cols="4">
-          <BFormCheckbox id="new-interval-input" v-model="newFormState.interval_after" />
+          <BFormCheckbox
+            id="new-interval-input"
+            v-model="newFormState.interval_after"
+            :unchecked-value="false"
+          />
         </BFormGroup>
         <BFormGroup label="Previous Act" label-for="new-previous-act-input" label-cols="4">
           <BFormSelect
@@ -104,7 +108,11 @@
           <BFormInvalidFeedback>This is a required field.</BFormInvalidFeedback>
         </BFormGroup>
         <BFormGroup label="Interval After" label-for="edit-interval-input" label-cols="4">
-          <BFormCheckbox id="edit-interval-input" v-model="editFormState.interval_after" />
+          <BFormCheckbox
+            id="edit-interval-input"
+            v-model="editFormState.interval_after"
+            :unchecked-value="false"
+          />
         </BFormGroup>
         <BFormGroup label="Previous Act" label-for="edit-previous-act-input" label-cols="4">
           <BFormSelect

--- a/client-v3/src/components/user/settings/StageDirectionStyles.vue
+++ b/client-v3/src/components/user/settings/StageDirectionStyles.vue
@@ -46,7 +46,12 @@
         />
       </BFormGroup>
       <BFormGroup label="Text Colour" label-for="default-text-colour-input">
-        <BFormCheckbox v-model="defaultFormState.enableTextColour" switch class="mb-1">
+        <BFormCheckbox
+          v-model="defaultFormState.enableTextColour"
+          :unchecked-value="false"
+          switch
+          class="mb-1"
+        >
           Override text colour
         </BFormCheckbox>
         <BFormInput
@@ -195,6 +200,7 @@
           <BFormCheckbox
             id="new-background-colour-enable"
             v-model="newStyleFormState.enableBackgroundColour"
+            :unchecked-value="false"
             switch
           />
         </BFormGroup>
@@ -270,6 +276,7 @@
           <BFormCheckbox
             id="edit-background-colour-enable"
             v-model="editStyleFormState.enableBackgroundColour"
+            :unchecked-value="false"
             switch
           />
         </BFormGroup>

--- a/client-v3/src/components/user/settings/UserSettingsConfig.vue
+++ b/client-v3/src/components/user/settings/UserSettingsConfig.vue
@@ -13,6 +13,7 @@
                 id="enable-autosave-input"
                 v-model="state.enable_script_auto_save"
                 name="enable-autosave-input"
+                :unchecked-value="false"
                 switch
               />
             </BFormGroup>
@@ -43,6 +44,7 @@
                 id="cue-position-input"
                 v-model="state.cue_position_right"
                 name="cue-position-input"
+                :unchecked-value="false"
                 switch
               />
             </BFormGroup>
@@ -90,6 +92,7 @@
                 id="character-mru-sort-input"
                 v-model="state.character_mru_sort"
                 name="character-mru-sort-input"
+                :unchecked-value="false"
                 switch
               />
             </BFormGroup>
@@ -103,6 +106,7 @@
                 id="character-combined-dropdown-input"
                 v-model="state.character_combined_dropdown"
                 name="character-combined-dropdown-input"
+                :unchecked-value="false"
                 switch
               />
             </BFormGroup>
@@ -116,6 +120,7 @@
                 id="show-current-cue-footer-input"
                 v-model="state.show_current_cue_footer"
                 name="show-current-cue-footer-input"
+                :unchecked-value="false"
                 switch
               />
             </BFormGroup>

--- a/client-v3/src/views/electron/ServerSelector.vue
+++ b/client-v3/src/views/electron/ServerSelector.vue
@@ -248,7 +248,9 @@
         </BFormGroup>
 
         <BFormGroup>
-          <BFormCheckbox v-model="manualForm.sslEnabled">Use SSL (HTTPS)</BFormCheckbox>
+          <BFormCheckbox v-model="manualForm.sslEnabled" :unchecked-value="false"
+            >Use SSL (HTTPS)</BFormCheckbox
+          >
         </BFormGroup>
 
         <BButton


### PR DESCRIPTION
## Summary
- Bumps `bootstrap-vue-next` from `^0.45.7` (resolved `0.45.10`) to `^1.0.1` in `client-v3` — the library's first stable major release. Supersedes the dependabot 0.46.4 bump (#1324, closed) since it made more sense to jump straight to 1.x while the gap was still small.
- Fixes the one real breaking change in this range: `BFormCheckbox`'s `unchecked-value` default flipped from `false` to `undefined` in `0.46.0`. Added explicit `:unchecked-value="false"` to all 14 affected plain checkboxes across 7 files (`ConfigSettings.vue`, `ConfigLogs.vue`, `ConfigUsers.vue`, `ConfigActs.vue` ×2, `UserSettingsConfig.vue` ×5, `StageDirectionStyles.vue` ×3, `ServerSelector.vue`) to preserve prior behavior.

Everything else in the 0.45.10→1.0.1 changelog (resolver config, plugin registration, peer deps, `BFormRating` prop/slot renames, orchestrator composable internals) either doesn't apply to how this app uses BVN, or was confirmed unchanged (e.g. `BFormGroup` still emits the `.b-form-group` class that `dark.scss` depends on — verified directly in the compiled output).

## Test plan
- [x] `npm run typecheck` — clean (the 30-file `BModal` typed-ref surface is unaffected)
- [x] `npm run ci-lint` — clean
- [x] `npm run test:run` — 39/39 Vitest tests pass
- [x] `npm run build` and `BUILD_TARGET=electron npm run build` — both succeed (confirms the package's move to ESM-only doesn't break the Vite build)
- [x] `npm run test:e2e` — full suite, 221/221 passing, including toggle-behavior specs that directly exercise the checkbox fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)