### PR TITLE
Add RBAC cleanup regression tests, close #1155 as not reproducible

### DIFF
--- a/server/test/controllers/api/v1/show/test_cues.py
+++ b/server/test/controllers/api/v1/show/test_cues.py
@@ -1,5 +1,5 @@
 import tornado.escape
-from sqlalchemy import select
+from sqlalchemy import select, text
 
 from models.cue import Cue, CueAssociation, CueGroup, CueType
 from models.script import (
@@ -1040,6 +1040,51 @@ class TestCueTypesController(DigiScriptTestCase):
         with self._app.get_db().sessionmaker() as session:
             self.assertIsNone(session.get(CueType, cue_type_id))
             self.assertIsNone(session.get(CueGroup, group_id))
+
+    def test_delete_cue_type_cleans_up_rbac_mapping_row(self):
+        """Deleting a cue type removes the RBAC grant auto-created for its creator
+        (per #1154).
+
+        ``CueTypesController.delete()`` has no explicit RBAC cleanup call -- this
+        verifies the ``DigiDBSession`` delete-hook mechanism handles it instead.
+        """
+        response = self.fetch(
+            "/api/v1/show/cues/types",
+            method="POST",
+            body=tornado.escape.json_encode(
+                {"prefix": "SND", "description": "Sound", "colour": "#00ff00"}
+            ),
+            headers={"Authorization": f"Bearer {self.user_token}"},
+        )
+        self.assertEqual(200, response.code)
+        cue_type_id = tornado.escape.json_decode(response.body)["id"]
+
+        with self._app.get_db().sessionmaker() as session:
+            user = session.get(User, self.user_id)
+            cue_type = session.get(CueType, cue_type_id)
+            self.assertTrue(
+                self._app.rbac.has_role(
+                    user, cue_type, Role.READ | Role.WRITE | Role.EXECUTE
+                )
+            )
+
+        response = self.fetch(
+            f"/api/v1/show/cues/types?id={cue_type_id}",
+            method="DELETE",
+            headers={"Authorization": f"Bearer {self.admin_token}"},
+        )
+        self.assertEqual(200, response.code)
+
+        with self._app.get_db().sessionmaker() as session:
+            row_count = session.execute(
+                text("SELECT COUNT(*) FROM rbac_user_cuetypes WHERE cuetypes_id = :v"),
+                {"v": cue_type_id},
+            ).scalar()
+            self.assertEqual(
+                0,
+                row_count,
+                "rbac_user_cuetypes row should be removed when the cue type is deleted",
+            )
 
 
 class TestCueGroups(DigiScriptTestCase):

--- a/server/test/controllers/api/v1/show/test_shows.py
+++ b/server/test/controllers/api/v1/show/test_shows.py
@@ -1,5 +1,5 @@
 import tornado.escape
-from sqlalchemy import select
+from sqlalchemy import select, text
 
 from models.cue import CueType
 from models.mics import Microphone
@@ -7,6 +7,7 @@ from models.script import Script, ScriptRevision
 from models.session import ShowSession
 from models.show import Act, Character, CharacterGroup, Scene, Show, ShowScriptType
 from models.user import User
+from rbac.role import Role
 from test.conftest import DigiScriptTestCase
 
 
@@ -340,6 +341,83 @@ class TestShowDeletionController(DigiScriptTestCase):
             )
             self.assertIsNotNone(
                 session.get(Show, self.show_a_id), "Loaded show must not be deleted"
+            )
+
+    def test_delete_show_cleans_up_rbac_mapping_rows(self):
+        """Deleting a show removes RBAC grants on the show itself and on any
+        cascade-deleted cue types/scripts.
+
+        This is handled entirely by the ``DigiDBSession`` delete-hook mechanism
+        (``check_object_deletion`` firing for both the show and every object
+        cascade-deleted with it) -- ``ShowsController.delete()`` has no explicit
+        RBAC cleanup call, deliberately, to verify the hook covers it.
+
+        :raises AssertionError: if any ``rbac_user_*`` row survives the deletion.
+        """
+        with self._app.get_db().sessionmaker() as session:
+            show_b = Show(name="RBAC Show", script_mode=ShowScriptType.FULL)
+            session.add(show_b)
+            session.flush()
+            show_b_id = show_b.id
+
+            script = Script(show_id=show_b_id)
+            session.add(script)
+            session.flush()
+            script_id = script.id
+
+            cue_type = CueType(show_id=show_b_id, prefix="LX", description="Lighting")
+            session.add(cue_type)
+            session.flush()
+            cue_type_id = cue_type.id
+
+            normal_user = User(
+                username="rbac_probe_user", is_admin=False, password="test"
+            )
+            session.add(normal_user)
+            session.flush()
+            normal_user_id = normal_user.id
+            session.commit()
+
+        with self._app.get_db().sessionmaker() as session:
+            show_b = session.get(Show, show_b_id)
+            script = session.get(Script, script_id)
+            cue_type = session.get(CueType, cue_type_id)
+            normal_user = session.get(User, normal_user_id)
+            self._app.rbac.give_role(normal_user, show_b, Role.READ)
+            self._app.rbac.give_role(normal_user, cue_type, Role.READ)
+            self._app.rbac.give_role(normal_user, script, Role.READ)
+
+        response = self._delete(show_b_id)
+        self.assertEqual(200, response.code)
+
+        with self._app.get_db().sessionmaker() as session:
+            self.assertEqual(
+                0,
+                session.execute(
+                    text("SELECT COUNT(*) FROM rbac_user_shows WHERE shows_id = :v"),
+                    {"v": show_b_id},
+                ).scalar(),
+                "rbac_user_shows row should be removed when the show is deleted",
+            )
+            self.assertEqual(
+                0,
+                session.execute(
+                    text(
+                        "SELECT COUNT(*) FROM rbac_user_cuetypes WHERE cuetypes_id = :v"
+                    ),
+                    {"v": cue_type_id},
+                ).scalar(),
+                "rbac_user_cuetypes row should be removed when its show cascade-deletes"
+                " the cue type",
+            )
+            self.assertEqual(
+                0,
+                session.execute(
+                    text("SELECT COUNT(*) FROM rbac_user_script WHERE script_id = :v"),
+                    {"v": script_id},
+                ).scalar(),
+                "rbac_user_script row should be removed when its show cascade-deletes"
+                " the script",
             )
 
     def test_delete_currently_loaded_show(self):


### PR DESCRIPTION
## Summary

Issue #1155 claimed RBAC mapping rows (`rbac_user_shows`, `rbac_user_cuetypes`, `rbac_user_script`) are orphaned on resource deletion because `CueTypesController.delete()` / `ShowsController.delete()` never call `rbac.delete_resource()`, and proposed adding `ON DELETE CASCADE` (Option B) as a systemic fix.

Investigation before implementing Option B found the bug does not reproduce:

- `DigiDBSession._delete_impl` (`server/utils/database.py:18-37`, added in commit `861f259`) fires all registered delete hooks — including `RBACDatabase.check_object_deletion` — on every `session.delete(obj)` call.
- Because SQLAlchemy's own cascade recursion re-invokes `self._delete_impl(...)` for every ORM-cascaded child object (`Show.cue_type_list` / `Show.scripts` are `cascade="all, delete-orphan"`), the hook also fires for CueTypes/Scripts deleted along with their parent Show — not just for objects deleted directly.
- No code path bypasses this: there are no bulk `delete()` statements and no raw (non-`DigiDBSession`) `Session` usage anywhere in the codebase.

Empirically verified against the real HTTP endpoints: creating a Show with a CueType and a Script, granting RBAC roles on all three, then deleting the Show via `DELETE /api/v1/show` correctly empties all three `rbac_user_*` tables. Direct CueType deletion via `DELETE /show/cues/types` was verified separately.

This PR adds permanent regression tests (following the issue's own suggested test cases) locking in this correct behavior, and #1155 will be closed with this evidence rather than merging Option A or B for a bug that doesn't exist.

## Changes

- `server/test/controllers/api/v1/show/test_shows.py`: `test_delete_show_cleans_up_rbac_mapping_rows` — grants RBAC roles on a show/cuetype/script, deletes the show via the real HTTP endpoint, asserts all three `rbac_user_*` rows are gone.
- `server/test/controllers/api/v1/show/test_cues.py`: `test_delete_cue_type_cleans_up_rbac_mapping_row` — creates a cue type (auto-granting an RBAC role per #1154), deletes it via the real HTTP endpoint, asserts the `rbac_user_cuetypes` row is gone.

## Test plan

- [x] `pytest test/controllers/api/v1/show/test_shows.py test/controllers/api/v1/show/test_cues.py -v` — 67 passed
- [x] Full backend suite: `pytest` — 706 passed
- [x] `ruff format` / `ruff check` on modified files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6PjrtidthtkSj8j2TuNLS